### PR TITLE
fix: clearer errors for exhausted ACS-metadata fallback and invalid url_online() input

### DIFF
--- a/R/URL_FUNCTIONS_part1.R
+++ b/R/URL_FUNCTIONS_part1.R
@@ -59,9 +59,12 @@ url_acs_table_info <- function(tables = tables_ejscreen_acs, fips = NULL, yr, fi
 #'
 url_online <- function(url = "https://ejam.publicenvirodata.org") {
 
-  if (length(url) > 1) {stop("can only check one URL at a time using url_online()")} 
+  if (length(url) > 1) {stop("can only check one URL at a time using url_online()")}
   url <- trimws(unname(as.character(url[1])))
-  if (!nzchar(url)) {stop("must specify a URL")}
+  # Guard NULL / character(0) / NA before nzchar(): those would otherwise make the nzchar()
+  # test return logical(0) or TRUE and trigger a cryptic "missing value where TRUE/FALSE
+  # needed" error instead of the intended "must specify a URL".
+  if (length(url) == 0 || is.na(url) || !nzchar(url)) {stop("must specify a URL")}
   if (offline()) {
     warning("Cannot check URL when offline -- internet connection does not seem to be available")
     return(NA)

--- a/R/calc_blockgroupstats_acs.R
+++ b/R/calc_blockgroupstats_acs.R
@@ -120,6 +120,15 @@ calc_blockgroupstats_acs <- function(yr,
         x <- geo_info(2023)
       }
     }
+    # If every attempted year failed (e.g. tidycensus/Census API unreachable), x is NULL or
+    # all-NA. Stop with a clear message rather than letting the NULL/all-NA flow downstream,
+    # where it would silently yield empty tables_bg/tables_tract and a confusing later error.
+    if (needs_fallback(x)) {
+      stop("Could not obtain ACS table geography metadata from tidycensus for ", yr, ", ",
+           as.numeric(yr) - 1, ", or 2023, so block-group vs tract resolution per table ",
+           "cannot be determined. Check the internet connection and that tidycensus can ",
+           "reach the Census API (a valid CENSUS_API_KEY is required).")
+    }
     tables_resolution = x$geography[ match(tables, x$table)] # geo res of first hit in x info, per table
     tables_bg    = tables[tables_resolution %in% "block group" ]
     tables_tract = tables[tables_resolution %in% "tract" ]

--- a/tests/testthat/test-URL_FUNCTIONS_part1.R
+++ b/tests/testthat/test-URL_FUNCTIONS_part1.R
@@ -193,3 +193,17 @@ test_that("urls_from_keylists keylist_4all ok", {
   )
 })
 ############################ #
+
+test_that("url_online rejects empty/NA/NULL input with a clear message (no offline call)", {
+  # These must stop BEFORE any network/offline() check, with the intended message,
+  # not a cryptic 'missing value where TRUE/FALSE needed'.
+  expect_error(EJAM:::url_online(""),               regexp = "must specify a URL")
+  expect_error(EJAM:::url_online("   "),            regexp = "must specify a URL")
+  expect_error(EJAM:::url_online(NA),               regexp = "must specify a URL")
+  expect_error(EJAM:::url_online(NA_character_),    regexp = "must specify a URL")
+  expect_error(EJAM:::url_online(character(0)),     regexp = "must specify a URL")
+  expect_error(EJAM:::url_online(NULL),             regexp = "must specify a URL")
+  # multiple URLs still rejected distinctly
+  expect_error(EJAM:::url_online(c("a", "b")),      regexp = "one URL at a time")
+})
+############################ #


### PR DESCRIPTION
Addresses the two Copilot review comments raised on the #401 (development → main) sync. Both are minor robustness fixes to pre-existing code; no behavior change on the normal paths.

- **`calc_blockgroupstats_acs()`** — if the ACS table-geography fallback ladder fails for *all* attempted years (`yr`, `yr-1`, `2023`; e.g. tidycensus/Census API unreachable), `x` was NULL/all-NA and flowed downstream to silently-empty `tables_bg`/`tables_tract` and a confusing later error. Now `stop()`s with an actionable message.
- **`url_online()`** — guards `NULL` / `character(0)` / `NA` before `nzchar()`, which otherwise threw "missing value where TRUE/FALSE needed" instead of the intended "must specify a URL". Adds regression tests (empty/whitespace/NA/NULL/multi-URL).

Tests: `test-URL_FUNCTIONS_part1.R` 28 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)