### PR TITLE
Fixed bug where latitude or longitude could get slightly rounded in link to 1-site report

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# Development version
+
+- Bug fixes: 
+  - Fixed a bug where the community report in version 2.32.6.003 incorrectly showed results rounded to zero decimal places. The bug was in `fixcolnames()` and had been introduced 3 weeks earlier while a separate issue was being fixed.
+  - Fixed a bug where some latitude or longitude values could get somewhat rounded off in the URL from `url_ejamapi()` linking to the API to get a single-site report, so a report would show a very slightly different point and population count, for example, for some sites, versus what was intended. 
+  - Other changes in preparation for next release.
+
+
 # EJAM 2.32.6.003 (November 2025)
 
 - Bug fixes:

--- a/R/MODULE_latlon_from_map_click.R
+++ b/R/MODULE_latlon_from_map_click.R
@@ -106,6 +106,7 @@ MODULE_SERVER_latlon_from_map_click <- function(id,
                                 layerId = "mycircle"
             ) %>%
             leaflet::addPopups(lng = input$mymap_click$lng, lat = input$mymap_click$lat,
+                               # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
                                popup = paste0("lat,lon: ", input$mymap_click$lat, ", ", input$mymap_click$lng))
         })
       })
@@ -124,6 +125,7 @@ MODULE_SERVER_latlon_from_map_click <- function(id,
                                 layerId = "mycircle",
                                 highlightOptions = leaflet::highlightOptions(fillOpacity = 0.5, bringToFront = TRUE) ) %>%# this just makes it shaded when mouse hovers above the circle
             leaflet::addPopups(lng = input$mymap_click$lng, lat = input$mymap_click$lat,
+                               # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
                                popup = paste0("lat,lon: ", input$mymap_click$lat, ", ", input$mymap_click$lng))
         })
       })

--- a/R/URL_FUNCTIONS_part1.R
+++ b/R/URL_FUNCTIONS_part1.R
@@ -271,6 +271,21 @@ urls_from_keylists <- function(..., keylist_bysite=NULL, keylist_4all=NULL,
     ## so how pass a parameter value of NULL ??
     keylist_bysite[sapply(keylist_bysite, is.null)] <- pass_null_as # actually it will turn into "" and then get dropped entirely by url_from_keylist() now
 
+    ## Retain all the precision of the latitude and longitude when converting to character for the URL-encoded API call:
+    old_option_digits = getOption('digits')
+    on.exit({options(digits = old_option_digits)})
+    options(digits = 15)
+    ## This is essential when using apply() on a data.frame below, since that apply() uses as.matrix()
+    ## which converts latlon info in a way that is affected by the "digits" option it seems
+    ##   options(digits = 15)
+    ##   as.matrix(testpoints_10[1, 1:2])
+    ## #    lat        lon
+    ## # 1 "37.64122" "-122.41065"  ## retained exact number
+    ##  options(digits = 7)
+    ##  as.matrix(testpoints_10[1, 1:2]) # or print(as.matrix(testpoints_10[1, 1:2]), digits = 15) is no different since it is now character not numeric
+    ## #    lat        lon
+    ## # 1 "37.64122" "-122.4107"
+
     keylist_bysite <- paste0(
       # "&",
       apply(as.data.frame(keylist_bysite) , 1,
@@ -279,6 +294,8 @@ urls_from_keylists <- function(..., keylist_bysite=NULL, keylist_4all=NULL,
               url_from_keylist(keylist = as.list(z), baseurl = "", encode = encode) # should drop empties
             }
       ))
+
+    options(digits = old_option_digits)
   }
 
   forallpart <- url_from_keylist(keylist = keylist_4all, baseurl = "", encode = encode, ifna = "") # should drop empties
