### PR TITLE
[codex] Fix Excel freeze pane columns

### DIFF
--- a/R/table_xls_format.R
+++ b/R/table_xls_format.R
@@ -718,7 +718,9 @@ table_xls_format <- function(overall,
   ## ROW1 FREEZE PANES AND LEFTMOST COLUMNS ####
 
   # openxlsx::freezePane(wb, sheet = 'Each Site', firstRow = TRUE) #, firstCol = TRUE)  ## freeze first row and column
-  openxlsx::freezePane(wb, sheet = 'Each Site', firstActiveCol = 4, firstActiveRow = 2)
+first_active_col_eachsite <- match("valid", headers_eachsite)
+if (is.na(first_active_col_eachsite)) first_active_col_eachsite <- 1
+openxlsx::freezePane(wb, sheet = 'Each Site', firstActiveCol = first_active_col_eachsite, firstActiveRow = 2)
   # openxlsx::freezePane(wb, sheet = 'Overall',   firstActiveCol = 1)
   openxlsx::freezePane(wb, sheet = 'Overall',   firstActiveCol = 1, firstActiveRow = 2)
   openxlsx::freezePane(wb, sheet = 'Overall 2', firstActiveCol = 1, firstActiveRow = 2)

--- a/R/table_xls_format.R
+++ b/R/table_xls_format.R
@@ -718,7 +718,7 @@ table_xls_format <- function(overall,
   ## ROW1 FREEZE PANES AND LEFTMOST COLUMNS ####
 
   # openxlsx::freezePane(wb, sheet = 'Each Site', firstRow = TRUE) #, firstCol = TRUE)  ## freeze first row and column
-  openxlsx::freezePane(wb, sheet = 'Each Site', firstActiveCol = 5, firstActiveRow = 2)
+  openxlsx::freezePane(wb, sheet = 'Each Site', firstActiveCol = 4, firstActiveRow = 2)
   # openxlsx::freezePane(wb, sheet = 'Overall',   firstActiveCol = 1)
   openxlsx::freezePane(wb, sheet = 'Overall',   firstActiveCol = 1, firstActiveRow = 2)
   openxlsx::freezePane(wb, sheet = 'Overall 2', firstActiveCol = 1, firstActiveRow = 2)

--- a/R/table_xls_format.R
+++ b/R/table_xls_format.R
@@ -718,9 +718,9 @@ table_xls_format <- function(overall,
   ## ROW1 FREEZE PANES AND LEFTMOST COLUMNS ####
 
   # openxlsx::freezePane(wb, sheet = 'Each Site', firstRow = TRUE) #, firstCol = TRUE)  ## freeze first row and column
-first_active_col_eachsite <- match("valid", headers_eachsite)
-if (is.na(first_active_col_eachsite)) first_active_col_eachsite <- 1
-openxlsx::freezePane(wb, sheet = 'Each Site', firstActiveCol = first_active_col_eachsite, firstActiveRow = 2)
+  first_active_col_eachsite <- match("valid", headers_eachsite)
+  if (is.na(first_active_col_eachsite)) first_active_col_eachsite <- 1
+  openxlsx::freezePane(wb, sheet = 'Each Site', firstActiveCol = first_active_col_eachsite, firstActiveRow = 2)
   # openxlsx::freezePane(wb, sheet = 'Overall',   firstActiveCol = 1)
   openxlsx::freezePane(wb, sheet = 'Overall',   firstActiveCol = 1, firstActiveRow = 2)
   openxlsx::freezePane(wb, sheet = 'Overall 2', firstActiveCol = 1, firstActiveRow = 2)

--- a/tests/testthat/test-ejam2excel.R
+++ b/tests/testthat/test-ejam2excel.R
@@ -57,6 +57,17 @@ test_that("ejam2excel saves key tables, tabs, saved numbers match original", {
   )
 
   tab_bysite <- readxl::read_excel(fname, sheet = "Each Site") %>% as.data.frame()
+  expect_equal(
+    names(tab_bysite)[1:4],
+    c("EJAM Report", "EJSCREEN Map", "ejam_uniq_id", "valid")
+  )
+
+  bysite_sheet_xml <- paste(readLines(unz(fname, "xl/worksheets/sheet1.xml"), warn = FALSE), collapse = "")
+  bysite_pane_xml <- regmatches(bysite_sheet_xml, gregexpr("<pane[^>]+", bysite_sheet_xml))[[1]]
+  expect_length(bysite_pane_xml, 1)
+  expect_match(bysite_pane_xml, 'xSplit="3"')
+  expect_match(bysite_pane_xml, 'topLeftCell="D2"')
+
   expect_equal(NROW(tab_bysite),
                NROW(testoutput_ejamit_10pts_1miles$results_bysite))
 


### PR DESCRIPTION
## Summary
- Freeze only the report/link columns and `ejam_uniq_id` in the Excel `Each Site` sheet.
- Leave the `valid` column scrollable by moving the active pane from column E to column D.
- Add regression coverage that checks the generated workbook pane XML and first columns.

Closes #148.

## Testing
- `devtools::test(filter = "ejam2excel", reporter = "stop")`