### PR TITLE
fix: Census-key guard must not block calc_blockgroupstats_acs(acs_raw=...) path

### DIFF
--- a/R/calc_blockgroupstats_acs.R
+++ b/R/calc_blockgroupstats_acs.R
@@ -74,22 +74,25 @@ calc_blockgroupstats_acs <- function(yr,
   if (!requireNamespace("ACSdownload", quietly = TRUE)) {
     stop("requires installed package ACSdownload from https://github.com/ejanalysis/ACSdownload and documented at https://ejanalysis.github.io/ACSdownload/")
   }
-  # Fail fast on a missing Census API key: tidycensus (>= 1.8) errors without one, even for
-  # the load_variables() metadata lookup used by acs_table_info() below. Checking here (before
-  # the prior-year fallback ladder) means any later acs_table_info() error is about data
-  # availability, not the key, so the ladder can safely treat it as "try a prior year".
-  if (nchar(Sys.getenv("CENSUS_API_KEY")) == 0) {
-    stop("A Census API key is required to build ACS data: tidycensus (>= 1.8) now errors ",
-         "without one. Set it once with ",
-         'tidycensus::census_api_key("YOUR KEY", install = TRUE), then restart R. ',
-         "See ?tidycensus::census_api_key")
-  }
   # library(EJAM); library(dplyr); library(data.table)
 
   if (missing(yr)) {
     yr <- acs_endyear(guess_always = TRUE, guess_census_has_published = TRUE)
   }
   if (is.null(acs_raw)) {
+    # Fail fast on a missing Census API key: tidycensus (>= 1.8) errors without one, even
+    # for the load_variables() metadata lookup used by acs_table_info() below. Checking
+    # here (before the prior-year fallback ladder) means any later acs_table_info() error
+    # is about data availability, not the key, so the ladder can safely treat it as "try a
+    # prior year". The check belongs INSIDE this is.null(acs_raw) branch: when acs_raw is
+    # supplied (e.g. the pipeline rebuilding bg_acsdata from the saved raw-ACS stage), no
+    # tidycensus/Census-API call happens here, so a keyless environment must not be blocked.
+    if (nchar(Sys.getenv("CENSUS_API_KEY")) == 0) {
+      stop("A Census API key is required to build ACS data: tidycensus (>= 1.8) now errors ",
+           "without one. Set it once with ",
+           'tidycensus::census_api_key("YOUR KEY", install = TRUE), then restart R. ',
+           "See ?tidycensus::census_api_key")
+    }
     ################################################### #
     ## BLOCK GROUP SURVEY DATA HANDLED DIFFERENTLY/ SEPARATELY FROM
     ## Tract resolution survey data that has to be allocated to blockgroups.

--- a/tests/testthat/test-calc_blockgroupstats_acs_keyguard.R
+++ b/tests/testthat/test-calc_blockgroupstats_acs_keyguard.R
@@ -11,7 +11,7 @@ test_that("keyless calc_blockgroupstats_acs errors about the key ONLY when it mu
 
   # download path: fail fast with the actionable key message
   expect_error(
-    calc_blockgroupstats_acs(yr = 2022, acs_raw = NULL),
+    EJAM:::calc_blockgroupstats_acs(yr = 2022, acs_raw = NULL),
     regexp = "Census API key"
   )
 
@@ -19,7 +19,7 @@ test_that("keyless calc_blockgroupstats_acs errors about the key ONLY when it mu
   # acs_raw will fail later for structural reasons; assert only that whatever
   # error (if any) arises is NOT the key guard.
   err <- tryCatch({
-    calc_blockgroupstats_acs(yr = 2022, acs_raw = list(blockgroup = list()))
+    EJAM:::calc_blockgroupstats_acs(yr = 2022, acs_raw = list(blockgroup = list()))
     ""
   }, error = function(e) conditionMessage(e))
   expect_false(grepl("Census API key", err, fixed = TRUE))

--- a/tests/testthat/test-calc_blockgroupstats_acs_keyguard.R
+++ b/tests/testthat/test-calc_blockgroupstats_acs_keyguard.R
@@ -1,0 +1,26 @@
+# The CENSUS_API_KEY fail-fast in calc_blockgroupstats_acs() must only block the
+# download/metadata path (acs_raw = NULL). When acs_raw is supplied -- e.g. the
+# pipeline rebuilding bg_acsdata from the saved raw-ACS stage -- no tidycensus or
+# Census API call happens, so a keyless environment must not be stopped by it.
+
+test_that("keyless calc_blockgroupstats_acs errors about the key ONLY when it must download (acs_raw = NULL)", {
+  skip_if_not_installed("ACSdownload")
+  oldkey <- Sys.getenv("CENSUS_API_KEY")
+  on.exit(Sys.setenv(CENSUS_API_KEY = oldkey), add = TRUE)
+  Sys.setenv(CENSUS_API_KEY = "")
+
+  # download path: fail fast with the actionable key message
+  expect_error(
+    calc_blockgroupstats_acs(yr = 2022, acs_raw = NULL),
+    regexp = "Census API key"
+  )
+
+  # acs_raw-supplied path: must NOT be blocked by the key guard. A minimal fake
+  # acs_raw will fail later for structural reasons; assert only that whatever
+  # error (if any) arises is NOT the key guard.
+  err <- tryCatch({
+    calc_blockgroupstats_acs(yr = 2022, acs_raw = list(blockgroup = list()))
+    ""
+  }, error = function(e) conditionMessage(e))
+  expect_false(grepl("Census API key", err, fixed = TRUE))
+})


### PR DESCRIPTION
Follow-up to #392/#391. The key fail-fast fired even when `acs_raw` is supplied — a path that makes **no** tidycensus/Census-API call (it's how the pipeline rebuilds `bg_acsdata` from the saved raw-ACS stage). Keyless environments (CI; `Rscript --no-init-file` when the key lives in `.Rprofile`) were wrongly blocked — this bit today's 2022 exports-only pipeline rerun.

Fix: move the guard inside the `is.null(acs_raw)` (download/metadata) branch, where it still fails fast before the prior-year fallback ladder. Adds a 2-path regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)