### PR TITLE
Fix shapefile area assignment for no-block polygons

### DIFF
--- a/R/ejamit.R
+++ b/R/ejamit.R
@@ -665,7 +665,14 @@ ejamit <- function(sitepoints = NULL,
                          download_city_fips_bounds = download_city_fips_bounds, download_noncity_fips_bounds = download_noncity_fips_bounds)
     }
     if (sitetype %in% "shp") {
-      areas <- area_sqmi(shp = shp_valid) # includes any BUFFER ADDED
+      areas_by_site <- data.table(
+        ejam_uniq_id = as.character(shp_valid$ejam_uniq_id),
+        area_sqmi = area_sqmi(shp = shp_valid) # includes any BUFFER ADDED
+      )
+      areas <- areas_by_site[
+        match(as.character(out$results_bysite$ejam_uniq_id), ejam_uniq_id),
+        area_sqmi
+      ]
     }
     if (sitetype %in% "latlon") {
       # CHECK IF DONUT OPTION WAS USED !       radius_donut_lower_edge
@@ -849,5 +856,4 @@ ejamit <- function(sitepoints = NULL,
 
   invisible(out)
 }
-
 

--- a/tests/testthat/test-area_sqmi.R
+++ b/tests/testthat/test-area_sqmi.R
@@ -81,6 +81,32 @@ junk2 <- function() {
 rm(junk1, junk2)
 ############################################# #  ############################################# #
 
+test_that("ejamit(shapefile=) handles valid polygons with no blockpoints", {
+  shp <- shape_buffered_from_shapefile_points(
+    shapefile_from_sitepoints(testpoints_100[23:25, ]),
+    radius.miles = 1
+  )
+
+  expect_no_error({
+    suppressWarnings({
+      out <- ejamit(
+        shapefile = shp,
+        quiet = TRUE,
+        silentinteractive = TRUE,
+        include_ejindexes = FALSE
+      )
+    })
+  })
+
+  expect_equal(NROW(out$results_bysite), NROW(shp))
+  expect_equal(sum(!out$results_bysite$valid), 1)
+  expect_true(any(
+    grepl("no block centroids", out$results_bysite$invalid_msg, fixed = TRUE)
+  ))
+  expect_true("area_sqmi" %in% names(out$results_bysite))
+})
+############################################# #
+
 ## to be finished possibly... ***
 
 # test_that("area_sqmi ok within ejamit", {

--- a/tests/testthat/test-area_sqmi.R
+++ b/tests/testthat/test-area_sqmi.R
@@ -82,8 +82,14 @@ rm(junk1, junk2)
 ############################################# #  ############################################# #
 
 test_that("ejamit(shapefile=) handles valid polygons with no blockpoints", {
+  no_block_fixture <- data.frame(
+    site_name = c("new_york_city", "los_angeles", "pacific_ocean"),
+    lat = c(40.7128, 34.0522, 38),
+    lon = c(-74.0060, -118.2437, -145)
+  )
+
   shp <- shape_buffered_from_shapefile_points(
-    shapefile_from_sitepoints(testpoints_100[23:25, ]),
+    shapefile_from_sitepoints(no_block_fixture),
     radius.miles = 1
   )
 


### PR DESCRIPTION
## Summary

- Fixes #338 by assigning shapefile `area_sqmi` values by `ejam_uniq_id` instead of assuming every valid polygon has a returned aggregation row.
- Adds focused regression coverage for buffered shapefile polygons where one polygon has no block centroids and should be returned as invalid instead of crashing.
- Uses explicit named test coordinates so the no-block case is not dependent on incidental rows in packaged `testpoints_100` data.

## Scope

This is the narrow #338 fix split out from PR #339. It intentionally avoids the broader `development -> main` changes in #339.

Changed files:

- `R/ejamit.R`
- `tests/testthat/test-area_sqmi.R`

## Validation

- `devtools::test(filter = 'area_sqmi')`: 39 passed, 0 failed, 0 warnings, 0 skipped.