### PR TITLE
Require Census API key for tidycensus (>= 1.8) breaking change

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -77,7 +77,7 @@ Imports:
     shinyjs (>= 2.1.0),
     stringr (>= 1.5.1),
     tibble (>= 3.3.0),
-    tidycensus (>= 1.6),
+    tidycensus (>= 1.8),
     tidyr (>= 1.3),
     webshot2,
     writexl (>= 1.5.3),

--- a/R/acs_bybg.R
+++ b/R/acs_bybg.R
@@ -21,8 +21,10 @@
 #' which will download ACS nationwide data by table
 #' instead of using acs_bybg(), which queried the API state-by-state.
 #'
-#' acs_bybg() probably requires [getting and specifying an API key for Census Bureau](https://api.census.gov/data/key_signup.html) ! (at least if query is large).
-#'   see [tidycensus package help](https://walker-data.com/tidycensus/)  envt var CENSUS_API_KEY
+#' acs_bybg() requires a [Census Bureau API key](https://api.census.gov/data/key_signup.html):
+#'   tidycensus (>= 1.8) now errors (no longer just warns) without one. Set it once with
+#'   `tidycensus::census_api_key("YOUR KEY", install = TRUE)` (stores envt var CENSUS_API_KEY),
+#'   then restart R. See [tidycensus package help](https://walker-data.com/tidycensus/) and ?tidycensus::census_api_key.
 #'
 #' NOTES ON KEY TABLES IN ACS THAT ARE RELEVANT TO EJSCREEN:
 #' ```
