### PR TITLE
Fix release install checks and EJAM app URL

### DIFF
--- a/.github/workflows/install-release-user-check.yaml
+++ b/.github/workflows/install-release-user-check.yaml
@@ -119,9 +119,12 @@ jobs:
 
       - name: Check DESCRIPTION version
         run: |
-          desc_version <- read.dcf("DESCRIPTION", fields = "Version")[1, "Version"]
-          expected <- Sys.getenv("EXPECTED_VERSION")
-          ref <- Sys.getenv("EJAM_INSTALL_REF")
+          clean_scalar <- function(x) {
+            trimws(unname(as.character(x[1])))
+          }
+          desc_version <- clean_scalar(read.dcf("DESCRIPTION", fields = "Version")[1, "Version"])
+          expected <- clean_scalar(Sys.getenv("EXPECTED_VERSION"))
+          ref <- clean_scalar(Sys.getenv("EJAM_INSTALL_REF"))
           if (!nzchar(expected) && grepl("^v[0-9]", ref)) {
             expected <- sub("^v", "", ref)
           }
@@ -193,7 +196,7 @@ jobs:
       GITHUB_PAT: ${{ github.token }}
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       EJAM_INSTALL_REPO: ${{ github.repository }}
-      EJAM_INSTALL_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || '*release' }}
+      EJAM_INSTALL_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}
       EXPECTED_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.expected_version || '' }}
       RELEASE_TAG: ${{ github.event.release.tag_name || '' }}
 
@@ -219,9 +222,12 @@ jobs:
           )
 
           library(EJAM)
-          installed_version <- as.character(utils::packageVersion("EJAM"))
-          expected <- Sys.getenv("EXPECTED_VERSION")
-          release_tag <- Sys.getenv("RELEASE_TAG")
+          clean_scalar <- function(x) {
+            trimws(unname(as.character(x[1])))
+          }
+          installed_version <- clean_scalar(utils::packageVersion("EJAM"))
+          expected <- clean_scalar(Sys.getenv("EXPECTED_VERSION"))
+          release_tag <- clean_scalar(Sys.getenv("RELEASE_TAG"))
           if (!nzchar(expected) && grepl("^v[0-9]", release_tag)) {
             expected <- sub("^v", "", release_tag)
           }

--- a/R/URL_FUNCTIONS_part1.R
+++ b/R/URL_FUNCTIONS_part1.R
@@ -59,8 +59,9 @@ url_acs_table_info <- function(tables = tables_ejscreen_acs, fips = NULL, yr, fi
 #'
 url_online <- function(url = "https://ejam.publicenvirodata.org") {
 
-  if (missing(url)) {stop("must specify a URL")}
-  if (length(url) > 1) {stop("can only check one URL at a time using url_online()")}
+  if (length(url) > 1) {stop("can only check one URL at a time using url_online()")} 
+  url <- trimws(unname(as.character(url[1])))
+  if (!nzchar(url)) {stop("must specify a URL")}
   if (offline()) {
     warning("Cannot check URL when offline -- internet connection does not seem to be available")
     return(NA)

--- a/R/URL_FUNCTIONS_part1.R
+++ b/R/URL_FUNCTIONS_part1.R
@@ -57,7 +57,7 @@ url_acs_table_info <- function(tables = tables_ejscreen_acs, fips = NULL, yr, fi
 #'
 #' @keywords internal
 #'
-url_online <- function(url = "https://ejam.policyinnovation.info") {
+url_online <- function(url = "https://ejam.publicenvirodata.org") {
 
   if (missing(url)) {stop("must specify a URL")}
   if (length(url) > 1) {stop("can only check one URL at a time using url_online()")}

--- a/man/url_online.Rd
+++ b/man/url_online.Rd
@@ -4,7 +4,7 @@
 \alias{url_online}
 \title{utility - check if URL available, such as if an API is online or offline}
 \usage{
-url_online(url = "https://ejam.policyinnovation.info")
+url_online(url = "https://ejam.publicenvirodata.org")
 }
 \arguments{
 \item{url}{the URL to check}

--- a/vignettes/dev-app-settings.Rmd
+++ b/vignettes/dev-app-settings.Rmd
@@ -312,7 +312,7 @@ browseURL(urlx)
 Using a custom URL to go to a web app with custom settings
 
 ```{r browseURL, eval=FALSE}
-urlbase <- "https://ejam.policyinnovation.info/?_inputs_&"
+urlbase <- "https://ejam.publicenvirodata.org/?_inputs_&"
 
 myparams <- c(
   standard_analysis_title="Custom NAICS Analysis",

--- a/vignettes/ejscreen.Rmd
+++ b/vignettes/ejscreen.Rmd
@@ -40,7 +40,7 @@ EJAM-related repositories.
         archive.org](https://web.archive.org/web/20250203174905/https://ejscreen.epa.gov/mapper/help/ejscreen_help.pdf){target="_blank"}
 
     -   [EJSCREEN Multisite Tool User
-        Guide](https://ejam.policyinnovation.info/www/user-guide-2025-02.pdf){target="_blank"}
+        Guide](https://ejam.publicenvirodata.org/www/user-guide-2025-02.pdf){target="_blank"}
         (aka EJAM walkthrough). Also [saved in repo](`r paste0(EJAM::url_package(get_full_url = TRUE), "/blob/main/inst/app/www/user-guide-2025-02.pdf")`){target="_blank"}
 
 ## Documentation of Data Sources and Technical Methods


### PR DESCRIPTION
Updates the release/user install workflow so release events install the published tag and version comparisons normalize DESCRIPTION/env values before comparing. Also replaces ejam.policyinnovation.info links with ejam.publicenvirodata.org in code, vignettes, and generated Rd.