### PR TITLE
[codex] Fix ejam2report footer regex test on development

### DIFF
--- a/tests/testthat/test-ejam2report.R
+++ b/tests/testthat/test-ejam2report.R
@@ -41,7 +41,7 @@ test_that("PDF footer CSS handles missing, vector, and escaped footer text", {
   )
   expect_true(grepl("<style>", footer, fixed = TRUE))
   expect_true(grepl('class="report-running-footer-screen"', footer, fixed = TRUE))
-  expect_true(grepl("@media print.*\\.report-running-footer-screen.*display:\\s*none", footer, perl = TRUE))
+  expect_true(grepl("@media print[\\s\\S]*\\.report-running-footer-screen[\\s\\S]*display:\\s*none", footer, perl = TRUE))
   expect_true(grepl('content: " A\\\\B \\"quoted\\"\\nnext";', footer, fixed = TRUE))
 
   blank_footer <- as.character(EJAM:::generate_report_footer(footer_text = NA))


### PR DESCRIPTION
## Summary
- Updates the `test-ejam2report.R` footer CSS regex on `development` to match across newlines.
- Brings the expectation in line with the version already present on `ACS2024`.

## Why
The previous regex used `.*` with `perl = TRUE`, which did not match the generated multiline CSS footer block. That caused the exact `PDF footer CSS handles missing, vector, and escaped footer text` test to fail on `development` while passing on `ACS2024`.

## Validation
- `R -q -e "pkgload::load_all('.', quiet = TRUE); testthat::test_file('tests/testthat/test-ejam2report.R', desc = 'PDF footer CSS handles missing, vector, and escaped footer text')"`
- `git diff --check`