### PR TITLE
Fix pb_download missing .arrow extension on filenames

### DIFF
--- a/R/download_latest_arrow_data.R
+++ b/R/download_latest_arrow_data.R
@@ -102,7 +102,7 @@ download_latest_arrow_data <- function(
     # If user installs for the first time, they won't have any arrow datasets or
     # the txt with the version, which is added at the end of this program
 
-    missing_files <- varnames
+    missing_files <- paste0(varnames, ".arrow")
     if (is.null(usersArrowVersions)) {
       message("Downloading latest arrow-format datasets (blocks, etc.)")
     } else {


### PR DESCRIPTION
## Summary

- In `download_latest_arrow_data()`, the version-mismatch `else` branch was overwriting `missing_files` with bare `varnames` (e.g. `"blockpoints"`) instead of the correctly-formed filenames with extensions (e.g. `"blockpoints.arrow"`)
- `piggyback::pb_download()` matches against release asset names, which include the `.arrow` suffix — so every file was reported as _"not found in repo"_ and no download occurred
- One-character fix: `missing_files <- paste0(varnames, ".arrow")`

## Test plan

- [ ] Confirm `library(EJAM)` on a fresh install no longer warns "file(s) not found in repo" when arrow files are missing and a valid token is available
- [ ] Confirm existing behaviour unchanged when files are already present (early-return path is unaffected)

---

> fyi this is from claude, I double checked and seems right but please validate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)