### PR TITLE
Preload bgej on package attach to fix first-upload cold-start

### DIFF
--- a/R/aaa_onAttach.R
+++ b/R/aaa_onAttach.R
@@ -96,7 +96,7 @@
   if (asap_download) {
 
     if (length(try(find.package("EJAM", quiet = T))) == 1) { # if it has been installed. but that function has to have already been added to package namespace once
-      dataload_dynamic(varnames = c("blockpoints", "blockwts", "quaddata"),
+      dataload_dynamic(varnames = c("blockpoints", "blockwts", "quaddata", "bgej"),
                          folder_local_source = app_sys('data'),
                          onAttach = TRUE) # use default local folder when trying dataload_from_local()
       # EJAM function ... but does it have to say EJAM :: here? trying to avoid having packrat see that and presume EJAM pkg must be installed for app to work. ***


### PR DESCRIPTION
## Summary

- `bgej` (84 MB arrow file) was only lazy-loaded on first user upload, causing a multi-second delay while the file read from disk
- During that delay, Shiny's reactive system could time out and show an error — the second upload always worked because `bgej` was already in memory
- Adding `bgej` to the `dataload_dynamic()` call in `.onAttach()` ensures it is warm before the app starts accepting requests, matching the existing pattern for `blockpoints`, `blockwts`, and `quaddata`

## Test plan

- [ ] Confirm first upload no longer shows an error / delay on a fresh container start
- [ ] Confirm startup time increase is acceptable (~1-2s extra for the 84 MB read)
- [ ] Confirm second+ uploads still work as before

---

> fyi this is from claude, I double checked and seems right but please validate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)