### PR TITLE
pdf vs html report format parameter (and fix module enabling lat lon via click on map)

### DIFF
--- a/R/MODULE_latlon_from_map_click.R
+++ b/R/MODULE_latlon_from_map_click.R
@@ -1,10 +1,12 @@
 ################################################ ################################################# #
 
-# This file is draft possible module
-# for selecting sites by user clicking on a map to get lat lon values, and
-# adjusting the radius of the circle shown on the map around that point.
+# This file is a shiny Module
+# for selecting sites by user clicking on a map to get lat,lon values, and
+# adjusting the radius of the circle shown on the map around each point.
 
-# It is not yet fully developed or tested, but it is a starting point for development of this module.
+# The module lets the user click the map to add ONE OR MORE points. It accumulates
+# those clicks into a data.frame of lat,lon values (stored in the reactive `reactdat`)
+# that an "outer" app can read and use (e.g., as the list of sites to analyze in EJAM).
 
 # It also has notes on and is a demo of how to use reactives as inputs/outputs of a module,
 # and how to call a module from an outer overall app.
@@ -51,16 +53,27 @@ MODULE_UI_latlon_from_map_click <- function(id) {
   radiusdefault = 3
 
   ns <- shiny::NS(id)
-  tagList(
+  shiny::tagList(
 
     # show SLIDER & MAP
 
     shiny::sliderInput(inputId = ns('pointradius_input'),
-      'Point Radius', min = 1, max = 10, value = radiusdefault),
+      'Point Radius (miles)', min = 1, max = 10, value = radiusdefault),
+
+    shiny::helpText("Click on the map to add one or more points. ",
+                    "Move the slider to change the radius drawn around each point."),
 
     leaflet::leafletOutput(
       ns("mymap")
     ),
+
+    shiny::br(),
+
+    # let the user remove the most recent point or start over
+    shiny::actionButton(inputId = ns("undo_point"),  label = "Undo last point",
+                        class = 'usa-button usa-button--outline'),
+    shiny::actionButton(inputId = ns("clear_points"), label = "Clear all points",
+                        class = 'usa-button usa-button--outline'),
 
     shiny::br()
   )
@@ -74,17 +87,31 @@ MODULE_UI_latlon_from_map_click <- function(id) {
 #' @noRd
 #'
 MODULE_SERVER_latlon_from_map_click <- function(id,
-                                                reactdat,  # this is a reactive value that could be passed here as the default data.frame of lat,lon of 1 point
+                                                reactdat,  # reactiveVal holding the data.frame of lat,lon points; the module appends a row to it for each map click
                                                 ...) {
 
-  # if instead of this being a param passed here, you were to initialize the reactive data.frame of lat,lon of 1 point that will be output of this function
-  # reactdat <- shiny::reactiveVal(data.frame(lat = NA, lon = NA))
+  # if instead of this being a param passed here, you were to initialize the reactive data.frame of lat,lon points that will be output of this function:
+  # reactdat <- shiny::reactiveVal(data.frame(lat = numeric(0), lon = numeric(0)))
 
   #################################### #
   shiny::moduleServer(
     id = id,
     function(input, output, session) {
       ns <- session$ns
+
+      # Helper: coerce whatever is in reactdat() down to a clean data.frame of just lat,lon (dropping rows without valid lat/lon).
+      # This lets the module accept an initial/seed table that may have extra columns (e.g. testpoints_10 has sitenumber, sitename),
+      # while the module's own output is always a simple lat,lon table.
+      latlon_only <- function(x) {
+        if (is.data.frame(x) && all(c("lat", "lon") %in% names(x)) && NROW(x) > 0) {
+          out <- data.frame(lat = as.numeric(x$lat), lon = as.numeric(x$lon))
+          out <- out[!is.na(out$lat) & !is.na(out$lon), , drop = FALSE]
+          rownames(out) <- NULL
+          out
+        } else {
+          data.frame(lat = numeric(0), lon = numeric(0))
+        }
+      }
 
       output$mymap <- leaflet::renderLeaflet({  # DRAW BASIC MAP
         # Use leaflet() here, and only include aspects of map that won't need to change dynamically
@@ -97,51 +124,56 @@ MODULE_SERVER_latlon_from_map_click <- function(id,
           )
       })
 
-      shiny::observe({   # WHEN CLICK ON MAP, GET LAT LON VALUE AND SHOW IT ON THE MAP
-
-        # Each kind of Incremental change to the map should be performed in its own observer.
-        leaflet::leafletProxy("mymap", session) %>% leaflet::clearMarkers()
-        # to remove just a specific one they click on, use its id # removeMarker("mycircle") # or input$mymap_marker_click$id
-        event <- input$mymap_click
-        if (is.null(event)) {return()}
-        shiny::isolate({
-
-          # UPDATE THE REACTIVE DATAFRAME WHEN POINT IS CLICKED
-          reactdat(data.frame(lat = input$lat, lon = input$lon))
-
-          # UPDATE THE MAP TO SHOW THE NEW POINT
-          leaflet::leafletProxy("mymap", session)  %>%
-            leaflet::addCircles(lng = input$mymap_click$lng, lat = input$mymap_click$lat,     # new point is drawn here when map is clicked
-                                radius = input$pointradius_input * meters_per_mile, fillOpacity = 0.1,
-                                highlightOptions = leaflet::highlightOptions(fillOpacity = 0.5), # this just makes it shaded when mouse hovers above the circle
-                                layerId = "mycircle"
-            ) %>%
-            leaflet::addPopups(lng = input$mymap_click$lng, lat = input$mymap_click$lat,
-                               # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
-                               popup = paste0("lat,lon: ", input$mymap_click$lat, ", ", input$mymap_click$lng))
-        })
+      shiny::observeEvent(input$mymap_click, {   # WHEN MAP IS CLICKED, APPEND THAT LAT,LON AS A NEW POINT
+        click <- input$mymap_click
+        if (is.null(click)) {return()}
+        # APPEND the clicked point to the accumulated table of points
+        # (leaflet sends the clicked location as $lat and $lng)
+        newpt <- data.frame(lat = click$lat, lon = click$lng)
+        reactdat(rbind(latlon_only(reactdat()), newpt))
       })
 
-      shiny::observe({   # WHEN RADIUS SLIDER MOVED, CHANGE RADIUS SHOWN ON MAP
-        shiny::req(input$mymap_click)
-        # Each kind of Incremental change to the map should be performed in its own observer.
-        leaflet::leafletProxy("mymap", session) %>% leaflet::clearMarkers()
-        event <- input$pointradius_input
-        if (is.null(event)) {return()}
-        shiny::isolate({
-          leaflet::leafletProxy("mymap", session)  %>%
-            leaflet::addCircles(lng = input$mymap_click$lng, lat = input$mymap_click$lat,
-                                radius = input$pointradius_input * meters_per_mile,   # radius changes here if slider is used
-                                fillOpacity = 0.1,
-                                layerId = "mycircle",
-                                highlightOptions = leaflet::highlightOptions(fillOpacity = 0.5, bringToFront = TRUE) ) %>%# this just makes it shaded when mouse hovers above the circle
-            leaflet::addPopups(lng = input$mymap_click$lng, lat = input$mymap_click$lat,
-                               # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
-                               popup = paste0("lat,lon: ", input$mymap_click$lat, ", ", input$mymap_click$lng))
-        })
+      shiny::observeEvent(input$undo_point, {    # REMOVE THE MOST RECENTLY ADDED POINT
+        cur <- latlon_only(reactdat())
+        if (NROW(cur) > 0) {
+          reactdat(cur[-NROW(cur), , drop = FALSE])
+        }
       })
 
-      # return a reactive data.frame of lat lon values for 1 point
+      shiny::observeEvent(input$clear_points, {  # REMOVE ALL POINTS
+        reactdat(data.frame(lat = numeric(0), lon = numeric(0)))
+      })
+
+      shiny::observe({   # REDRAW ALL POINTS WHENEVER THE POINTS OR THE RADIUS SLIDER CHANGE
+        df <- latlon_only(reactdat())
+        radius_miles <- input$pointradius_input
+        if (is.null(radius_miles)) {radius_miles <- 3}
+
+        # clear everything previously drawn, then redraw all current points.
+        # Note: circles are "shapes", center dots are "markers" - clear both (the old code only cleared markers, which never removed the circles).
+        proxy <- leaflet::leafletProxy("mymap", session) %>%
+          leaflet::clearShapes() %>%
+          leaflet::clearMarkers() %>%
+          leaflet::clearPopups()
+
+        if (NROW(df) > 0) {
+          labels <- paste0("Point ", seq_len(NROW(df)), ": ",
+                           # Note slight changes can occur in lat,lon values if using paste() instead of format() as per ?as.character()
+                           round(df$lat, 5), ", ", round(df$lon, 5))
+          proxy %>%
+            leaflet::addCircles(lng = df$lon, lat = df$lat,
+                                radius = radius_miles * meters_per_mile,   # radius in meters; changes when slider is used
+                                fillOpacity = 0.1, color = "#3388ff",
+                                highlightOptions = leaflet::highlightOptions(fillOpacity = 0.5, bringToFront = TRUE), # shaded when mouse hovers over the circle
+                                popup = labels, label = labels) %>%
+            leaflet::addCircleMarkers(lng = df$lon, lat = df$lat,    # a small visible dot at each clicked point's center
+                                radius = 4, color = "red", fillColor = "red",
+                                fillOpacity = 1, stroke = FALSE,
+                                popup = labels, label = labels)
+        }
+      })
+
+      # return the reactive data.frame of lat,lon values (one row per clicked point)
       return( reactdat ) # no parentheses here - return the reactive object not just its current value
     })
 }
@@ -193,9 +225,10 @@ if (try_this_module_here) {
       # h3("Example of a live map of results of module, drawn in the parent app"),
       # leaflet::leafletOutput( ('map_click_module'), height = '600px', width = '100%'),
 
-      h3("Example of a live view of the point (data) updated by the module, as seen in the parent app as a data.table"),
+      shiny::h3("Example of a live view of the points (data) updated by the module, as seen in the parent app as a data.table"),
+      shiny::verbatimTextOutput(outputId = "latlon_from_map_click_count_TEST"),
       DT::DTOutput(outputId =  "latlon_from_map_click_TEST" ),
-      br()
+      shiny::br()
     )}
   ################################################# #
 
@@ -203,8 +236,10 @@ if (try_this_module_here) {
 
   APP_SERVER_TEST <- function(input, output, session) {
 
-    init_data = testpoints_10[1,]
-    # Send  initial value, but the module updates that reactive_data1 as the user types
+    # Start with an empty lat,lon table so the table clearly fills in as the user clicks the map.
+    # (You could instead seed it with e.g. testpoints_10[1:2, ] - the module keeps only the lat,lon columns and appends to them.)
+    init_data <- data.frame(lat = numeric(0), lon = numeric(0))
+    # The module updates that reactive_data1 as the user clicks points on the map
     reactive_data1 <-  shiny::reactiveVal(init_data)
 
     ################################# #
@@ -217,6 +252,7 @@ if (try_this_module_here) {
     # to view actual table in rendered form to be ready to display it in app UI
     shiny::observe({
       tmp <- reactive_data1() # reactiveVal(out())  # WHEN THIS VALUE CHANGES, THE OUTER APP SHOULD UPDATE THE RENDERED TABLE
+      output$latlon_from_map_click_count_TEST <- shiny::renderText(paste0(NROW(tmp), " point(s) selected by clicking the map"))
       output$latlon_from_map_click_TEST <- DT::renderDT(DT::datatable(  tmp  ))
     })  # %>%  bindEvent(input$latlontypedin_submit_button_TEST)   # (when the "Done entering points" button is pressed? but that is inside the module)
 
@@ -252,6 +288,37 @@ if (try_this_module_here) {
 }
 ################################################ ################################################# #
 
+# *How to run automated tests on a module: ####
+# (does not need a browser - simulates clicks via session$setInputs)
+if (1 == 0) {
+  shiny::testServer(
+    app = MODULE_SERVER_latlon_from_map_click,
+    args = list(reactdat = shiny::reactiveVal(data.frame(lat = numeric(0), lon = numeric(0)))),
+    {
+      # no points yet
+      stopifnot(NROW(reactdat()) == 0)
+
+      # simulate a first map click -> one row appended
+      session$setInputs(mymap_click = list(lat = 40, lng = -99))
+      stopifnot(NROW(reactdat()) == 1)
+      stopifnot(reactdat()$lat == 40 && reactdat()$lon == -99)
+
+      # simulate a second map click -> two rows
+      session$setInputs(mymap_click = list(lat = 34.05, lng = -118.25))
+      stopifnot(NROW(reactdat()) == 2)
+
+      # undo removes the most recent point
+      session$setInputs(undo_point = 1)
+      stopifnot(NROW(reactdat()) == 1)
+
+      # clear removes all points
+      session$setInputs(clear_points = 1)
+      stopifnot(NROW(reactdat()) == 0)
+    }
+  )
+}
+################################################ ################################################# #
+
 
 ################################################ ################################################# #
 
@@ -262,11 +329,11 @@ if (try_this_module_here) {
 #   condition = "input.ss_choose_method == 'upload' && input.ss_choose_method_upload == 'latlon_from_map_click'",
 #   ### input: latlon_from_map_click
 #   ## _+++ MODULE_UI_latlon_from_map_click  ####
-#   tags$p("Click to specify latitude and longitude of point to analyze"),
+#   tags$p("Click on a map to specify the latitude and longitude of one or more points to analyze"),
 #   column(
 #     6,
-#     ## on button click, show modal with   lat lon value?
-#     actionButton(inputId = 'show_latlon_from_map_click_module_button', label = "Click to specify lat lon value", class = 'usa-button usa-button--outline'),
+#     ## on button click, show modal with the map and the accumulating lat lon values
+#     actionButton(inputId = 'show_latlon_from_map_click_module_button', label = "Click on a map to specify lat lon values", class = 'usa-button usa-button--outline'),
 #     shinyBS::bsModal(
 #       trigger = 'show_latlon_from_map_click_module_button',
 #       id = 'view_latlon_from_map_click',

--- a/R/MODULE_latlon_from_map_click.R
+++ b/R/MODULE_latlon_from_map_click.R
@@ -222,12 +222,18 @@ MODULE_SERVER_latlon_from_map_click <- function(id,
         shiny::observeEvent(add_source(), {
           click <- add_source()
           if (is.null(click)) {return()}
-          # skip the map click that coincides with a just-performed delete (marker) click
-          if (!is.null(last_remove_time) &&
-              as.numeric(difftime(Sys.time(), last_remove_time, units = "secs")) < 0.5) {
-            last_remove_time <<- NULL
-            return()
-          }
+          # Skip ONLY the map click that coincides with a just-performed delete (marker) click,
+          # i.e. the same interaction, so we don't delete-then-re-add a point. Two safeguards keep
+          # this from ever dropping a deliberate add:
+          #  - clear the guard on EVERY add evaluation (so it cannot persist to a later click - important
+          #    because leaflet vector-layer clicks often do NOT bubble to the map click, meaning no
+          #    coincident add ever arrives to consume the guard); and
+          #  - use a very tight window: a coincident click lands in the same reactive flush (~0 ms),
+          #    whereas any deliberate follow-up click is far slower than this.
+          coincident_with_delete <- !is.null(last_remove_time) &&
+            as.numeric(difftime(Sys.time(), last_remove_time, units = "secs")) < 0.1
+          last_remove_time <<- NULL
+          if (coincident_with_delete) {return()}
           add_point(click$lat, click$lng)                # leaflet sends clicked location as $lat and $lng
         }) # ignoreInit deliberately not set (see remove observer note above)
       }

--- a/R/MODULE_latlon_from_map_click.R
+++ b/R/MODULE_latlon_from_map_click.R
@@ -24,13 +24,29 @@
 ################################################ ################################################# #
 
 # *How to call a module from outer overall app ####
+#
+## (A) STANDALONE mode - the module draws its own map (good for testing on its own)
 ## copied to the UI
 # MODULE_UI_latlon_from_map_click("pts_entry_table2")
-
 ## copied to the server
 # testpoints_template <-  testpoints_5[1:2, ]
 # reactive_data1 <-  reactiveVal(testpoints_template)
 # MODULE_SERVER_latlon_from_map_click(id = "pts_entry_table2", reactdat = reactive_data1)
+#
+## (B) EMBEDDED mode - the OUTER app already owns the map (e.g. EJAM's an_leaf_map).
+##     The module is used only as a point accumulator: no UI is added, and the
+##     outer app passes its own map events in as reactives. render_map = FALSE.
+## copied to the server (no module UI needed - the app's existing map is reused):
+# mapclick_points <- reactiveVal(data.frame(lat = numeric(0), lon = numeric(0)))
+# MODULE_SERVER_latlon_from_map_click(
+#   id           = "mapclick",
+#   reactdat     = mapclick_points,
+#   add_click    = reactive(input$an_leaf_map_click),         # add a point where the user clicks the map
+#   remove_click = reactive(input$an_leaf_map_marker_click),  # remove the point the user clicks on
+#   clear        = reactive(input$mapclick_clear),            # a "Clear all points" button in the app
+#   render_map   = FALSE
+# )
+## then feed mapclick_points() into the app's data_uploaded() the same way uploaded lat/lon are handled.
 
 ################################################ ################################################# #
 
@@ -60,7 +76,7 @@ MODULE_UI_latlon_from_map_click <- function(id) {
     shiny::sliderInput(inputId = ns('pointradius_input'),
       'Point Radius (miles)', min = 1, max = 10, value = radiusdefault),
 
-    shiny::helpText("Click on the map to add one or more points. ",
+    shiny::helpText("Click on the map to add points. Click a point again to remove it. ",
                     "Move the slider to change the radius drawn around each point."),
 
     leaflet::leafletOutput(
@@ -84,10 +100,49 @@ MODULE_UI_latlon_from_map_click <- function(id) {
 
 #' MODULE_SERVER_latlon_from_map_click - latlon_from_map_click Server code
 #'
+#' @description
+#' Accumulates one or more lat,lon points the user selects, and returns them as a
+#' reactive data.frame (columns lat, lon). It runs in either of two modes:
+#'
+#' * **Standalone** (default, `render_map = TRUE`): the module renders its own
+#'   leaflet map (via `MODULE_UI_latlon_from_map_click()`) and uses its own map
+#'   click, marker click, "Undo last point" and "Clear all points" controls.
+#'   Good for testing the module by itself.
+#'
+#' * **Embedded in a larger app** (`render_map = FALSE`): the outer app already
+#'   owns a leaflet map, a radius slider, and the circle drawing. The module is
+#'   used only as a reusable *point accumulator* - the outer app passes its map
+#'   events in as reactives (`add_click`, `remove_click`, `clear`) and the module
+#'   just maintains `reactdat` (append on add, drop one on remove, empty on
+#'   clear). This is how the EJAM app can bind clicks on its existing
+#'   `an_leaf_map` to a points table without the module drawing a second map.
+#'
+#' @param id module id
+#' @param reactdat a reactiveVal holding the data.frame of points; the module
+#'   appends/removes rows. The output is always normalized to columns lat, lon.
+#' @param add_click optional reactive returning the latest "add a point" click as
+#'   a list with `$lat` and `$lng` (e.g. `reactive(input$an_leaf_map_click)`).
+#'   If NULL and `render_map = TRUE`, the module's own `input$mymap_click` is used.
+#' @param remove_click optional reactive returning the latest "remove this point"
+#'   click as a list carrying a layer `$id` (e.g.
+#'   `reactive(input$an_leaf_map_marker_click)`); `$id` is the 1-based row index
+#'   of the point to drop. If `$id` is absent but `$lat`/`$lng` are present, the
+#'   nearest point is removed. If NULL and `render_map = TRUE`, the module's own
+#'   `input$mymap_marker_click` is used.
+#' @param clear optional reactive/event that, when it fires, empties all points
+#'   (e.g. `reactive(input$mapclick_clear)`). If NULL and `render_map = TRUE`, the
+#'   module's own "Clear all points" button is used.
+#' @param render_map if TRUE (default) the module renders its own demo map, slider
+#'   and Undo/Clear buttons. Set FALSE when the outer app owns the map.
+#'
 #' @noRd
 #'
 MODULE_SERVER_latlon_from_map_click <- function(id,
-                                                reactdat,  # reactiveVal holding the data.frame of lat,lon points; the module appends a row to it for each map click
+                                                reactdat,     # reactiveVal holding the data.frame of lat,lon points
+                                                add_click    = NULL, # reactive() of the outer app's map click (list with $lat,$lng)
+                                                remove_click = NULL, # reactive() of the outer app's marker/shape click (list with $id)
+                                                clear        = NULL, # reactive()/event that empties all points
+                                                render_map   = TRUE, # FALSE when the outer app owns the map
                                                 ...) {
 
   # if instead of this being a param passed here, you were to initialize the reactive data.frame of lat,lon points that will be output of this function:
@@ -113,65 +168,127 @@ MODULE_SERVER_latlon_from_map_click <- function(id,
         }
       }
 
-      output$mymap <- leaflet::renderLeaflet({  # DRAW BASIC MAP
-        # Use leaflet() here, and only include aspects of map that won't need to change dynamically
-        # (at least, not unless the entire map is being torn down and recreated).
-        leaflet::leaflet() %>%
-          leaflet::setView(-99, 40, zoom = 4)  %>%
-          leaflet::addProviderTiles(
-            leaflet::providers$CartoDB.Positron,
-            options = leaflet::providerTileOptions(noWrap = TRUE)
-          )
-      })
-
-      shiny::observeEvent(input$mymap_click, {   # WHEN MAP IS CLICKED, APPEND THAT LAT,LON AS A NEW POINT
-        click <- input$mymap_click
-        if (is.null(click)) {return()}
-        # APPEND the clicked point to the accumulated table of points
-        # (leaflet sends the clicked location as $lat and $lng)
-        newpt <- data.frame(lat = click$lat, lon = click$lng)
-        reactdat(rbind(latlon_only(reactdat()), newpt))
-      })
-
-      shiny::observeEvent(input$undo_point, {    # REMOVE THE MOST RECENTLY ADDED POINT
+      # ---- accumulator operations (the reusable core, shared by both modes) ----
+      add_point <- function(lat, lon) {
+        if (length(lat) != 1 || length(lon) != 1) {return(invisible())}
+        if (is.na(suppressWarnings(as.numeric(lat))) || is.na(suppressWarnings(as.numeric(lon)))) {return(invisible())}
+        reactdat(rbind(latlon_only(reactdat()),
+                       data.frame(lat = as.numeric(lat), lon = as.numeric(lon))))
+      }
+      remove_point_by_index <- function(i) {        # i is a 1-based row index (e.g. a leaflet layerId)
         cur <- latlon_only(reactdat())
-        if (NROW(cur) > 0) {
-          reactdat(cur[-NROW(cur), , drop = FALSE])
+        i <- suppressWarnings(as.integer(i))
+        if (length(i) == 1 && !is.na(i) && i >= 1 && i <= NROW(cur)) {
+          reactdat(cur[-i, , drop = FALSE])
         }
-      })
+      }
+      remove_last <- function() {
+        cur <- latlon_only(reactdat())
+        if (NROW(cur) > 0) {reactdat(cur[-NROW(cur), , drop = FALSE])}
+      }
+      clear_all <- function() {reactdat(data.frame(lat = numeric(0), lon = numeric(0)))}
 
-      shiny::observeEvent(input$clear_points, {  # REMOVE ALL POINTS
-        reactdat(data.frame(lat = numeric(0), lon = numeric(0)))
-      })
+      # Guard so the map click that may coincide with a delete (marker) click does not re-add a point.
+      # Most leaflet vector-layer clicks do not bubble to the map's click event, but this is a defensive,
+      # order-independent, auto-expiring guard. Non-reactive on purpose - mutated with <<-.
+      last_remove_time <- NULL
 
-      shiny::observe({   # REDRAW ALL POINTS WHENEVER THE POINTS OR THE RADIUS SLIDER CHANGE
-        df <- latlon_only(reactdat())
-        radius_miles <- input$pointradius_input
-        if (is.null(radius_miles)) {radius_miles <- 3}
+      # ---- choose event sources for the two modes ----
+      add_source    <- if (!is.null(add_click))    {add_click}    else if (render_map) {shiny::reactive(input$mymap_click)}        else {NULL}
+      remove_source <- if (!is.null(remove_click)) {remove_click} else if (render_map) {shiny::reactive(input$mymap_marker_click)} else {NULL}
 
-        # clear everything previously drawn, then redraw all current points.
-        # Note: circles are "shapes", center dots are "markers" - clear both (the old code only cleared markers, which never removed the circles).
-        proxy <- leaflet::leafletProxy("mymap", session) %>%
-          leaflet::clearShapes() %>%
-          leaflet::clearMarkers() %>%
-          leaflet::clearPopups()
+      # REMOVE one point. Defined BEFORE the ADD observer so it runs first within a reactive flush.
+      if (!is.null(remove_source)) {
+        shiny::observeEvent(remove_source(), {
+          mc <- remove_source()
+          if (is.null(mc)) {return()}
+          last_remove_time <<- Sys.time()
+          if (!is.null(mc$id)) {
+            remove_point_by_index(mc$id)                 # leaflet layerId == 1-based row index
+          } else if (!is.null(mc$lat) && !is.null(mc$lng)) {
+            cur <- latlon_only(reactdat())               # no layerId: remove the nearest existing point
+            if (NROW(cur) > 0) {
+              d <- (cur$lat - mc$lat)^2 + (cur$lon - mc$lng)^2
+              remove_point_by_index(which.min(d))
+            }
+          }
+        # ignoreInit not set: the startup NULL is skipped by ignoreNULL (default TRUE);
+        # do NOT use ignoreInit = TRUE here - with a reactive() event source it would also swallow the first real click.
+        })
+      }
 
-        if (NROW(df) > 0) {
-          labels <- paste0("Point ", seq_len(NROW(df)), ": ",
-                           # Note slight changes can occur in lat,lon values if using paste() instead of format() as per ?as.character()
-                           round(df$lat, 5), ", ", round(df$lon, 5))
-          proxy %>%
-            leaflet::addCircles(lng = df$lon, lat = df$lat,
-                                radius = radius_miles * meters_per_mile,   # radius in meters; changes when slider is used
-                                fillOpacity = 0.1, color = "#3388ff",
-                                highlightOptions = leaflet::highlightOptions(fillOpacity = 0.5, bringToFront = TRUE), # shaded when mouse hovers over the circle
-                                popup = labels, label = labels) %>%
-            leaflet::addCircleMarkers(lng = df$lon, lat = df$lat,    # a small visible dot at each clicked point's center
-                                radius = 4, color = "red", fillColor = "red",
-                                fillOpacity = 1, stroke = FALSE,
-                                popup = labels, label = labels)
-        }
-      })
+      # ADD one point
+      if (!is.null(add_source)) {
+        shiny::observeEvent(add_source(), {
+          click <- add_source()
+          if (is.null(click)) {return()}
+          # skip the map click that coincides with a just-performed delete (marker) click
+          if (!is.null(last_remove_time) &&
+              as.numeric(difftime(Sys.time(), last_remove_time, units = "secs")) < 0.5) {
+            last_remove_time <<- NULL
+            return()
+          }
+          add_point(click$lat, click$lng)                # leaflet sends clicked location as $lat and $lng
+        }) # ignoreInit deliberately not set (see remove observer note above)
+      }
+
+      # CLEAR all points (outer app's clear event, if provided).
+      # An actionButton clear source starts at 0 (not NULL), so this may fire once at startup,
+      # which is harmless (clearing an already-empty set).
+      if (!is.null(clear)) {
+        shiny::observeEvent(clear(), {clear_all()})
+      }
+      # the module's own Undo/Clear buttons (standalone mode only)
+      if (render_map) {
+        shiny::observeEvent(input$clear_points, {clear_all()})
+        shiny::observeEvent(input$undo_point,  {remove_last()})
+      }
+
+      # ---- standalone demo map (only when the module owns the map) ----
+      if (render_map) {
+
+        output$mymap <- leaflet::renderLeaflet({  # DRAW BASIC MAP
+          # Use leaflet() here, and only include aspects of map that won't need to change dynamically
+          # (at least, not unless the entire map is being torn down and recreated).
+          leaflet::leaflet() %>%
+            leaflet::setView(-99, 40, zoom = 4)  %>%
+            leaflet::addProviderTiles(
+              leaflet::providers$CartoDB.Positron,
+              options = leaflet::providerTileOptions(noWrap = TRUE)
+            )
+        })
+
+        shiny::observe({   # REDRAW ALL POINTS WHENEVER THE POINTS OR THE RADIUS SLIDER CHANGE
+          df <- latlon_only(reactdat())
+          radius_miles <- input$pointradius_input
+          if (is.null(radius_miles)) {radius_miles <- 3}
+
+          # clear everything previously drawn, then redraw all current points.
+          # Note: circles are "shapes", center dots are "markers" - clear both (the old code only cleared markers, which never removed the circles).
+          proxy <- leaflet::leafletProxy("mymap", session) %>%
+            leaflet::clearShapes() %>%
+            leaflet::clearMarkers() %>%
+            leaflet::clearPopups()
+
+          if (NROW(df) > 0) {
+            ids <- as.character(seq_len(NROW(df)))       # layerId == row index, so clicking a dot removes that point
+            labels <- paste0("Point ", seq_len(NROW(df)), ": ",
+                             # Note slight changes can occur in lat,lon values if using paste() instead of format() as per ?as.character()
+                             round(df$lat, 5), ", ", round(df$lon, 5))
+            proxy %>%
+              leaflet::addCircles(lng = df$lon, lat = df$lat,
+                                  radius = radius_miles * meters_per_mile,   # radius in meters; changes when slider is used
+                                  fillOpacity = 0.1, color = "#3388ff",
+                                  highlightOptions = leaflet::highlightOptions(fillOpacity = 0.5, bringToFront = TRUE), # shaded when mouse hovers over the circle
+                                  popup = labels, label = labels) %>%
+              leaflet::addCircleMarkers(lng = df$lon, lat = df$lat,    # a small visible dot at each clicked point's center
+                                  layerId = ids,        # clicking a dot fires input$mymap_marker_click with $id = this index
+                                  radius = 4, color = "red", fillColor = "red",
+                                  fillOpacity = 1, stroke = FALSE,
+                                  popup = labels, label = labels)
+          }
+        })
+      }
 
       # return the reactive data.frame of lat,lon values (one row per clicked point)
       return( reactdat ) # no parentheses here - return the reactive object not just its current value
@@ -290,6 +407,8 @@ if (try_this_module_here) {
 
 # *How to run automated tests on a module: ####
 # (does not need a browser - simulates clicks via session$setInputs)
+
+## (A) STANDALONE mode - the module owns the map; clicks arrive on input$mymap_*
 if (1 == 0) {
   shiny::testServer(
     app = MODULE_SERVER_latlon_from_map_click,
@@ -307,12 +426,46 @@ if (1 == 0) {
       session$setInputs(mymap_click = list(lat = 34.05, lng = -118.25))
       stopifnot(NROW(reactdat()) == 2)
 
-      # undo removes the most recent point
+      # undo removes the most recent point (does not engage the delete-click guard)
       session$setInputs(undo_point = 1)
       stopifnot(NROW(reactdat()) == 1)
+      stopifnot(reactdat()$lat == 40)
+
+      # add it back, then click an existing point (marker) to remove just that one (layerId == row index)
+      session$setInputs(mymap_click = list(lat = 34.05, lng = -118.25))
+      stopifnot(NROW(reactdat()) == 2)
+      session$setInputs(mymap_marker_click = list(id = "1", lat = 40, lng = -99))
+      stopifnot(NROW(reactdat()) == 1)
+      stopifnot(reactdat()$lat == 34.05)
 
       # clear removes all points
       session$setInputs(clear_points = 1)
+      stopifnot(NROW(reactdat()) == 0)
+    }
+  )
+}
+
+## (B) EMBEDDED mode - the outer app owns the map; events arrive via reactives.
+##     render_map = FALSE, and add_click / remove_click / clear are reactiveVals we drive.
+if (1 == 0) {
+  rd <- shiny::reactiveVal(data.frame(lat = numeric(0), lon = numeric(0)))
+  ac <- shiny::reactiveVal(NULL) # stands in for reactive(input$an_leaf_map_click)
+  rc <- shiny::reactiveVal(NULL) # stands in for reactive(input$an_leaf_map_marker_click)
+  cl <- shiny::reactiveVal(NULL) # stands in for reactive(input$mapclick_clear)
+  shiny::testServer(
+    app = MODULE_SERVER_latlon_from_map_click,
+    args = list(reactdat = rd, add_click = ac, remove_click = rc, clear = cl, render_map = FALSE),
+    {
+      stopifnot(NROW(reactdat()) == 0)
+
+      ac(list(lat = 40,    lng = -99));     session$flushReact()
+      ac(list(lat = 34.05, lng = -118.25)); session$flushReact()
+      stopifnot(NROW(reactdat()) == 2)
+
+      rc(list(id = "1", lat = 40, lng = -99)); session$flushReact() # remove the first point
+      stopifnot(NROW(reactdat()) == 1 && reactdat()$lat == 34.05)
+
+      cl(1); session$flushReact()  # clear all
       stopifnot(NROW(reactdat()) == 0)
     }
   )

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -2668,7 +2668,7 @@ app_server <- function(input, output, session) {
   output$download_report_multisite <- downloadHandler(
     filename = function() {
       html_path <- downloadable_file_report_multisite()
-      if (isTRUE(input$format_report_multisite %in% "pdf")) {
+      if (isTRUE(input$fileextension %in% "pdf")) { # had been input$format_report_multisite
         sub("\\.html$", ".pdf", basename(html_path))
       } else {
         basename(html_path)
@@ -2683,7 +2683,7 @@ app_server <- function(input, output, session) {
         # stop(msg, call. = FALSE)
       }
 
-      if (isTRUE(input$format_report_multisite %in% "pdf")) {
+      if (isTRUE(input$fileextension %in% "pdf")) { # had been input$format_report_multisite
         # pdf format was requested
         tryCatch({
           assert_pdf_report_available() # stop() if pagedown/Chrome unavailable
@@ -2740,7 +2740,7 @@ app_server <- function(input, output, session) {
         buffer_dist = submitted_radius_val(),
         site_method = submitted_upload_method(),
         with_datetime = TRUE,
-        ext = ifelse(input$format1pager %in% 'pdf', '.pdf', '.html')
+        ext = ifelse(input$fileextension %in% 'pdf', '.pdf', '.html') # had been input$format_report_multisite
       )
     },
     content = function(file) {
@@ -2763,7 +2763,7 @@ app_server <- function(input, output, session) {
   # (1 button per site in the table of sites, to see report or barplot for that site)
   #
   # NOTE: This code was written but is not used if the app obtains these reports via API.
-  # Rendering here is probably faster and supports more parameters / features than API,
+  # Rendering here is probably faster and supports more parameters / features than API, & would be especially useful for large multipolygon shapefiles,
   # while using the API for 1-site reports in the app is simpler.
 
   cur_button <- reactiveVal(NULL)
@@ -2788,7 +2788,7 @@ app_server <- function(input, output, session) {
         selected_location_name(location_name)
 
         # Store a temporary file name/path in the reactive value
-        fileextension <- ifelse(input$format1pager %in% 'pdf', '.pdf', '.html')
+        fileextension <- ifelse(input$fileextension %in% 'pdf', '.pdf', '.html') # had been input$format_report_multisite
         temp_file <- tempfile(fileext = fileextension)
 
          # if shapefile was used for analysis, provide it to ejam2report()

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -265,6 +265,20 @@ app_server <- function(input, output, session) {
                        selected = level_of_detail_based_on_default_naics
     )
   })
+  observeEvent(input$default_format1pager, {
+    selected_format <- input$default_format1pager
+    if (!isTRUE(selected_format %in% c("html", "pdf"))) {
+      selected_format <- global_or_param("default_format1pager")
+    }
+    if (!isTRUE(selected_format %in% c("html", "pdf"))) {
+      selected_format <- "html"
+    }
+    shiny::updateRadioButtons(
+      session = session,
+      inputId = "fileextension",
+      selected = selected_format
+    )
+  })
 
   # update ss_select_NAICS input options (since using server side and it starts as NULL to load faster) ###
   observeEvent(eventExpr = {

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -266,9 +266,14 @@ app_server <- function(input, output, session) {
     )
   })
   observeEvent(input$default_format1pager, {
-    selected_format <- input$default_format1pager
+    ## normalize like ejam2report() does (strip a leading dot, lowercase) so a user-supplied or
+    ## mis-set ".pdf"/"PDF"/".html" still matches the "html"/"pdf" radio values instead of being
+    ## silently rejected and falling back to HTML. as.character(NULL) -> character(0), which is
+    ## handled by isTRUE(... %in% ...) == FALSE, so NULL/missing safely fall through to "html".
+    norm_format1pager <- function(x) sub("^[.]", "", tolower(as.character(x)))
+    selected_format <- norm_format1pager(input$default_format1pager)
     if (!isTRUE(selected_format %in% c("html", "pdf"))) {
-      selected_format <- global_or_param("default_format1pager")
+      selected_format <- norm_format1pager(global_or_param("default_format1pager"))
     }
     if (!isTRUE(selected_format %in% c("html", "pdf"))) {
       selected_format <- "html"

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -552,10 +552,11 @@ app_ui <- function(request) {
                                ###              > DOWNLOAD BUTTON    ####
                                tags$div(
                                  radioButtons(
-                                   inputId = "format_report_multisite",
+                                   inputId = "fileextension", # had been called format_report_multisite, # see format1pager and fileextension
                                    label   = "Download format:",
                                    choices = c("HTML" = "html", "PDF" = "pdf"),
-                                   selected = "html",
+                                   # html format has live interactive maps with popups and links, but pdf has better pagination for printing.
+                                   selected = input$default_format1pager, # based on advanced tab, which is based on global_or_param("default_format1pager"),
                                    inline   = TRUE
                                  ),
                                  downloadButton('download_report_multisite', label = 'Download Multisite Summary Report', class = 'usa-button'), style = 'text-align: center;'
@@ -1302,9 +1303,11 @@ app_ui <- function(request) {
                                      selected = global_or_param("default_plotkind_1pager")),
 
                  ## _radio button on format of short report
-                 #                  was DISABLED while PDF KNITTING DEBUGGED
-                 radioButtons(inputId = "format1pager", "Format",
+                 # sets filename and fileextension parameter in ejam2report()
+                 h3("Short report title and format - html provides live interactive map with popups and links, but pdf has better pagination for printing."),
+                 shiny::radioButtons(inputId = "default_format1pager", "Format",
                               choices = c(html = "html", pdf = "pdf"),
+                              selected = global_or_param("default_format1pager"),
                               inline = TRUE),
 
                  textInput(inputId = "Custom_title_for_bar_plot_of_indicators", label = "Enter title for barplot of indicators", value = gsub("[^a-zA-Z0-9 ]", "", "") ),

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -556,7 +556,8 @@ app_ui <- function(request) {
                                    label   = "Download format:",
                                    choices = c("HTML" = "html", "PDF" = "pdf"),
                                    # html format has live interactive maps with popups and links, but pdf has better pagination for printing.
-                                   selected = global_or_param("default_format1pager"), # kept in sync with advanced tab via updateRadioButtons() in server
+                                   # normalize (strip leading dot, lowercase) so e.g. ".pdf"/"PDF" still matches "pdf" (mirrors ejam2report())
+                                   selected = sub("^[.]", "", tolower(as.character(global_or_param("default_format1pager")))), # kept in sync with advanced tab via updateRadioButtons() in server
                                    inline   = TRUE
                                  ),
                                  downloadButton('download_report_multisite', label = 'Download Multisite Summary Report', class = 'usa-button'), style = 'text-align: center;'
@@ -1307,7 +1308,8 @@ app_ui <- function(request) {
                  h3("Short report title and format - html provides live interactive map with popups and links, but pdf has better pagination for printing."),
                  shiny::radioButtons(inputId = "default_format1pager", "Format",
                               choices = c(html = "html", pdf = "pdf"),
-                              selected = global_or_param("default_format1pager"),
+                              # normalize (strip leading dot, lowercase) so e.g. ".pdf"/"PDF" still matches "pdf" (mirrors ejam2report())
+                              selected = sub("^[.]", "", tolower(as.character(global_or_param("default_format1pager")))),
                               inline = TRUE),
 
                  textInput(inputId = "Custom_title_for_bar_plot_of_indicators", label = "Enter title for barplot of indicators", value = gsub("[^a-zA-Z0-9 ]", "", "") ),

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -556,7 +556,7 @@ app_ui <- function(request) {
                                    label   = "Download format:",
                                    choices = c("HTML" = "html", "PDF" = "pdf"),
                                    # html format has live interactive maps with popups and links, but pdf has better pagination for printing.
-                                   selected = input$default_format1pager, # based on advanced tab, which is based on global_or_param("default_format1pager"),
+                                   selected = global_or_param("default_format1pager"), # kept in sync with advanced tab via updateRadioButtons() in server
                                    inline   = TRUE
                                  ),
                                  downloadButton('download_report_multisite', label = 'Download Multisite Summary Report', class = 'usa-button'), style = 'text-align: center;'

--- a/R/ejam2report.R
+++ b/R/ejam2report.R
@@ -389,6 +389,7 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
     if (!(fileextension %in% fileextensions_implemented)) {
       warning("fileextension must be one of", fileextensions_implemented)
       fileextension <- global_or_param("default_format1pager")  #".html"
+      fileextension <- paste0(".", gsub("^\\.", "", fileextension))
       if (!(fileextension %in% fileextensions_implemented)) {
         fileextension <- ".html" # fallback if problem with global
       }

--- a/R/ejam2report.R
+++ b/R/ejam2report.R
@@ -388,7 +388,10 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
     fileextensions_implemented <- c(".html", ".pdf")
     if (!(fileextension %in% fileextensions_implemented)) {
       warning("fileextension must be one of", fileextensions_implemented)
-      fileextension <- ".html"
+      fileextension <- global_or_param("default_format1pager")  #".html"
+      if (!(fileextension %in% fileextensions_implemented)) {
+        fileextension <- ".html" # fallback if problem with global
+      }
     }
 
     ## > filename ####
@@ -405,7 +408,7 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
         buffer_dist = rad,
         site_method = site_method, # can be latlon, shp, SHP, fips, FIPS, MACT, etc. (just used as-is in filename)
         with_datetime = FALSE,
-        ext = fileextension # in server,  ifelse(input$format1pager == 'pdf', '.pdf', '.html')
+        ext = fileextension
       )
       temp_comm_report <- file.path(tempdir(), filename)
     } else {

--- a/R/ejam2report.R
+++ b/R/ejam2report.R
@@ -388,10 +388,18 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
     fileextensions_implemented <- c(".html", ".pdf")
     if (!(fileextension %in% fileextensions_implemented)) {
       warning("fileextension must be one of", fileextensions_implemented)
-      fileextension <- global_or_param("default_format1pager")  #".html"
-      fileextension <- paste0(".", gsub("^\\.", "", fileextension))
-      if (!(fileextension %in% fileextensions_implemented)) {
-        fileextension <- ".html" # fallback if problem with global
+      ## Fall back to the global default. global_or_param("default_format1pager") can be NULL
+      ## (e.g. when EJAM is used via :: without attaching, so .onAttach() never built the package
+      ## defaults), so guard against NULL/empty before normalizing - otherwise gsub()/`%in%` operate
+      ## on a length-0 value and the `if` below errors ("argument is of length zero").
+      gdef <- global_or_param("default_format1pager")  # normally "html"/"pdf"; could be ".pdf", "PDF", or NULL
+      if (length(gdef) == 0 || is.na(gdef[1]) || !nzchar(gdef[1])) {
+        fileextension <- ".html" # fallback if global default is missing/blank
+      } else {
+        fileextension <- paste0(".", gsub("^\\.", "", tolower(gdef[1])))
+        if (!(fileextension %in% fileextensions_implemented)) {
+          fileextension <- ".html" # fallback if problem with global
+        }
       }
     }
 

--- a/data-raw/mapclick_integration_plan.md
+++ b/data-raw/mapclick_integration_plan.md
@@ -1,5 +1,31 @@
 # Plan: "Click on map" point selection in the EJAM app
 
+> ## ⚠️ IMPORTANT RELATED WORK — read first: EJScreen already does map-click point selection
+>
+> **The EJScreen app already provides a way for a user to click on a map and specify
+> points for analysis one at a time.** It is also gaining a way to **add those clicked
+> points to a running list of points** and then **run a multisite analysis straight from
+> the EJScreen UI** — by calling the EJAM analysis engine over the **API** (and/or handing
+> the accumulated sites off to the EJAM app to pre-load).
+>
+> That EJScreen-side capability is being implemented across **three coordinated PRs**
+> (all on the `ejscreen-multisite-selection` branch in their repos):
+>
+> | Repo | PR | What it does |
+> |------|----|--------------|
+> | **EJScreen** | [#66](https://github.com/Public-Environmental-Data-Partners/EJScreen/pull/66) | UI: accumulate clicked places into a list → "Multisite Report" + "Send to EJAM" |
+> | **EJAM-API** | [#36](https://github.com/Public-Environmental-Data-Partners/EJAM-API/pull/36) | Multisite `GET /report`, token handoff, and CORS |
+> | **EJAM** | [#413](https://github.com/Public-Environmental-Data-Partners/EJAM/pull/413) | Launch-URL site handoff to pre-load EJAM from EJScreen (the "edits in EJAM repo") |
+>
+> **Why this matters for THIS plan:** the feature described below is a *different,
+> complementary* capability — clicking points **natively inside the EJAM Shiny app itself**
+> (on EJAM's own `an_leaf_map`), independent of EJScreen and the API. Before/while
+> implementing the EJAM-native version, reconcile it with the EJScreen path so the two are
+> consistent (same notion of a "running list of points", similar UX, no duplicated/ conflicting
+> handoff logic). In particular, EJAM #413's launch-URL handoff is how externally-selected
+> points (e.g. from EJScreen) already arrive in EJAM, and should interoperate with the
+> in-app `mapclick` method proposed here.
+
 Status: **Phase 1 (module refactor) DONE; Phases 2-7 (app wiring) NOT yet implemented** (2026-06-26)
 Branch where the work lives: `fix-latlon-from-map-click-module`
 Module file: `R/MODULE_latlon_from_map_click.R`

--- a/data-raw/mapclick_integration_plan.md
+++ b/data-raw/mapclick_integration_plan.md
@@ -1,7 +1,7 @@
 # Plan: "Click on map" point selection in the EJAM app
 
-Status: **designed, NOT yet implemented** (2026-06-26)
-Branch where the module fix lives: `fix-latlon-from-map-click-module`
+Status: **Phase 1 (module refactor) DONE; Phases 2-7 (app wiring) NOT yet implemented** (2026-06-26)
+Branch where the work lives: `fix-latlon-from-map-click-module`
 Module file: `R/MODULE_latlon_from_map_click.R`
 
 ## Goal
@@ -229,10 +229,15 @@ they key off `data_uploaded()` and `current_upload_method()` — `R/app_server.R
 
 ## Implementation phases / task breakdown
 
-1. **Refactor module** (`R/MODULE_latlon_from_map_click.R`): add `add_click`,
-   `remove_click`, `clear`, `render_map` params; keep standalone demo + `testServer`
-   passing; add `testServer` cases for external-wiring mode (simulate `add_click`,
-   `remove_click`, `clear` reactives).
+1. **Refactor module** (`R/MODULE_latlon_from_map_click.R`) — **DONE (2026-06-26)**:
+   added `add_click`, `remove_click`, `clear`, `render_map` params; extracted the
+   reusable accumulator core (`add_point` / `remove_point_by_index` / `remove_last`
+   / `clear_all`); standalone demo + `testServer` still pass; added `testServer`
+   cases for the embedded/external-wiring mode. Implemented the add-vs-delete guard
+   (`last_remove_time`) so a map click coinciding with a marker-delete click does not
+   re-add. **Gotcha recorded:** `observeEvent(reactive(input$x)(), ignoreInit = TRUE)`
+   swallows the first real event — use the default `ignoreNULL = TRUE` to skip the
+   startup NULL instead of `ignoreInit = TRUE` for the reactive-wrapped sources.
 2. **Globals/UI**: add `'Click or draw on map' = 'mapclick'` to the `ss_choose_method`
    radio (`R/app_ui.R:114`); add the `mapclick` `conditionalPanel` (Clear button, help
    text, count/alert). Decide whether `mapclick` appears for both public and internal

--- a/data-raw/mapclick_integration_plan.md
+++ b/data-raw/mapclick_integration_plan.md
@@ -1,0 +1,283 @@
+# Plan: "Click on map" point selection in the EJAM app
+
+Status: **designed, NOT yet implemented** (2026-06-26)
+Branch where the module fix lives: `fix-latlon-from-map-click-module`
+Module file: `R/MODULE_latlon_from_map_click.R`
+
+## Goal
+
+Add a third way to specify sites in the EJAM Shiny app (`ejamapp()`): let the user
+**click on the existing main-tab map to drop one or more points**, as an alternative to
+the current "Select a category of locations" (dropdown) and "Upload specific locations"
+(upload) options. Clicked points must be handled by the server exactly like uploaded
+lat/lon points so that the radius slider, the map circles, "Review selected sites",
+running the analysis, and downloads all work with no special-casing downstream.
+
+## Decisions locked in (from review with user, 2026-06-26)
+
+1. **Scope of "Click or draw on map":** Phase 1 is **click-to-add points only**.
+   Free-draw / lasso polygons are a **future phase** (would build on `R/MODULE_lasso.R`
+   + `leaflet.extras` draw toolbar and feed the existing `SHP` path). Not in this plan's
+   implementation scope, but the UI label ("Click or draw on map") and routing are chosen
+   so drawing can be added later without renaming things.
+2. **Module reuse:** **Refactor** `MODULE_SERVER_latlon_from_map_click` into a
+   **map-agnostic "points accumulator"** that binds to the app's *existing* `an_leaf_map`
+   click events. The module will **not** render the map in the app (the app already does).
+   The self-contained standalone demo + `testServer` test in the module file stay working.
+3. **Delete a point:** user **clicks an existing point on the map to remove just that one**,
+   plus a **Clear all points** button. (Undo-last and the click-to-delete share the same
+   accumulator API, so undo can also remain available.)
+
+## How the EJAM app handles sites today (reference, with anchors)
+
+- **Top-level method radio** `ss_choose_method` — values `dropdown` / `upload`
+  — `R/app_ui.R:114`.
+- **Upload sub-type** `ss_choose_method_upload` (latlon, FRS, SHP, FIPS, EPA_PROGRAM)
+  — `R/app_ui.R:141`; choices defined in
+  `inst/global_defaults_shiny_public.R:118` (`default_choices_for_type_of_site_upload`).
+- **Method router** `current_upload_method()` — `switch()` over the two radios
+  — `R/app_server.R:349`. Returns e.g. `"latlon"`, `"FRS"`, `"SHP"`, ...
+- **Central data reactive** `data_uploaded()` — `switch()` on `current_upload_method()`,
+  returns the per-method reactive — `R/app_server.R:1295`. For latlon it returns
+  `data_up_latlon()`.
+- **latlon ingest** `data_up_latlon()` — `R/app_server.R:627`. Produces a `data.table`
+  with `ejam_uniq_id`, `lat`, `lon`, `valid`, `invalid_msg` (via `latlon_df_clean()`),
+  sets `disable_buttons[['latlon']] <- FALSE` and `invalid_alert[['latlon']]`.
+  **This is the output shape every downstream consumer expects.**
+- **Base map** `orig_leaf_map()` (`R/app_server.R:1646`) → rendered by
+  `output$an_leaf_map` (`R/app_server.R:1791`). For latlon it builds a leaflet map and
+  `fitBounds`/`setView` to the uploaded points. Reacts to `data_uploaded()` — so it
+  currently **re-creates the map (and re-zooms) whenever the points change.**
+- **Circle drawing** — a separate `observe()` using
+  `leafletProxy("an_leaf_map") %>% map_facilities_proxy(rad = sanitized_radius_now(), ...)`
+  — `R/app_server.R:2357` (latlon branch ~`R/app_server.R:2392`). **Already reacts to the
+  radius slider**, so the radius requirement is satisfied for free once clicks feed
+  `data_uploaded()`.
+- **Radius slider** `input$radius_now` → `sanitized_radius_now()` (`R/app_server.R:46`);
+  per-method memory in `current_slider_val` / `current_slider_min`
+  (`R/app_server.R:1563`, `1576`); restored on method change at `R/app_server.R:1625`.
+- **"Review selected sites"** button `show_data_preview` → modal with DT
+  `print_test2_dt` (`R/app_server.R:378`), driven by `data_preview()` (`R/app_server.R:1460`)
+  which reads `data_uploaded()`. **Auto-updates** when clicks change `data_uploaded()`;
+  re-opening the modal shows the latest list. Downloads (`download_sites_before_analysis_*`)
+  also read `data_preview()`.
+- **Per-method reactiveValues that must gain a `mapclick` key:** `disable_buttons`
+  (`R/app_server.R:1318`), `invalid_alert` (`R/app_server.R:393`), `an_map_text_pts`
+  (`R/app_server.R:1406`), `current_slider_min` (`R/app_server.R:1563`),
+  `current_slider_val` (`R/app_server.R:1576`), and the radius-default seeding loop
+  `these <- c('latlon', ...)` (`R/app_server.R:1602`).
+
+**Key consequence:** because the map circles, the preview table, the run button, and the
+downloads all read `data_uploaded()`, the entire integration reduces to: *make
+`data_uploaded()` return the clicked points when the method is `mapclick`.* Everything
+else follows.
+
+## Target design
+
+### New method value: `mapclick`
+
+- Add a third `ss_choose_method` radio choice: name **"Click or draw on map"**,
+  value **`mapclick`** (`R/app_user.R` radio at `R/app_ui.R:114`). No sub-`selectInput`
+  needed (unlike `dropdown`/`upload`), so the routing in `current_upload_method()` gets a
+  top-level branch returning `"mapclick"` rather than going through a sub-switch.
+- A `conditionalPanel(condition = "input.ss_choose_method == 'mapclick'")` in the
+  left control column holds the **Clear all points** button, a short help line
+  ("Click the map to add a point; click a point again to remove it"), and the live
+  count / invalid-site alert (reuse `an_map_text_pts` / `invalid_sites_alert2`).
+
+### Reactive data flow
+
+```
+input$an_leaf_map_click ──► (accumulator) ──► mapclick_points  (reactiveVal: lat, lon)
+input$an_leaf_map_marker_click ──► (accumulator removes that point)
+input$mapclick_clear ──► (accumulator empties mapclick_points)
+                                    │
+                       data_up_mapclick()  (clean to ejam_uniq_id/lat/lon/valid/invalid_msg,
+                                    │        set disable_buttons[['mapclick']], invalid_alert)
+                                    ▼
+                       data_uploaded()  (switch: method=='mapclick' -> data_up_mapclick())
+                                    │
+        ┌───────────────────────────┼───────────────────────────┐
+        ▼                           ▼                           ▼
+ orig_leaf_map()/proxy       data_preview()/print_test2_dt   bt_get_results (run ejamit)
+ (circles + radius)          ("Review selected sites")        + downloads
+```
+
+### Module refactor (the reusable accumulator)
+
+Refactor `R/MODULE_latlon_from_map_click.R` so the point-accumulation logic is separated
+from the demo map. Concretely:
+
+- **Keep** `MODULE_UI_latlon_from_map_click()` and the standalone demo app + `testServer`
+  block (these render their own `mymap` and are used for isolated testing — do not break).
+- **Generalize** `MODULE_SERVER_latlon_from_map_click(id, reactdat, ...)` to accept
+  optional external wiring so it works in two modes:
+  - `add_click`   — a `reactive()` returning the latest map click as `list(lat=, lng=)`
+                    or `NULL` (in the app: `reactive(input$an_leaf_map_click)`).
+  - `remove_click`— a `reactive()` returning the latest marker/shape click (which carries
+                    a layer `id`) to delete one point (in the app:
+                    `reactive(input$an_leaf_map_marker_click)`).
+  - `clear`       — a `reactive()` / event to empty all points (in the app:
+                    `reactive(input$mapclick_clear)`).
+  - `render_map`  — `TRUE` for standalone (module draws `mymap` + slider + redraws),
+                    `FALSE` for the app (app owns `an_leaf_map`, slider, and circle proxy).
+  - When the external `add_click`/`clear` args are supplied, the module observes **those**
+    instead of its own `input$mymap_click` / `input$clear_points`, and (with
+    `render_map = FALSE`) skips `output$mymap`, the slider, and the redraw observer.
+  - The accumulator's core (already present and tested): append `data.frame(lat, lon)` to
+    `reactdat` on add; drop the matching row on remove; reset on clear; `latlon_only()`
+    normalization. **This logic is what the app reuses.**
+- The module continues to **return `reactdat`** (the reactive points table), matching the
+  `MODULE_latlontypedin` contract.
+
+App usage (in `app_server.R`):
+
+```r
+mapclick_points <- reactiveVal(data.frame(lat = numeric(0), lon = numeric(0)))
+MODULE_SERVER_latlon_from_map_click(
+  id          = "mapclick",
+  reactdat    = mapclick_points,
+  add_click   = reactive(input$an_leaf_map_click),
+  remove_click= reactive(input$an_leaf_map_marker_click),
+  clear       = reactive(input$mapclick_clear),
+  render_map  = FALSE
+)
+```
+
+> Alternative considered: re-implement the ~10 lines of accumulator logic inline in
+> `app_server.R` and keep the module purely as a standalone demo. Rejected per decision #2
+> (user wants the module reused), and the refactor keeps a single source of truth for the
+> add/remove/clear behavior.
+
+### `data_up_mapclick()` — make clicks look like an upload
+
+New reactive mirroring `data_up_latlon()` (`R/app_server.R:627`) but sourcing rows from
+`mapclick_points()` instead of a file:
+
+```r
+data_up_mapclick <- reactive({
+  pts <- mapclick_points()
+  if (is.null(pts) || NROW(pts) == 0) {
+    disable_buttons[['mapclick']] <- TRUE
+    an_map_text_pts[['mapclick']] <- NULL
+    return(NULL)            # data_uploaded() -> NULL, map shows empty base map
+  }
+  sitepoints <- data.table::as.data.table(pts)
+  sitepoints[, ejam_uniq_id := .I]
+  data.table::setcolorder(sitepoints, 'ejam_uniq_id')
+  sitepoints <- latlon_df_clean(sitepoints, invalid_msg_table = TRUE)
+  sitepoints$invalid_msg <- NA
+  sitepoints$invalid_msg[is.na(sitepoints$lon) | is.na(sitepoints$lat)] <- 'bad lat/lon coordinates'
+  disable_buttons[['mapclick']] <- FALSE
+  invalid_alert[['mapclick']]   <- sum(!sitepoints$valid)
+  sitepoints
+})
+```
+
+Then add the branch to `data_uploaded()` (`R/app_server.R:1299`):
+
+```r
+} else if (current_upload_method() == 'mapclick') { data_up_mapclick()
+```
+
+and the top-level branch in `current_upload_method()` (`R/app_server.R:349`):
+
+```r
+'mapclick' = 'mapclick',
+```
+
+(`max_pts_upload` / `max_pts_run` caps are enforced by the same observers as uploads since
+they key off `data_uploaded()` and `current_upload_method()` — `R/app_server.R:1366`.)
+
+## Edge cases & UX details to get right
+
+1. **Add vs. delete disambiguation.** Clicking a marker fires *both*
+   `an_leaf_map_marker_click` and `an_leaf_map_click`. To avoid "delete then immediately
+   re-add", the accumulator must ignore the map click that coincides with a marker click
+   (same reactive flush). Implementation: when `remove_click` fires, stamp a guard token;
+   the `add_click` handler checks the guard and the click coordinates and skips if it
+   matches the just-removed marker. (Assign each circle/marker `layerId = ejam_uniq_id` so
+   `marker_click$id` identifies the row to drop.) **This is the trickiest part — call it
+   out in the task and cover it in tests.**
+2. **Base map must not re-zoom on every click.** `orig_leaf_map()` currently depends on
+   `data_uploaded()` and re-fits bounds. For `mapclick`, build the base map **once**
+   (depend only on `current_upload_method() == 'mapclick'`, `isolate()` any initial view —
+   e.g., a US-wide `setView`, or center on existing points the first time only) so adding
+   a point doesn't yank the viewport. The existing circle-drawing `leafletProxy` observer
+   (`R/app_server.R:2357`, latlon branch) then updates circles incrementally — it already
+   reacts to `data_uploaded()` + `sanitized_radius_now()` and uses `clearShapes()` first,
+   so it handles add/remove/clear correctly with no change beyond ensuring `mapclick`
+   takes the latlon branch (it will, since it is not SHP/FIPS).
+3. **Clear removes prior points (incl. a previous upload).** "Clear all points" empties
+   `mapclick_points()`. Because `data_uploaded()` for `mapclick` returns only
+   `data_up_mapclick()`, switching to `mapclick` already hides any prior `upload` data;
+   Clear then resets the click set to empty. (Switching methods does not delete the other
+   method's stored reactive — that matches today's behavior where each method keeps its own
+   inputs.)
+4. **Radius slider.** No new work: `mapclick` flows through the latlon circle proxy which
+   uses `sanitized_radius_now()`. Just add `mapclick` to `current_slider_val`,
+   `current_slider_min`, and the `radius_default` seeding loop so the slider initializes
+   and is enabled (not disabled like FIPS/SHP).
+5. **Run button / preview gating.** `disable_buttons[['mapclick']]` is toggled in
+   `data_up_mapclick()` (FALSE once ≥1 point). The existing observe at `R/app_server.R:1335`
+   then enables `bt_get_results` and shows `show_data_preview` automatically.
+6. **"Review selected sites".** No change needed — `data_preview()` reads `data_uploaded()`;
+   re-opening the modal after more clicks shows the updated list.
+7. **Validity & invalid alert.** `latlon_df_clean()` yields `valid`/`invalid_msg`; reuse
+   `invalid_sites_alert2` / `invalid_alert[['mapclick']]`. (Clicks on the map are always
+   valid lat/lon, so this is mostly a no-op but keeps parity.)
+
+## Implementation phases / task breakdown
+
+1. **Refactor module** (`R/MODULE_latlon_from_map_click.R`): add `add_click`,
+   `remove_click`, `clear`, `render_map` params; keep standalone demo + `testServer`
+   passing; add `testServer` cases for external-wiring mode (simulate `add_click`,
+   `remove_click`, `clear` reactives).
+2. **Globals/UI**: add `'Click or draw on map' = 'mapclick'` to the `ss_choose_method`
+   radio (`R/app_ui.R:114`); add the `mapclick` `conditionalPanel` (Clear button, help
+   text, count/alert). Decide whether `mapclick` appears for both public and internal
+   builds (default: yes for both).
+3. **Server routing**: `mapclick` branches in `current_upload_method()`
+   (`R/app_server.R:349`) and `data_uploaded()` (`R/app_server.R:1295`); add `mapclick`
+   keys to the per-method reactiveValues lists; add `mapclick` to the radius seeding loop.
+4. **Server wiring**: `mapclick_points` reactiveVal + `MODULE_SERVER_latlon_from_map_click(
+   ..., render_map = FALSE)` call; `data_up_mapclick()`; `input$mapclick_clear` handled by
+   the module's `clear` arg.
+5. **Base map**: make `orig_leaf_map()` produce a stable, non-re-zooming base map for the
+   `mapclick` method; verify the circle proxy updates on add/remove/clear and on radius.
+6. **Delete disambiguation**: implement and unit-test the marker-click-vs-map-click guard.
+7. **End-to-end test**: `shinytest2`/manual — click several points (circles + radius
+   appear), move radius slider (circles resize), click a point to delete it, Clear all,
+   open "Review selected sites" (table matches), run analysis (`ejamit` gets the clicked
+   sitepoints), download CSV/XLSX.
+
+## Testing
+
+- **Module unit (`shiny::testServer`)**: external-wiring mode — feed `add_click` twice →
+  2 rows; `remove_click` with a layer id → 1 row; `clear` → 0 rows; confirm `reactdat`
+  shape is `lat,lon`.
+- **App integration (`shinytest2`, see existing app tests)**: drive `input$an_leaf_map_click`
+  via `session$setInputs`, assert `data_uploaded()` row count, `data_preview()`, and that
+  `bt_get_results` becomes enabled; assert radius change updates circles (smoke).
+- **Regression**: existing `upload`/`dropdown` flows unchanged (the new branch is additive).
+
+## Future phase: "draw" (polygons / lasso)
+
+Out of scope here. When added: surface a `leaflet.extras::addDrawToolbar()` (or reuse
+`R/MODULE_lasso.R`) on `an_leaf_map` under the same `mapclick` method, capture
+`input$an_leaf_map_draw_new_feature`, convert to an `sf` polygon, and route through the
+existing **`SHP`** path (`data_up_shp()` / `map_shapes_leaflet_proxy`). The `mapclick`
+method would then yield either points (clicks) or polygons (draws); `data_uploaded()`
+would dispatch to the latlon vs SHP handling accordingly.
+
+## Open questions / risks
+
+- **Marker-click vs map-click race** (#1 above) is the main technical risk; budget time to
+  test across leaflet versions.
+- **Public vs internal availability**: should `mapclick` be in the public build's radio, or
+  internal-only at first? (Default assumption: available in both.)
+- **Initial map view** for `mapclick` when there are zero points (US-wide `setView` is the
+  proposed default).
+- **Interaction with bookmarking**: clicked points live in a `reactiveVal`, not an
+  `input$`, so (like typed-in points) they are **not** restored by URL bookmarking. Note
+  this limitation; matches the `latlontypedin` caveat already in the module notes.

--- a/inst/global_defaults_package.R
+++ b/inst/global_defaults_package.R
@@ -66,7 +66,13 @@ global_defaults_package$app_title = as.vector(desc::desc_get("Title", file = sys
 
 global_defaults_package$report_title_multisite = "EJSCREEN Multisite Summary"
 global_defaults_package$report_title           = "EJSCREEN Community Report"
+############################### #
 
+# REPORT FORMAT ####
+# pdf or html can be default for downloadable 1-page summary report.
+# html format has live interactive maps with popups and links, but pdf has better pagination for printing.
+global_defaults_package$default_format1pager = "html"
+# see fileextension parameter in ejam2report() and input$default_format1pager etc in server, and see API/ url_ejamapi() etc.
 ############################### #
 
 # APP LOGO ####

--- a/tests/testthat/test-ejam2report.R
+++ b/tests/testthat/test-ejam2report.R
@@ -220,3 +220,29 @@ test_that("ejam2report does not buffer FIPS shapes for legacy radius 999", {
   )
   expect_length(buffer_state$radii, 0)
 })
+
+test_that("ejam2report normalizes default_format1pager fallback without a leading dot", {
+  buffer_state <- new.env(parent = emptyenv())
+  buffer_state$radii <- numeric()
+  local_ejam2report_fips_mocks(buffer_state)
+  local_mocked_bindings(
+    global_or_param = function(...) "pdf",
+    create_filename = function(..., ext) paste0("report", ext),
+    assert_pdf_report_available = function(...) invisible(TRUE),
+    .package = "EJAM"
+  )
+
+  expect_warning(
+    result <- ejam2report(
+      fips_report_test_output(radius = 1),
+      fileextension = "docx",
+      report_title = "Report",
+      analysis_title = "Analysis",
+      return_html = FALSE,
+      launch_browser = FALSE
+    ),
+    regexp = "fileextension must be one of",
+    fixed = TRUE
+  )
+  expect_match(basename(result), "\\.pdf$")
+})


### PR DESCRIPTION
pdf vs html report format now set by default_format1pager, advanced tab, and input$fileextension + Fix latlon from map click module