@@ -448,6 +465,7 @@ collapse_keylist <- function(klist, encode=TRUE) {
 #
 #       geometry = paste0('{"spatialReference":{"wkid":', 0, '},','"x":', -100, ',"y":', 34, '}'),
 #       ## cannot flexibly create one parameter based on other  parameters:
+## Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
 #       # paste0('{"spatialReference":{"wkid":',wkid, '},','"x":', lon, ',"y":', lat, '}'),
 #
 #       radius = 3.1,
@@ -464,4 +482,5 @@ collapse_keylist <- function(klist, encode=TRUE) {
 ########################################################### #
 #
 # ### how old api-related function  used to do it
+## # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
 # geometry <- paste0('{"spatialReference":{"wkid":',wkid, '},','"x":', lon, ',"y":', lat, '}')

--- a/R/URL_FUNCTIONS_part2.R
+++ b/R/URL_FUNCTIONS_part2.R
@@ -335,6 +335,7 @@ url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
   baseurl_query <- paste0(baseurl, "?wherestr=")
   whereq <- ""
   if (!is.null(lat)) {
+    # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
     whereq <- paste( lat,  lon, sep = ',') # points (or centroids of polygons)
     whereq[is.na(lat) | is.na(lon)] <- NA
   }
@@ -465,7 +466,7 @@ url_enviromapper <- function(sitepoints = NULL, lon = NULL, lat = NULL, shapefil
   ######################## #  ######################## #  ######################## #
 
   ## > MAKE URL ####
-
+  # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
   urlx <- paste0(baseurl, zoom, ",", lat, ",", lon)
 
   ######################## #

--- a/R/ejam2report.R
+++ b/R/ejam2report.R
@@ -234,6 +234,7 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
     ## and could also add here ?
     # addlatlon = TRUE
     # if (addlatlon && sitetype == "latlon" && nsites == 1) {
+    ### # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
     #   locationstr <- paste0(locationstr, ' Centered at ', ejamout1$lat, ', ', ejamout1$lon)
     # }
     ##################### #

--- a/R/latlon_from_map_click_demo.R
+++ b/R/latlon_from_map_click_demo.R
@@ -38,6 +38,7 @@ latlon_from_map_click_demo <- function(radiusdefault = 3) {
                               layerId = "mycircle",
                               highlightOptions = leaflet::highlightOptions(fillOpacity = 0.5) ) %>%  # this just makes it shaded when mouse hovers above the circle
           leaflet::addPopups(lng = input$mymap_click$lng, lat = input$mymap_click$lat,
+                             # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
                              popup = paste0("lat,lon: ", input$mymap_click$lat, ", ", input$mymap_click$lng))
       })
     })
@@ -55,6 +56,7 @@ latlon_from_map_click_demo <- function(radiusdefault = 3) {
                               fillOpacity = 0.1,
                               layerId = "mycircle",
                               highlightOptions = leaflet::highlightOptions(fillOpacity = 0.5, bringToFront = TRUE) ) %>%# this just makes it shaded when mouse hovers above the circle
+          # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
           leaflet::addPopups(lng = input$mymap_click$lng, lat = input$mymap_click$lat,
                              popup = paste0("lat,lon: ", input$mymap_click$lat, ", ", input$mymap_click$lng))
       })