@@ -203,7 +205,7 @@ acs_bybg <- function(
   # NEED API KEY POSSIBLY, FOR LARGE QUERIES AT LEAST
 
   if (nchar(Sys.getenv("CENSUS_API_KEY")) == 0) {
-    warning("envt var CENSUS_API_KEY not found - tidycensus::get_acs() may require having set up a census api key - see ?tidycensus::census_api_key  ")
+    warning("envt var CENSUS_API_KEY not found - tidycensus (>= 1.8) now requires a Census API key and tidycensus::get_acs() will error without one. Set it with tidycensus::census_api_key(\"YOUR KEY\", install = TRUE) - see ?tidycensus::census_api_key  ")
   }
 
   # if (!exists("get_acs")) {  # now in Imports of DESCRIPTION file

--- a/R/acs_bycounty.R
+++ b/R/acs_bycounty.R
@@ -58,7 +58,7 @@ acs_bycounty <- function(myvars = "B03002_001", myst = "DE", yr = NULL) {
 
   # >>> check if census api key available *** ####
   if (nchar(Sys.getenv("CENSUS_API_KEY")) == 0) {
-    warning("envt var CENSUS_API_KEY not found - tidycensus::get_acs() may require having set up a census api key - see ?tidycensus::census_api_key  ")
+    warning("envt var CENSUS_API_KEY not found - tidycensus (>= 1.8) now requires a Census API key and tidycensus::get_acs() will error without one. Set it with tidycensus::census_api_key(\"YOUR KEY\", install = TRUE) - see ?tidycensus::census_api_key  ")
   }
 
   data_county <- tidycensus::get_acs(

--- a/R/calc_blockgroupstats_acs.R
+++ b/R/calc_blockgroupstats_acs.R
@@ -13,6 +13,14 @@ acs_table_info <- function(yr, tables_acs, dataset = 'acs5') {
 
   if (missing(tables_acs)) {tables_acs <- as.vector(tables_ejscreen_acs)}
   if (missing(yr)) {yr <- acs_endyear(guess_census_has_published = T)}
+  # Census API key is now mandatory: tidycensus (>= 1.8) errors (no longer warns) without
+  # a key, INCLUDING for metadata via load_variables(). Fail fast with an actionable message.
+  if (nchar(Sys.getenv("CENSUS_API_KEY")) == 0) {
+    stop("A Census API key is required: tidycensus (>= 1.8) now errors without one, ",
+         "including for metadata via tidycensus::load_variables(). Set one once with ",
+         'tidycensus::census_api_key("YOUR KEY", install = TRUE), then restart R. ',
+         "See ?tidycensus::census_api_key")
+  }
   x = tidycensus::load_variables(yr, dataset = dataset, cache = T)
   x$table = gsub("^(.*)_.*$", "\\1", x$name)
   x = x[x$table %in% tables_acs, ]
@@ -66,6 +74,16 @@ calc_blockgroupstats_acs <- function(yr,
   if (!requireNamespace("ACSdownload", quietly = TRUE)) {
     stop("requires installed package ACSdownload from https://github.com/ejanalysis/ACSdownload and documented at https://ejanalysis.github.io/ACSdownload/")
   }
+  # Fail fast on a missing Census API key: tidycensus (>= 1.8) errors without one, even for
+  # the load_variables() metadata lookup used by acs_table_info() below. Checking here (before
+  # the prior-year fallback ladder) means any later acs_table_info() error is about data
+  # availability, not the key, so the ladder can safely treat it as "try a prior year".
+  if (nchar(Sys.getenv("CENSUS_API_KEY")) == 0) {
+    stop("A Census API key is required to build ACS data: tidycensus (>= 1.8) now errors ",
+         "without one. Set it once with ",
+         'tidycensus::census_api_key("YOUR KEY", install = TRUE), then restart R. ',
+         "See ?tidycensus::census_api_key")
+  }
   # library(EJAM); library(dplyr); library(data.table)
 
   if (missing(yr)) {
@@ -76,15 +94,27 @@ calc_blockgroupstats_acs <- function(yr,
     ## BLOCK GROUP SURVEY DATA HANDLED DIFFERENTLY/ SEPARATELY FROM
     ## Tract resolution survey data that has to be allocated to blockgroups.
     ## Check available resolution of each table here.
-    x <- acs_table_info(yr = yr, tables_acs = tables, dataset = "acs5")
-    if (all(is.na(x$geography))) {
-      # tidycensus package has not yet updated the geo table, perhaps, as was the case as of April 27, 2026 for the ACS 2020-2024 data released in Jan 2026.
-      # assume geo resolution of each table number is same as prior year, for which it is already in the tidycensus pkg,
-      # and will hope the table numbers are still the same which is not always true
-      x <- acs_table_info(yr = as.numeric(yr) - 1, tables_acs = tables, dataset = "acs5")
-      if (all(is.na(x$geography))) {
-        # still a problem?? know it is available for 2023 dataset, and will hope the table numbers are still the same which is not always true
-        x <- acs_table_info(yr = 2023, tables_acs = tables, dataset = "acs5")
+    # Get table geography metadata, falling back to a prior year if the newest vintage is
+    # not yet served by tidycensus. tidycensus (>= 1.8) may *error* (not just return NA
+    # geography) for a year it does not support, so catch errors here too and treat them
+    # the same as all-NA geography. (A missing key already stopped us above, so an error
+    # here is about data availability, not the key.) We assume table numbers + geography
+    # resolution are unchanged from the prior year, which is usually but not always true.
+    geo_info <- function(year) {
+      tryCatch(acs_table_info(yr = year, tables_acs = tables, dataset = "acs5"),
+               error = function(e) {
+                 message("tidycensus could not return ACS table metadata for ", year,
+                         " (", conditionMessage(e), "); will try a prior year.")
+                 NULL
+               })
+    }
+    needs_fallback <- function(x) is.null(x) || all(is.na(x$geography))
+    x <- geo_info(yr)
+    if (needs_fallback(x)) {
+      x <- geo_info(as.numeric(yr) - 1)
+      if (needs_fallback(x)) {
+        # known available for the 2023 dataset
+        x <- geo_info(2023)
       }
     }
     tables_resolution = x$geography[ match(tables, x$table)] # geo res of first hit in x info, per table

--- a/R/calc_ejscreen_dataset.R
+++ b/R/calc_ejscreen_dataset.R
@@ -74,7 +74,10 @@
 #'  - EJAM_TRACT_WEIGHT_SOURCE: decennial2020 or acs. decennial2020 matches
 #'    legacy EJSCREEN tract-to-blockgroup apportionment.
 #'  - AWS_PROFILE and AWS_REGION: used when pipeline_storage is s3
-#'  - CENSUS_API_KEY: used by functions that download ACS data (or that download boundaries/shapefiles for FIPS from some sources)
+#'  - CENSUS_API_KEY: REQUIRED. Used by functions that download ACS data or ACS table
+#'    metadata (and that download boundaries/shapefiles for FIPS from some sources).
+#'    tidycensus (>= 1.8) now errors without a key, even for metadata via load_variables().
+#'    Set it once with `tidycensus::census_api_key("YOUR KEY", install = TRUE)`, then restart R.
 #'  - EJAM_FORCE_ACS: TRUE to redownload/recalculate raw ACS and bg_acsdata.
 #'  - EJAM_FORCE_BG_ACSDATA: TRUE to rebuild bg_acsdata from saved raw ACS.
 #'  - EJAM_FORCE_BG_GEODATA: TRUE to redownload/recalculate Census/TIGER blockgroup geodata.

--- a/R/shapes_from_fips.R
+++ b/R/shapes_from_fips.R
@@ -394,7 +394,7 @@ shapes_counties_from_countyfips <- function(countyfips = '10001', outFields = c(
   # >>> check if census api key available *** ####
   if (nchar(Sys.getenv("CENSUS_API_KEY")) == 0) {
     tidycensus_ok <- FALSE
-    warning("envt var CENSUS_API_KEY not found - tidycensus::get_acs() may require having set up a census api key - see ?tidycensus::census_api_key  ")
+    warning("envt var CENSUS_API_KEY not found - tidycensus (>= 1.8) now requires a Census API key and tidycensus::get_acs() will error without one. Set it with tidycensus::census_api_key(\"YOUR KEY\", install = TRUE) - see ?tidycensus::census_api_key  ")
   }
   if (myservice[1] %in% c("cartographic", "tiger") && tidycensus_ok) {
     ## > tidycensus ok ####
@@ -875,7 +875,7 @@ shapes_places_from_placefips <- function(fips, myservice = 'tiger', year = 2024)
 
   # >>> check if census api key available *** ####
   if (nchar(Sys.getenv("CENSUS_API_KEY")) == 0) {
-    warning("envt var CENSUS_API_KEY not found - tigris::places() may require having set up a census api key - see ?tidycensus::census_api_key  ")
+    warning("envt var CENSUS_API_KEY not found - tigris/Census now require a Census API key and tigris::places() will error without one. Set it with tidycensus::census_api_key(\"YOUR KEY\", install = TRUE) - see ?tidycensus::census_api_key  ")
   }
 
   # Downloads ALL places in relevant STATES...  and last step will drop unrequested places

--- a/man/acs_bybg.Rd
+++ b/man/acs_bybg.Rd
@@ -78,8 +78,10 @@ See newer ACSdownload::get_acs_new() as used in calc_blockgroupstats_acs() etc.,
 which will download ACS nationwide data by table
 instead of using acs_bybg(), which queried the API state-by-state.
 
-acs_bybg() probably requires \href{https://api.census.gov/data/key_signup.html}{getting and specifying an API key for Census Bureau} ! (at least if query is large).
-see \href{https://walker-data.com/tidycensus/}{tidycensus package help}  envt var CENSUS_API_KEY
+acs_bybg() requires a \href{https://api.census.gov/data/key_signup.html}{Census Bureau API key}:
+tidycensus (>= 1.8) now errors (no longer just warns) without one. Set it once with
+\code{tidycensus::census_api_key("YOUR KEY", install = TRUE)} (stores envt var CENSUS_API_KEY),
+then restart R. See \href{https://walker-data.com/tidycensus/}{tidycensus package help} and ?tidycensus::census_api_key.
 
 NOTES ON KEY TABLES IN ACS THAT ARE RELEVANT TO EJSCREEN:
 

--- a/man/calc_ejscreen_dataset.Rd
+++ b/man/calc_ejscreen_dataset.Rd
@@ -344,7 +344,10 @@ variables:
 \item EJAM_TRACT_WEIGHT_SOURCE: decennial2020 or acs. decennial2020 matches
 legacy EJSCREEN tract-to-blockgroup apportionment.
 \item AWS_PROFILE and AWS_REGION: used when pipeline_storage is s3
-\item CENSUS_API_KEY: used by functions that download ACS data (or that download boundaries/shapefiles for FIPS from some sources)
+\item CENSUS_API_KEY: REQUIRED. Used by functions that download ACS data or ACS table
+metadata (and that download boundaries/shapefiles for FIPS from some sources).
+tidycensus (>= 1.8) now errors without a key, even for metadata via load_variables().
+Set it once with \code{tidycensus::census_api_key("YOUR KEY", install = TRUE)}, then restart R.
 \item EJAM_FORCE_ACS: TRUE to redownload/recalculate raw ACS and bg_acsdata.
 \item EJAM_FORCE_BG_ACSDATA: TRUE to rebuild bg_acsdata from saved raw ACS.
 \item EJAM_FORCE_BG_GEODATA: TRUE to redownload/recalculate Census/TIGER blockgroup geodata.

--- a/vignettes/dev-update-ejscreen-datasets-yearly.Rmd
+++ b/vignettes/dev-update-ejscreen-datasets-yearly.Rmd
@@ -324,7 +324,7 @@ RStudio/source-based workflows and GitHub Actions. The main settings are:
 | `EJAM_REFRESH_DECENNIAL_BGWTS` | `"TRUE"` to ignore and overwrite the cached decennial blockgroup weights. |
 | `EJAM_TIGER_BG_CACHE_DIR` | Optional local folder for downloaded Census TIGER/Line block group zip files. If unset, EJAM uses a durable user cache folder. |
 | `AWS_PROFILE`, `AWS_REGION` | Used by the AWS CLI for S3-backed runs. |
-| `CENSUS_API_KEY` | Used by ACS/Census download helpers where needed. |
+| `CENSUS_API_KEY` | **Required.** Used by ACS/Census helpers for data *and metadata*. tidycensus (>= 1.8) errors without a key, even for `load_variables()`. Set once with `tidycensus::census_api_key("YOUR KEY", install = TRUE)`, then restart R. See `?tidycensus::census_api_key`. |
 | `EJAM_FORCE_ACS` | `"TRUE"` to redownload raw ACS and rebuild ACS stages. |
 | `EJAM_FORCE_BG_ACSDATA` | `"TRUE"` to rebuild `bg_acsdata` from saved raw ACS. |
 | `EJAM_FORCE_BG_GEODATA` | `"TRUE"` to redownload/rebuild the Census/TIGER `bg_geodata` stage. |
@@ -413,6 +413,14 @@ changes. The script in `data-raw/datacreate_names_of_indicators.R` uses
 
 
 ## Run a Fresh ACS Update
+
+> **Prerequisite: a Census API key.** As of tidycensus (>= 1.8) the Census Bureau
+> requires an API key for all requests, including the `load_variables()` metadata lookup
+> EJAM uses to resolve ACS table geography. tidycensus now *errors* (no longer warns)
+> without one. Get a free key at <https://api.census.gov/data/key_signup.html> and set it
+> once with `tidycensus::census_api_key("YOUR KEY", install = TRUE)`, then restart R.
+> (The bulk ACS download via `ACSdownload::get_acs_new()` reads Census summary files, but
+> the metadata step still needs the key.)
 
 Start from a clean branch. For ACS 2020-2024 using local checkpoints:
 


### PR DESCRIPTION
Lands the Census-API-key fix on `development` (and from there to `main`).

tidycensus 1.8 made a Census API key mandatory for all requests, including metadata via `load_variables()`; it now errors instead of warning with no key.

- DESCRIPTION: tidycensus floor 1.6 -> 1.8
- `acs_table_info()` + `calc_blockgroupstats_acs()`: fail fast with an actionable 'set your key' message when CENSUS_API_KEY is unset
- `calc_blockgroupstats_acs()`: prior-year table-geography fallback now also catches `load_variables()` erroring (not just NA geography)
- Reworded 4 stale 'may require a key' warnings -> 'now requires' + `census_api_key()` hint
- Docs: roxygen + pipeline-vignette prerequisite; regenerated man/

Tracking: #391. Already backported + released as v3.2022.1 / v3.2023.1 / v3.2024.1; this PR is the missing development/main landing. No version bump in this commit (intentional).