### PR TITLE
Fix pkgdown docs deploy (skip Suggests/AOI; don't run examples)

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -120,6 +120,12 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::pkgdown, local::.
+          # Install only hard deps (+ pkgdown) for the docs build. Avoids building
+          # optional Suggests like the GitHub-only `AOI` package, which fails to
+          # build in CI ("lazy loading failed for package 'AOI' / object '%>%' not
+          # found") and was breaking every pkgdown deploy. The docs don't need
+          # Suggests (EJAM vignettes are eval=FALSE; AOI examples are \dontrun).
+          dependencies: '"hard"'
           needs: website
 
       - name: Build site

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -149,7 +149,12 @@ jobs:
           pkgdown::init_site(pkg)
           pkgdown::build_favicons(pkg)
           pkgdown::build_home(pkg)
-          pkgdown::build_reference(pkg)
+          # examples = FALSE: don't execute every function's @examples during the
+          # docs deploy. EJAM examples download the large ejamdata arrow data and
+          # run analyses, making the build extremely slow and fragile in CI. The
+          # reference pages still show the example code; example correctness is
+          # covered by R CMD check, not the docs deploy.
+          pkgdown::build_reference(pkg, examples = FALSE)
           pkgdown::build_articles(pkg)
           pkgdown::build_tutorials(pkg)
           pkgdown::build_news(pkg)

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,7 @@ inst/plumber/log_api_usage*.txt
 
 # Ignore scratch report render artifact created during report rendering
 inst/report/community_report/junk.html
+
+# Claude Code / agent local files (untracked tooling state)
+.claude/
+.claude-code-memory-import/


### PR DESCRIPTION
Fixes the chronically-failing pkgdown docs deploy so the versioned docs site can publish.

Two changes to `.github/workflows/pkgdown.yaml`:
1. `dependencies: '"hard"'` — install only hard deps for the docs build, skipping Suggests. The GitHub-only `AOI` package fails to build in CI (`lazy loading failed for package 'AOI' / object '%>%' not found`), which broke **every** docs deploy. This matches what `install-quick-check`, `install-release-user-check`, and `test-webapp-functionality` already do.
2. `build_reference(pkg, examples = FALSE)` — don't execute every function's `@examples` during the docs deploy (they download the large ejamdata data + run analyses, making the build extremely slow/fragile). Example correctness is covered by `R CMD check`.

Validated: a docs build from this branch now succeeds and deploys (root = v3.2022.0). The per-version (`/v3.YYYY.0/`) and `/dev/` builds are deploying from this branch too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)