--- a/R/latlon_from_vectorofcsvpairs.R
+++ b/R/latlon_from_vectorofcsvpairs.R
@@ -73,26 +73,33 @@ latlon_from_vectorofcsvpairs <- function(x) {
 #'   into one vector of comma-separated pairs like latitude,longitude
 #' @param lat vector of latitudes
 #' @param lon vector of longitudes
+#' @param sep optional separator, like "," (default), or ", " (with a space) or "|"
 #'
 #' @return vector of comma-separated pairs (see example)
 #'
 #' @examples
-#'    lat_example = c(30.01,30.26,30.51)
-#'    lon_example = c(-90.61,-90.95,-91.23)
-#'    latloncsv_example = c("30.01,-90.61", "30.26,-90.95", "30.51,-91.23")
-#'    all.equal(latloncsv_example,
-#'              latlon2csv(lat = lat_example, lon = lon_example)
-#'    )
+#' lat_example = c(41,42,43)
+#' lon_example = c(-100,-90,-80)
+#' latloncsv_example = c("41,-100", "42,-90", "43,-80")
+#' all.equal(latloncsv_example,
+#'           latlon2csv(lat = lat_example, lon = lon_example)
+#' )
+#' latlon2csv(lat = lat_example, lon = lon_example)
+#'
+#' # Note slight changes can occur in lat,lon values if just using
+#' # paste(lat,lon,sep=',) instead of format() as noted in ?as.character()
+#' testpoints_10[1, c("lat","lon")]
+#' latlon2csv(lat = testpoints_10$lat[1], lon = testpoints_10$lon[1])
 #'
 #' @keywords internal
 #' @export
 #'
-latlon2csv <- function(lat, lon) {
+latlon2csv <- function(lat, lon, sep=",") {
 
   ## combines a list of latitudes and list of longitudes
   ## into a vector of comma-separated values for latitude and longitude
-
-  latloncsv <- paste(lat, lon, sep = ',')
+  # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
+  latloncsv <- paste(lat, lon, sep = sep)
   return(latloncsv)
 }
 ##################################################### #
@@ -128,7 +135,7 @@ latloncsv2nexus <- function(latloncsv) {
     stop('some lat or lon are NA')}
   if (any(!latlon_is.valid(lat = latitudes, lon = longitudes))) {
     stop('some lat or lon do not seem to be valid numbers')}
-
+  # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
   nexusformat  <- paste(latloncsv, collapse = ';')
   return(nexusformat)
 }

--- a/R/map_google.R
+++ b/R/map_google.R
@@ -6,39 +6,41 @@
 #'   or lat can be a data.frame with lat,lon column names in which case longitude should not be provided,
 #'   such as \code{lat = testpoints_10[1,]}, or lat and lon can be separately provided as vectors.
 #' @param lon longitude, or omit this parameter to provide points as the first parameter.
-#' 
+#'
 #' @param zoom zoomed out value could be 3 or 5, zoomed in default is 12
 #' @param point logical, if TRUE, URL will have a marker at the point
 #'   and zoom parameter is ignored. Otherwise just the map.
 #'
 #' @return URL(s) vector one per point
 #' @seealso [map_google()]
-#' 
+#'
 #' @export
 #' @keywords internal
 #'
 url_map_google <- function(lat, lon, zoom = 13, point = TRUE) {
-  
+
   # "https://developers.google.com/maps/documentation/urls/get-started"
-  
+
   # also see map_google()
-  
+
   if (missing(lon)) {
     pts = sitepoints_from_any(lat)
     lat = pts$lat
     lon = pts$lon
   }
-  
+
   if (point) {
-    
-    paste0("https://www.google.com/maps/search/?api=1&query=", lat, "%2C", lon) 
+    # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
+    paste0("https://www.google.com/maps/search/?api=1&query=", lat, "%2C", lon)
     # provides marker at the point but cannot specify zoom
-    
+
   } else {
     if (kind == 1) {
-      paste0("https://www.google.com/maps/@?api=1&map_action=map&basemap=satellite&center=", lat, "%2C", lon, "&", "zoom=", zoom ) 
+      # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
+      paste0("https://www.google.com/maps/@?api=1&map_action=map&basemap=satellite&center=", lat, "%2C", lon, "&", "zoom=", zoom )
       # no marker but can specify zoom and basemap satellite
     } else {
+      # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
       paste0("https://www.google.com/maps/@", lat, ",", lon, ",", zoom, "z")
       # no marker but can specify zoom and the default is satellite?
     }

--- a/R/plot_distance_by_pctd.R
+++ b/R/plot_distance_by_pctd.R
@@ -78,6 +78,7 @@ plot_distance_by_pctd <- function(s2b = NULL, sitenumber = 1, #  NULL,
     } else {
       warning('s2b not provided, so showing random example data only')
       pts = suppressWarnings(testpoints_n(1))
+      # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
       cat(paste0("site: ", pts$lat, ", ", pts$lon, "\n"))
       s2b <- getblocksnearby(pts, radius = radius, quiet = T)
       sitenumber <- 1
@@ -92,6 +93,7 @@ plot_distance_by_pctd <- function(s2b = NULL, sitenumber = 1, #  NULL,
       } else {
         warning("s2b must be results of getblocksnearby() or else a table of points with lat,lon columns and 1 row per point")
         pts = suppressWarnings(testpoints_n(1))
+        # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
         cat(paste0("site: ", pts$lat, ", ", pts$lon, "\n"))
         s2b <- getblocksnearby(pts, radius = radius, quiet = T)
         sitenumber <- 1
@@ -100,6 +102,7 @@ plot_distance_by_pctd <- function(s2b = NULL, sitenumber = 1, #  NULL,
       warning("s2b must be results of getblocksnearby() or else a table of points with lat,lon columns and 1 row per point")
       warning('s2b not provided, so showing sample data only')
       pts = suppressWarnings(testpoints_n(1))
+      # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
       cat(paste0("site: ", pts$lat, ", ", pts$lon, "\n"))
       s2b <- getblocksnearby(pts, radius = radius, quiet = T)
       sitenumber <- 1

--- a/R/popup_from_ejscreen.R
+++ b/R/popup_from_ejscreen.R
@@ -405,6 +405,7 @@ popup_from_ejscreen <- function(out,
   if ('area_sqmi' %in% names(out)) {pops_sqmi      <- paste0('Area: ',   out$area_sqmi, ' square miles', '<br>')} else {pops_sqmi <- ''}
 
   if (!(all(is.na(out$lon)))) {
+    # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
     pops_latlon <- paste0('long, lat: ',  out$lon, ', ', out$lat,             '<br>')
   } else {
     pops_latlon <- ''

--- a/R/url_ejamapi.R
+++ b/R/url_ejamapi.R
@@ -377,6 +377,7 @@ url_ejamapi = function(
           # x <- latlon_from_anything(sitepoints, interactiveprompt = F) # do we want this actually ?? see notes in sites_from_input() and related
           lat <- x$lat
           lon <- x$lon
+          # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
           lat <- paste0(lat, collapse = ",")
           lon <- paste0(lon, collapse = ",")
         }

--- a/man/blockgroupstats.Rd
+++ b/man/blockgroupstats.Rd
@@ -18,9 +18,9 @@ It is a data.table with one row for every US Census blockgroup.
 
 The source of data for each indicator was documented by EJSCREEN, as archived on these pages:
 \itemize{
-\item \href{https://web.archive.org/web/20250124090116/https://www.epa.gov/ejscreen/ejscreen-change-log}{EJSCREEN Change Log - newest indicators, etc.}
-\item \href{https://web.archive.org/web/20250123161322/https://www.epa.gov/ejscreen/ejscreen-map-descriptions}{Full list of indicators, with definitions}
-\item \href{https://web.archive.org/web/20250123162159/https://www.epa.gov/ejscreen/overview-environmental-indicators-ejscreen}{Year and source of each environmental indicator}
+\item \href{https://web.archive.org/web/20250124090116/https://www.epa.gov/ejscreen/ejscreen-change-log}{EJSCREEN Change Log - newest indicators, etc.}{target="_blank"}
+\item \href{https://web.archive.org/web/20250123161322/https://www.epa.gov/ejscreen/ejscreen-map-descriptions}{Full list of indicators, with definitions as archived}{target="_blank"}.
+\item \href{https://web.archive.org/web/20250123162159/https://www.epa.gov/ejscreen/overview-environmental-indicators-ejscreen}{Year and source of each environmental indicator}{target="_blank"}
 }
 
 More about blockgroupstats

--- a/man/latlon2csv.Rd
+++ b/man/latlon2csv.Rd
@@ -4,12 +4,14 @@
 \alias{latlon2csv}
 \title{helper function - combine lat/lon values into csv format}
 \usage{
-latlon2csv(lat, lon)
+latlon2csv(lat, lon, sep = ",")
 }
 \arguments{
 \item{lat}{vector of latitudes}
 
 \item{lon}{vector of longitudes}
+
+\item{sep}{optional separator, like "," (default), or ", " (with a space) or "|"}
 }
 \value{
 vector of comma-separated pairs (see example)
@@ -19,12 +21,18 @@ Combines a vector of latitudes and a vector of longitudes
 into one vector of comma-separated pairs like latitude,longitude
 }
 \examples{
-   lat_example = c(30.01,30.26,30.51)
-   lon_example = c(-90.61,-90.95,-91.23)
-   latloncsv_example = c("30.01,-90.61", "30.26,-90.95", "30.51,-91.23")
-   all.equal(latloncsv_example,
-             latlon2csv(lat = lat_example, lon = lon_example)
-   )
+lat_example = c(41,42,43)
+lon_example = c(-100,-90,-80)
+latloncsv_example = c("41,-100", "42,-90", "43,-80")
+all.equal(latloncsv_example,
+          latlon2csv(lat = lat_example, lon = lon_example)
+)
+latlon2csv(lat = lat_example, lon = lon_example)
+
+# Note slight changes can occur in lat,lon values if just using
+# paste(lat,lon,sep=',) instead of format() as noted in ?as.character()
+testpoints_10[1, c("lat","lon")]
+latlon2csv(lat = testpoints_10$lat[1], lon = testpoints_10$lon[1])
 
 }
 \keyword{internal}

--- a/tests/testthat/test-latlon_from_fips.R
+++ b/tests/testthat/test-latlon_from_fips.R
@@ -177,6 +177,7 @@ test_that("latlon_from_fips works on county and state", {
 #
 #
 #     cat("fips = ",fips[i], "\n")
+### # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
 #     print(paste0("lat,lon", x$lat, ", ", x$lon, "\n"))
 #
 #     # get fips from s2b$bgid


### PR DESCRIPTION
Problem was slightly rounding of some coordinates, in the URL from `url_ejamapi()` linking to the API to get a single-site report.

Fixed a bug where some latitude or longitude values could get somewhat rounded off in the URL from `url_ejamapi()` linking to the API to get a single-site report, so a report would show a very slightly different point and population count, for example, for some sites, versus what was intended.

  This could create a small discrepancy between a report obtained via API-powered link in the EJAM app (in map popup for a site or link in table of detailed list of sites analyzed in EJAM), versus a report obtained directly from EJSCREEN app requesting a report on one site or directly from RStudio console using `ejam2report()` function.

This shows what the difference could be:
  print(testpoints_10[1,], digits = 15) # shows that the intended longitude was  -122.41065
url_ejamapi(testpoints_10[1,]) # Was wrong: was returning  "https://ejamapi-84652557241.us-central1.run.app/report?lat=37.64122&lon=-122.4107&buffer=3" (assuming digits option was default of 7) url_ejamapi(testpoints_10[1,]) # Fixed now: Now returning  "https://ejamapi-84652557241.us-central1.run.app/report?lat=37.64122&lon=-122.41065&buffer=3"

Known issue: Still need to adjust other places where the latitude, longitude is printed, like in the map popups, since small rounding differences can occur in what was submitted as coordinates vs what is shown as text.