### PR TITLE
Harmonize app settings: ss_choose_method, anti-pattern fixes, launch-URL helper, default_site_method rename, docs

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -464,6 +464,24 @@ app_server <- function(input, output, session) {
   url_shapefile  <- reactiveVal(NULL)
   url_fips       <- reactiveVal(NULL)
 
+  # Launch-URL precedence helper (single home for layer-2 precedence). url_param(name) maps a
+  # parameter name to its launch-URL reactiveVal -- the only URL-provided params are these three
+  # typed place specs, so there is no generic per-name URL lookup. global_or_shinyparam_or_urlparam()
+  # returns the launch-URL value when present, else the ejamapp()/global default: a launch-URL value
+  # wins over the ejamapp/global default. Defined as closures here because the url_* reactiveVals are
+  # local to this server function. Used instead of hand-written url_*() %||% global_or_param() chains
+  # so the precedence is defined in one place.
+  url_param <- function(name) {
+    switch(name,
+           sitepoints = url_sitepoints(),
+           shapefile  = url_shapefile(),
+           fips       = url_fips(),
+           NULL)
+  }
+  global_or_shinyparam_or_urlparam <- function(name) {
+    url_param(name) %||% global_or_param(name)
+  }
+
   observe({
     search <- session$clientData$url_search
     if (is.null(search) || !nzchar(search)) {return(NULL)}
@@ -573,7 +591,7 @@ app_server <- function(input, output, session) {
 
     if (is.null(input$ss_upload_shp)) {
       ## no uploaded file, so check if shape was provided via launch URL or as parameter in ejamapp()
-      xshp <- url_shapefile() %||% global_or_param("shapefile")
+      xshp <- global_or_shinyparam_or_urlparam("shapefile")
       if (is.null(xshp) || length(xshp) == 0) {
         if (input$testing) {cat("no shp uploaded, no shp provided in ejamapp(), so should stop here\n")}
         req(FALSE, cancelOutput = TRUE)
@@ -737,7 +755,7 @@ app_server <- function(input, output, session) {
   data_up_tablepassed_latlon <- reactive({
 
     sitepoints <- NULL # since never set in global_defaults_*.R, only exists if at all via  get_golem_options()
-    sitepoints <- url_sitepoints() %||% global_or_param("sitepoints") # launch-URL points take precedence over ejamapp() param
+    sitepoints <- global_or_shinyparam_or_urlparam("sitepoints") # launch-URL points take precedence over ejamapp() param
     req(sitepoints)
 
     ################################# #
@@ -1370,7 +1388,7 @@ app_server <- function(input, output, session) {
     xfips <- NULL
     if (is.null(input$ss_upload_fips)) {
       ### nothing uploaded, so check if fips got passed via launch URL or as parameter to ejamapp()
-      xfips <- url_fips() %||% global_or_param("fips")
+      xfips <- global_or_shinyparam_or_urlparam("fips")
       if (!is.null(xfips)) {
         cat("fips seems to have been passed as parameter to ejamapp() \n")
         ## reflect the fips param (launch-URL or ejamapp) in the radio (layer 2), but don't override

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -342,15 +342,30 @@ app_server <- function(input, output, session) {
 
   # SELECT method of site selection: dropdown / upload / mapclick (radio button) ####
   #
-  # The ss_choose_method radio is defined statically in app_ui.R (initial value =
-  # global_or_param("default_upload_dropdown")). The advanced-tab "Site Selection Method" radio
-  # (input$default_ss_choose_method) lets a user change which method is selected at runtime; apply
-  # that here via updateRadioButtons() - you cannot reference input$ from the UI. (This replaces an
-  # older approach that re-rendered the radio server-side via output$ss_choose_method_ui.)
+  # The ss_choose_method radio can be set from several sources. PRECEDENCE (highest first):
+  #   1. launch-URL params (?lat/?lon/?fips/?shape, #413) - set once at session init
+  #   2. ejamapp() data params (sitepoints / shapefile / fips) - belt-and-suspenders in data_up_*
+  #   3. advanced-tab "Site Selection Method" radio (input$default_ss_choose_method) - explicit user runtime choice
+  #   4. static UI default (global_or_param("default_upload_dropdown")) baked into app_ui.R
+  # All non-static writers go through set_site_method() so the writes live in one place. Once the
+  # user explicitly picks a method at runtime (layer 3), site_method_user_override latches TRUE and
+  # the lazy layer-2 belt-and-suspenders writes stop clobbering the user's choice. (You cannot
+  # reference input$ from app_ui.R, so the static default is applied there and any later change is
+  # applied server-side here via update*Input(); this replaces an older approach that re-rendered
+  # the radio via output$ss_choose_method_ui.)
+  site_method_user_override <- reactiveVal(FALSE)
+  set_site_method <- function(method, upload_submethod = NULL, source = "") {
+    if (isTRUE(input$testing)) {
+      message("set_site_method: ", method, if (!is.null(upload_submethod)) paste0("/", upload_submethod) else "", " (", source, ")")
+    }
+    shiny::updateRadioButtons(session = session, inputId = "ss_choose_method", selected = method)
+    if (!is.null(upload_submethod)) {
+      shiny::updateSelectInput(session = session, inputId = "ss_choose_method_upload", selected = upload_submethod)
+    }
+  }
   observeEvent(input$default_ss_choose_method, {
-    if (input$testing) {message("input$default_ss_choose_method is ", input$default_ss_choose_method)}
-    shiny::updateRadioButtons(session = session, inputId = "ss_choose_method",
-                              selected = input$default_ss_choose_method)
+    site_method_user_override(TRUE)  # explicit user runtime choice (layer 3): protect it from layer-2 clobber
+    set_site_method(input$default_ss_choose_method, source = "advanced-tab")
   }, ignoreInit = TRUE)
 
   # keep track of currently used method of site selection (also see submitted_upload_method reactive)
@@ -504,16 +519,14 @@ app_server <- function(input, output, session) {
                       error = function(e) NULL)
       if (!is.null(pts) && nrow(pts) > 0 && !anyNA(pts[, c("lat", "lon")])) {
         url_sitepoints(pts)
-        shiny::updateRadioButtons(session, inputId = "ss_choose_method", selected = "upload")
-        shiny::updateSelectInput(session, inputId = "ss_choose_method_upload", selected = "latlon")
+        set_site_method("upload", "latlon", source = "launch-URL")  # layer 1 (highest), init only
         loaded <- TRUE
       }
     }
     ## FIPS (each code is a separate site)
     if (!loaded && !is.null(spec$fips) && length(spec$fips) > 0) {
       url_fips(as.character(spec$fips))
-      shiny::updateRadioButtons(session, inputId = "ss_choose_method", selected = "upload")
-      shiny::updateSelectInput(session, inputId = "ss_choose_method_upload", selected = "FIPS")
+      set_site_method("upload", "FIPS", source = "launch-URL")  # layer 1 (highest), init only
       loaded <- TRUE
     }
     ## POLYGONS -- only inline GeoJSON text (the documented ?shape= contract).
@@ -534,8 +547,7 @@ app_server <- function(input, output, session) {
         # instead of re-parsing the GeoJSON -- matters for the large-polygon handoff.
         # shapefile_from_any() fast-returns an sf object as-is, so data_up_shp() stays cheap.
         url_shapefile(shp)
-        shiny::updateRadioButtons(session, inputId = "ss_choose_method", selected = "upload")
-        shiny::updateSelectInput(session, inputId = "ss_choose_method_upload", selected = "SHP")
+        set_site_method("upload", "SHP", source = "launch-URL")  # layer 1 (highest), init only
         loaded <- TRUE
       }
     }
@@ -564,9 +576,9 @@ app_server <- function(input, output, session) {
           cat("shapefile_from_any() cannot read specified shp parameter \n")
           req(FALSE, cancelOutput = TRUE)
         }
-        ## if user provided ejamapp(shapefile=xyz) but did not set these also, they will not see their upload ready to run:
-        shiny::updateRadioButtons(session, inputId = "ss_choose_method", selected = "upload")    # ejamapp() should ensure this happens via changing defaults but ok to also do here
-        shiny::updateSelectInput(session, inputId = "ss_choose_method_upload", selected = "SHP") # ejamapp() should ensure this happens via changing defaults but ok to also do here
+        ## if user provided ejamapp(shapefile=xyz) but did not set the method defaults also, reflect
+        ## it in the radio (layer 2) -- but never override an explicit runtime method choice (layer 3).
+        if (!site_method_user_override()) {set_site_method("upload", "SHP", source = "ejamapp(shapefile=)")}
       }
     } else {
       #   ###################################### #
@@ -773,9 +785,9 @@ app_server <- function(input, output, session) {
         ## if user provided ejamapp(sitepoints=xyz) but did not set these also, they will not see their upload ready to run:
         ## default_upload_dropdown = "upload"  --  input$default_ss_choose_method
         ## default_selected_type_of_site_upload = "latlon"  --  input$ss_choose_method_upload
-        # shiny::updateRadioButtons(session = session, inputId = "default_ss_choose_method", selected = "upload")
-        shiny::updateRadioButtons(inputId = "ss_choose_method", selected = "upload")
-        shiny::updateSelectInput(inputId = "ss_choose_method_upload", selected = "latlon")
+        ## reflect the ejamapp(sitepoints=) param in the radio (layer 2), but don't override an
+        ## explicit runtime method choice (layer 3).
+        if (!site_method_user_override()) {set_site_method("upload", "latlon", source = "ejamapp(sitepoints=)")}
         xsitepoints
       }
     } else {
@@ -1350,8 +1362,9 @@ app_server <- function(input, output, session) {
       xfips <- url_fips() %||% global_or_param("fips")
       if (!is.null(xfips)) {
         cat("fips seems to have been passed as parameter to ejamapp() \n")
-        shiny::updateRadioButtons(session = session, inputId = "ss_choose_method", selected = "upload")     # already done by ejamapp() but ok to repeat
-        shiny::updateSelectInput(session = session, inputId = "ss_choose_method_upload", selected = "FIPS") # already done by ejamapp() but ok to repeat
+        ## reflect the fips param (launch-URL or ejamapp) in the radio (layer 2), but don't override
+        ## an explicit runtime method choice (layer 3).
+        if (!site_method_user_override()) {set_site_method("upload", "FIPS", source = "ejamapp(fips=)/launch-URL")}
 
         fips_vec <- xfips
         fips_dt <- data.table(fips = fips_vec)

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -365,18 +365,29 @@ app_server <- function(input, output, session) {
   # applied server-side here via update*Input(); this replaces an older approach that re-rendered
   # the radio via output$ss_choose_method_ui.)
   site_method_user_override <- reactiveVal(FALSE)
+  site_method_last_set <- reactiveVal(NULL)  # value set_site_method() last wrote -- lets us tell our own programmatic writes apart from a user click on the main radio
   set_site_method <- function(method, upload_submethod = NULL, source = "") {
     if (isTRUE(input$testing)) {
       message("set_site_method: ", method, if (!is.null(upload_submethod)) paste0("/", upload_submethod) else "", " (", source, ")")
     }
+    site_method_last_set(method)  # record before the (async) update so the ss_choose_method observer ignores this programmatic change
     shiny::updateRadioButtons(session = session, inputId = "ss_choose_method", selected = method)
     if (!is.null(upload_submethod)) {
       shiny::updateSelectInput(session = session, inputId = "ss_choose_method_upload", selected = upload_submethod)
     }
   }
+  # Latch the user-override on an explicit runtime method change via EITHER the advanced-tab radio
+  # (input$default_ss_choose_method) OR the main radio (input$ss_choose_method). For the main radio we
+  # must distinguish a real user click from our own set_site_method() writes, so we only latch when the
+  # new value differs from the value set_site_method() last wrote.
   observeEvent(input$default_ss_choose_method, {
     site_method_user_override(TRUE)  # explicit user runtime choice (layer 3): protect it from layer-2 clobber
     set_site_method(input$default_ss_choose_method, source = "advanced-tab")
+  }, ignoreInit = TRUE)
+  observeEvent(input$ss_choose_method, {
+    if (!identical(as.character(input$ss_choose_method), as.character(site_method_last_set()))) {
+      site_method_user_override(TRUE)  # user changed the MAIN radio directly (not via set_site_method)
+    }
   }, ignoreInit = TRUE)
 
   # keep track of currently used method of site selection (also see submitted_upload_method reactive)

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -357,7 +357,7 @@ app_server <- function(input, output, session) {
   #   1. launch-URL params (?lat/?lon/?fips/?shape, #413) - set once at session init
   #   2. ejamapp() data params (sitepoints / shapefile / fips) - belt-and-suspenders in data_up_*
   #   3. advanced-tab "Site Selection Method" radio (input$default_ss_choose_method) - explicit user runtime choice
-  #   4. static UI default (global_or_param("default_upload_dropdown")) baked into app_ui.R
+  #   4. static UI default (global_or_param("default_site_method")) baked into app_ui.R
   # All non-static writers go through set_site_method() so the writes live in one place. Once the
   # user explicitly picks a method at runtime (layer 3), site_method_user_override latches TRUE and
   # the lazy layer-2 belt-and-suspenders writes stop clobbering the user's choice. (You cannot
@@ -812,7 +812,7 @@ app_server <- function(input, output, session) {
       xsitepoints <- data_up_tablepassed_latlon()
       if (!is.null(xsitepoints)) {
         ## if user provided ejamapp(sitepoints=xyz) but did not set these also, they will not see their upload ready to run:
-        ## default_upload_dropdown = "upload"  --  input$default_ss_choose_method
+        ## default_site_method = "upload"  --  input$default_ss_choose_method
         ## default_selected_type_of_site_upload = "latlon"  --  input$ss_choose_method_upload
         ## reflect the ejamapp(sitepoints=) param in the radio (layer 2), but don't override an
         ## explicit runtime method choice (layer 3).

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -199,22 +199,29 @@ app_server <- function(input, output, session) {
 
   ## advanced tab provides size cap on file uploads  ---------------------- #
 
+  # max_mb_upload_react is a PURE reactive: it reads input$max_mb_upload and returns the value
+  # clamped to [minmax_mb_upload, maxmax_mb_upload] (or the default if unset). It has NO
+  # side-effects. The observe below applies the side-effects (reflect the clamped value back into
+  # the widget, set shiny.maxRequestSize, reset the file inputs so a too-large upload can be retried
+  # under the new cap). Previously the reactive called updateNumericInput() inside itself -- a
+  # side-effect-in-a-reactive anti-pattern.
   max_mb_upload_react <- reactive({
     x <- as.numeric((input$max_mb_upload))
     if (is.null(x) || is.na(x) || length(x) == 0) {
       x <- global_or_param("default_max_mb_upload") #?
-      shiny::updateNumericInput(session = session, inputId = "max_mb_upload", value = x)
     } else {
       if (x > global_or_param("maxmax_mb_upload")) {x <- global_or_param("maxmax_mb_upload")}
       if (x < global_or_param("minmax_mb_upload")) {x <- global_or_param("minmax_mb_upload")}
-      shiny::updateNumericInput(session = session, inputId = "max_mb_upload", value = x)
     }
     x
   })
   observe({
+    x <- max_mb_upload_react()
+    # reflect the clamped/default value back in the widget (this side-effect moved here out of the reactive)
+    shiny::updateNumericInput(session = session, inputId = "max_mb_upload", value = x)
     # Adjusts cap on file size user can upload, and resets file inputs in case
     #   last attempt failed due to size, so you can retry with new cap.
-    options(shiny.maxRequestSize = max_mb_upload_react() * 1024^2)
+    options(shiny.maxRequestSize = x * 1024^2)
     ids_of_fileInput_lines <- c("ss_upload_latlon", "ss_upload_shp",
                                 "ss_upload_frs", "ss_upload_program","ss_upload_fips")
     for (idx in ids_of_fileInput_lines) {shinyjs::reset(idx)}
@@ -259,11 +266,15 @@ app_server <- function(input, output, session) {
                          server = TRUE)
   }, once = TRUE)
   observe({
-    # if defaults and/or adv tab was used to specify a detailed NAICS, must show detailed not basic versions for it to be visible as initial choice
-    level_of_detail_based_on_default_naics <- if (any(nchar(input$default_naics) > 3)) 'detailed' else global_or_param("default_naics_digits_shown")
-    updateRadioButtons(session = session, inputId = 'naics_digits_shown',
-                       selected = level_of_detail_based_on_default_naics
-    )
+    # If default_naics (from the global default and/or the advanced tab) contains a detailed
+    # (>3-digit) NAICS code, force the detailed list so that code is visible as an initial choice.
+    # Otherwise DO NOT touch naics_digits_shown: leave the app_ui.R default or the user's own pick
+    # in place. (The previous version reset it to the default on EVERY default_naics change, which
+    # silently clobbered a manual choice.) This observe depends only on input$default_naics, so its
+    # own updateRadioButtons() write to naics_digits_shown never re-triggers it.
+    if (any(nchar(input$default_naics) > 3)) {
+      updateRadioButtons(session = session, inputId = 'naics_digits_shown', selected = 'detailed')
+    }
   })
   observeEvent(input$default_format1pager, {
     ## normalize like ejam2report() does (strip a leading dot, lowercase) so a user-supplied or

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -121,10 +121,10 @@ app_ui <- function(request) {
                                choiceValues = c('dropdown',
                                                 'upload',
                                                 'mapclick'),
-                               selected = global_or_param("default_upload_dropdown")),
+                               selected = global_or_param("default_site_method")),
                   # NOTE: the UI is built once at page-load, before any reactive `input` exists, so
                   # `selected` MUST be a non-reactive value here - global_or_param() reads the ejamapp()
-                  # param / global default (default_upload_dropdown = "dropdown" / "upload" / "mapclick").
+                  # param / global default (default_site_method = "dropdown" / "upload" / "mapclick").
                   # Do NOT use `selected = input$default_ss_choose_method` here (that errors at UI build).
                   # The advanced-tab "Site Selection Method" setting is applied to this radio server-side
                   # via updateRadioButtons() - see observeEvent(input$default_ss_choose_method) in app_server.R.
@@ -1126,9 +1126,9 @@ app_ui <- function(request) {
 
                  radioButtons(inputId = "default_ss_choose_method", label = "Site Selection Method",
                               choices = c(Dropdown = "dropdown", Upload = "upload", `Click on map` = "mapclick"),
-                              selected = global_or_param("default_upload_dropdown"),
+                              selected = global_or_param("default_site_method"),
                               inline = TRUE),
-                 # global_default or ejamapp() parameter: default_upload_dropdown ("dropdown", "upload", or "mapclick"),
+                 # global_default or ejamapp() parameter: default_site_method ("dropdown", "upload", or "mapclick"),
                  # which is the initial selected value of
                  # input in advanced tab: input$default_ss_choose_method, which (via updateRadioButtons in the server)
                  # sets the initial/selected value of

--- a/R/ejamapp.R
+++ b/R/ejamapp.R
@@ -152,7 +152,7 @@
 #'   ## Cities dropdown list as default shown at launch:
 #'
 #' ejamapp(
-#'   default_upload_dropdown = "dropdown",
+#'   default_site_method = "dropdown",
 #'   default_selected_type_of_site_category = "FIPS_PLACE",
 #'   fipspicker_fips_type2pick_default = "Cities or Places"
 #' )
@@ -160,7 +160,7 @@
 #'   ## Specific cities are preselected at launch
 #'
 #'   ejamapp(
-#'   default_upload_dropdown = "dropdown",
+#'   default_site_method = "dropdown",
 #'   default_selected_type_of_site_category = "FIPS_PLACE",
 #'   fipspicker_fips_type2pick_default = "Cities or Places",
 #'   default_cities_picked = name2fips(c("akutan,ak", "syracuse city,ny") )
@@ -181,7 +181,7 @@
 #'   ## Polygons upload as the default shown at launch:
 #'
 #' ejamapp(
-#'   default_upload_dropdown = "upload",
+#'   default_site_method = "upload",
 #'   default_selected_type_of_site_upload = "SHP"
 #' )
 #'   #default_choices_for_type_of_site_upload = c(
@@ -194,10 +194,11 @@
 #'
 #'   ## Click-or-draw-on-map as the default site-selection method shown at launch.
 #'   ## The user clicks the map to specify one or more lat/lon points to analyze.
-#'   ## (default_upload_dropdown accepts "dropdown", "upload", or "mapclick".)
+#'   ## (default_site_method accepts "dropdown", "upload", or "mapclick".
+#'   ##  It was formerly named default_upload_dropdown, which still works as an alias.)
 #'
 #' ejamapp(
-#'   default_upload_dropdown = "mapclick"
+#'   default_site_method = "mapclick"
 #' )
 #'
 #'  ## Count how many of some indicator are >= some cutoff
@@ -284,10 +285,19 @@ ejamapp <- function(
 
   dots = rlang::list2(...)
 
+  # Back-compat: default_upload_dropdown was renamed to default_site_method (it now selects
+  # dropdown/upload/mapclick, not just upload). Normalize the OLD name to the new one BEFORE the
+  # alias blocks below run, so existing ejamapp(default_upload_dropdown=...) calls keep working and
+  # everything downstream (this function, global_or_param(), the UI) only sees default_site_method.
+  if ('default_upload_dropdown' %in% names(dots) && !('default_site_method' %in% names(dots))) {
+    dots$default_site_method <- dots$default_upload_dropdown
+  }
+  dots$default_upload_dropdown <- NULL  # drop the old key so only the new name flows downstream
+
   if ("fips" %in% names(dots)) {
     # dots$fips will be used
-    if (!('default_upload_dropdown' %in% names(dots))) {
-      dots$default_upload_dropdown <- "upload"
+    if (!('default_site_method' %in% names(dots))) {
+      dots$default_site_method <- "upload"
     }
     if (!('default_selected_type_of_site_upload' %in% names(dots))) {
       dots$default_selected_type_of_site_upload <- "FIPS"
@@ -298,7 +308,7 @@ ejamapp <- function(
   if ("shp" %in% names(dots) && is.null(dots$shapefile)) {   # is.null() so an explicit shapefile=NULL still lets the alias apply
     # dots$shp will be used
     dots$shapefile <- dots$shp # convenient alias
-    dots$default_upload_dropdown = "upload"
+    dots$default_site_method = "upload"
     dots$default_selected_type_of_site_upload = "SHP"
   }
   if ("shape" %in% names(dots) && is.null(dots$shapefile)) {
@@ -306,7 +316,7 @@ ejamapp <- function(
   }
   if (!is.null(dots$shapefile)) {
     # dots$shapefile will be used
-    dots$default_upload_dropdown = "upload"
+    dots$default_site_method = "upload"
     dots$default_selected_type_of_site_upload = "SHP"
     cat("launching with specified shapefile", "\n")
   }
@@ -318,27 +328,27 @@ ejamapp <- function(
     dots$sitepoints = data.frame(lat=dots$lat, lon = dots$lon)
   }
   if ("sitepoints" %in% names(dots)) {
-    dots$default_upload_dropdown = "upload"
+    dots$default_site_method = "upload"
     dots$default_selected_type_of_site_upload = "latlon"
     cat("launching with specified sitepoints", "\n")
   }
 
   if ("naics" %in% names(dots)) {dots$default_naics <- dots$naics}
   if ("default_naics" %in% names(dots)) {
-    dots$default_upload_dropdown   <- "dropdown"
+    dots$default_site_method   <- "dropdown"
     dots$default_selected_type_of_site_category <- "NAICS"
     dots$default_naics_digits_shown <- "detailed"  # if default_naics is >3 digits, this has to be "detailed" not "basic"
     cat("launching with specified default_naics =", paste0(dots$default_naics, collapse = ", "), "\n")
   }
   if ("sic" %in% names(dots)) {dots$default_sic <- dots$sic}
   if ("default_sic" %in% names(dots)) {
-    dots$default_upload_dropdown   <- "dropdown"
+    dots$default_site_method   <- "dropdown"
     dots$default_selected_type_of_site_category <- "SIC"
     cat("launching with specified default_sic =", paste0(dots$default_sic, collapse = ", "), "\n")
     }
   if ("mact" %in% names(dots)) {dots$default_mact <- dots$mact}
   if ("default_mact" %in% names(dots)) {
-    dots$default_upload_dropdown   <- "dropdown"
+    dots$default_site_method   <- "dropdown"
     dots$default_selected_type_of_site_category <- "MACT"
     cat("launching with specified default_mact =", paste0(dots$default_mact, collapse = ", "), "\n")
   }

--- a/R/utils_global_or_param.R
+++ b/R/utils_global_or_param.R
@@ -40,11 +40,20 @@
 #'
 global_or_param = function(vname) {
 
+  # Back-compat alias map: a param renamed in a later version still resolves under its OLD name when
+  # only the old key is present (e.g. a user's older global_defaults_*.R file). ejamapp() already
+  # normalizes old->new for its own params; this covers the global_defaults files and direct reads.
+  # old_name is NA for any vname that has no alias, so the lookups below are no-ops in that case.
+  old_name <- unname(c(default_site_method = "default_upload_dropdown")[vname])
+
   ################################ #
   ## 1st check if param was defined upon shiny app launch
   ## either via being passed to ejamapp() or  stored as golem global options upon app launch after having been defined by global_default_*.R file
 
   param_passed_to_ejamapp_or_global_defaults <- golem::get_golem_options(vname)
+  if (is.null(param_passed_to_ejamapp_or_global_defaults) && !is.na(old_name)) {
+    param_passed_to_ejamapp_or_global_defaults <- golem::get_golem_options(old_name)
+  }
 
   if (!is.null(param_passed_to_ejamapp_or_global_defaults)) {
     return(param_passed_to_ejamapp_or_global_defaults)
@@ -57,6 +66,9 @@ global_or_param = function(vname) {
     if (exists("global_defaults_package")) {
       if (vname %in% names(global_defaults_package)) {
         return(global_defaults_package[[vname]])
+      }
+      if (!is.na(old_name) && old_name %in% names(global_defaults_package)) {
+        return(global_defaults_package[[old_name]])
       }
     }
     ################################ #

--- a/data-raw/refactoring_app_settings_analysis.md
+++ b/data-raw/refactoring_app_settings_analysis.md
@@ -1,0 +1,140 @@
+# NOTES on how EJAM app settings / defaults / parameters get set
+
+`global_or_param()` vs shiny `input$` vs launch-URL params vs bookmarking — and how to keep it organized.
+
+- **Date:** 2026-06-29
+- **Author of analysis:** review for Mark (ejanalysis), based on a 3-part audit of `R/app_ui.R`, `R/app_server.R`, `R/ejamapp.R`, `R/utils_get_global_defaults_or_user_options.R`, `R/utils_global_or_param.R` on branch `mapclick-app-integration` (PR #418).
+- **Status:** Reference/analysis. The CLEANUP items at the end are **deferred to a separate branch/PR `refactoring_app_settings`** (its own session, based on `development`).
+
+---
+
+## TL;DR — it looks messier than it is, because two different concerns got tangled
+
+What felt like "competing designs" is really **two orthogonal axes**:
+
+- **Axis 1 — how the input widget is built** (a UI-mechanics concern): static-in-UI vs server-`renderUI` vs static-empty-plus-server-`update*Input`. The choice is almost always *forced* by the widget, not stylistic.
+- **Axis 2 — where the widget's value/default comes from** (a config-precedence concern): global-default files, `ejamapp()` params, advanced-tab inputs, Shiny bookmarks, and launch-URL params.
+
+Once you separate them, ~90% of the variation is correct and necessary. The genuine cleanup surface is ~5 specific spots (listed near the end).
+
+---
+
+## Axis 1 — how each input widget is built (and when each is correct)
+
+| Pattern | ~count (PR #418) | Use when | Why it is forced, not stylistic |
+|---|---|---|---|
+| **A — static UI default**: control written in `app_ui.R` with `selected =`/`value =`/`choices =` set to `global_or_param("…")` or a literal | ~48 controls | default is a plain value known at page-load, with a fixed choice set | simplest, correct for most controls. **UI is built before any reactive `input` exists, so the value MUST be non-reactive here** (never `input$…` in app_ui.R) |
+| **B — server `renderUI`** (`uiOutput('x')` in UI + `output$x <- renderUI({...})` in server) | ~7 input controls (radius slider `radius_now`, `summ_bar_*`, `summ_hist_ind`, `analysis_title`, `rg_enter_miles`) | the widget's **structure** (which choices exist, min/max, conditional sub-controls) depends on reactive state | you cannot bake a reactive structure into static UI. e.g. radius slider `min/max` depend on the chosen method; bar-plot choices depend on `include_ejindexes` |
+| **C — static-empty UI + server `update*Input()`** | ~20 update calls | choices load **server-side** (selectize `server=TRUE`), OR the value must change on a later **event** | a ~2,000-item NAICS list (also SIC, MACT) *cannot* be static — selectize must be populated server-side. This is why `updateSelectizeInput(ss_select_naics, selected = global_or_param("default_naics"))` exists: **required**, not an inconsistency. Also used for event-driven changes (advanced-tab sync, upload→method switch) |
+
+**Decision rule for contributors:**
+- known value + fixed choices → **A**
+- choices load lazily, or value must react to an event → **C**
+- the widget's shape itself is reactive → **B**
+- **never** reference `input$…` inside `app_ui.R` (errors at UI build). To make an advanced-tab setting change a main control, sync server-side via `update*Input()`.
+
+(There was a 4th, abandoned pattern — "Design B for the method radio": `output$ss_choose_method_ui <- renderUI(...)` reading `input$default_ss_choose_method`. It was dead, stale, and buggy; removed in PR #418 and replaced with the C-pattern `observeEvent(input$default_ss_choose_method, updateRadioButtons('ss_choose_method', …))`.)
+
+---
+
+## Axis 2 — where a value comes from (the precedence stack)
+
+There are really **two sub-systems**: a **startup-config pipeline** (consolidated, consistent) and a set of **runtime overrides** (each wired separately).
+
+### Startup-config pipeline (consolidated — this part is good)
+
+```
+ejamapp(...)  -- user's call, with convenience ALIASES
+   │  (1) ejamapp() normalizes aliases + cross-sets related defaults   [R/ejamapp.R ~275-388]
+   ▼
+get_global_defaults_or_user_options(user_specified_options = dots)      [R/utils_get_global_defaults_or_user_options.R:72]
+   │  (2) merge, FIRST-WRITER-WINS, in precedence order:
+   │        a. ejamapp() params (highest)
+   │        b. global_defaults_package.R
+   │        c. global_defaults_shiny.R
+   │        d. global_defaults_shiny_public.R (depends on isPublic)
+   ▼
+golem_opts  ──►  global_or_param("name")   [R/utils_global_or_param.R]
+   │
+   ├─► app_ui.R   : Design A  (selected = global_or_param("name"))
+   └─► app_server : Design C  (update*Input(..., selected = global_or_param("name")))
+```
+
+**Role of `get_global_defaults_or_user_options()`** (the user asked about this): it is the single place that collects the **startup** settings from the 4 sources above and consolidates them into one list (`golem_opts`) that both UI and server read via `global_or_param()`. The merge helper `update_global_defaults_or_user_options()` only adds a key if it is **not already set**, so earlier (higher-priority) sources win — user `ejamapp()` params override the files. 
+
+**Is it a good way to collect the various ways params get set?** For the **startup/config layer, yes** — it is centralized, ordered, first-writer-wins, and easy to reason about. Caveats / things to know:
+- It only covers the **startup** layer. It does **not** incorporate the *runtime* overrides below (advanced-tab inputs, bookmarks, launch-URL params). So it is "the collector" for config-at-launch, not a single unifying point for *all* ways a value can be set.
+- It `source()`s `global_defaults_package.R` with `local = FALSE` (into the global env) — a deliberate hack (needed so the summary-report logo etc. resolve), noted in the code.
+- It depends on each file defining a specific named list (`global_defaults_package`, `global_defaults_shiny`, `global_defaults_shiny_public`) in the sourced env — implicit coupling, but stable.
+- Recommendation: keep it. Just document clearly that it owns the **startup** layer, and give the **launch-URL** layer a parallel single helper (see the deferred plan) so runtime precedence is as centralized as startup precedence.
+
+**Role of `ejamapp()` alias handling** (the user asked about this): before the merge, `ejamapp()` normalizes a set of **convenience aliases** on its `...` dots and, for some, **cross-sets related defaults** so a one-liner "just works." Examples (`R/ejamapp.R ~275-388`):
+- `pts` → `sitepoints`; `lat`+`lon` → `sitepoints`; and `sitepoints` ⇒ also sets `default_upload_dropdown="upload"`, `default_selected_type_of_site_upload="latlon"`.
+- `shp` → `shapefile`; and `shapefile` ⇒ `default_upload_dropdown="upload"`, `…upload="SHP"`.
+- `fips` ⇒ `default_upload_dropdown="upload"`, `…upload="FIPS"`.
+- `naics` → `default_naics`; and `default_naics` ⇒ `default_upload_dropdown="dropdown"`, `…category="NAICS"`. Similarly `sic`/`mact`.
+- `radius`/`default_radius`; `report_title`/`default_report_title`/`default_report_title_multisite`; `analysis_title`/`default_analysis_title`; `testing`; etc.
+This is a **third param-setting concern** (alias normalization + dependent-default inference) that runs *upstream* of the merge. It is convenient and mostly good, but it is also where some of the "many ways to set the same thing" feeling comes from — e.g. the method (`default_upload_dropdown`) can be set directly, or implicitly via `fips`/`shp`/`pts`/`naics`/`sitepoints`/`shapefile`. Worth documenting the alias table in one place.
+
+### Runtime overrides (each wired separately — this is where harmonization helps)
+
+| Layer | Mechanism | Where | Consistency |
+|---|---|---|---|
+| **Advanced-tab → main control** | `observeEvent(input$default_ss_choose_method, updateRadioButtons('ss_choose_method', …))` and similar | app_server.R | ad hoc per control |
+| **Shiny native bookmarking** | `enableBookmarking='url'` (default in `ejamapp()`); `bookmarkButton()`; `?_inputs_&id=val…` restores all `input$` on load | ejamapp.R, app_ui.R | framework-level; only `input$` vars; no `onBookmark`/`onRestore` customization yet |
+| **Launch-URL custom params** (PR #413, *not on this branch yet*) | parse `session$clientData$url_search`; `url_*()` reactiveVals; precedence via `url_x() %||% global_or_param("x")` in each `data_up_*` reactive; also `update*Input` to reflect in UI | app_server.R on `ejscreen-multisite-selection` | **ad hoc** — repeated `%||%` per reactive; precedence not centralized |
+
+---
+
+## Precedence summary (highest wins)
+
+1. **Shiny bookmark** `?_inputs_&…` — restores `input$` values on load (overrides UI defaults). *Framework-level; orthogonal.*
+2. **Launch-URL custom params** `?lat=&lon=`, `?fips=`, `?shape=`, `?handoff=` (PR #413) — `url_x() %||% global_or_param("x")`.
+3. **`ejamapp()` params** (after alias normalization) — override the global-default files.
+4. **`global_defaults_*.R`** files (package < shiny < shiny_public).
+
+Layers 3–4 are consolidated and consistent (via `get_global_defaults_or_user_options()`). Layers 1–2 and the advanced-tab sync are each reasonable but wired **ad hoc**, and that is the real harmonization target.
+
+---
+
+## Where it is genuinely inconsistent / risky (verified in code)
+
+| Spot | Issue | Severity |
+|---|---|---|
+| `ss_choose_method` | 4 writers: advanced-tab sync (`app_server.R:~352`) + three `="upload"` updates from shapefile/sitepoints/fips ejamapp params (`~444`, `~657`, `~1212`). Last-writer-wins; no documented precedence | medium |
+| `max_mb_upload_react` (`app_server.R:~202`) | a `reactive()` that calls `updateNumericInput()` **inside itself** (side-effect in a reactive — anti-pattern). Self-settles so no infinite loop, but should be `observe`-writes + pure `reactive`-reads | low–med |
+| `naics_digits_shown` (`app_server.R:~261`) | an `observe` resets it whenever `default_naics` changes — silently overrides a user's manual pick | low |
+| `default_naics` / `default_sic` | belt-and-suspenders: Category-C server populate that re-fetches the same `global_or_param` the static UI "knows" — confusing but harmless | low |
+| Launch-URL `%||%` precedence (#413) | repeated per-reactive instead of one helper → easy to apply inconsistently as more URL params are added | medium (growing) |
+| `default_upload_dropdown` name | now selects 3 methods (dropdown / upload / mapclick) — the name is a misnomer | cosmetic |
+
+---
+
+## Assessment: is it messy? Do we need harmonization?
+
+**The architecture is sound; do not rewrite it.** The A/B/C variation is forced and correct; the startup-config pipeline is well-consolidated. The "messiness" is concentrated in (a) the *runtime* override layers being wired ad hoc, and (b) a handful of double-set / side-effect-in-reactive spots. **Targeted harmonization, not a rewrite.**
+
+---
+
+## DEFERRED — `refactoring_app_settings` branch/PR (separate session, based on `development`)
+
+This is captured here so the dedicated session has the full scope. That branch/PR should **include this report + the memory note**, **start with a plan**, then:
+
+1. **Centralize the launch-URL precedence**: add a helper named **`global_or_shinyparam_or_urlparam`**, defined in **`R/utils_global_or_param.R`**, that returns `url_param(name) %||% global_or_param(name)` (i.e. launch-URL value wins over the ejamapp/global default), and use it everywhere instead of hand-written `%||%` chains. Defines layer-2 precedence in one place. *(Coordinate with PR #413, which introduced the `url_*` reactives on `ejscreen-multisite-selection`.)*
+2. **Consolidate the `ss_choose_method` writers** into one observer with explicit precedence (URL > ejamapp data param > advanced-tab > static), commented. *User flagged this as good but tricky — do carefully and double-check.*
+3. **Fix the two anti-patterns**: split `max_mb_upload` into `observe`-writes / `reactive`-reads; make `naics_digits_shown` respect a user override.
+4. **Rename `default_upload_dropdown` → `default_site_method`** with a back-compat alias (the value now selects dropdown/upload/mapclick). *User flagged as good but tricky — do extremely carefully; keep the alias so existing `ejamapp()` calls and bookmarks/URLs keep working.*
+5. **Documentation pass**, especially the customizing vignette `dev-app-settings.Rmd` ("Defaults and Custom Settings for the Web App"): document the two-axis model, the alias table, the precedence stack (incl. launch-URL once merged), and the renamed param.
+
+---
+
+## Key file references
+
+- `R/utils_global_or_param.R` — `global_or_param()` (reads golem_opts; future `global_or_shinyparam_or_urlparam` home).
+- `R/utils_get_global_defaults_or_user_options.R:72` — startup merge of ejamapp params + 3 global-default files.
+- `R/ejamapp.R ~275-388` — alias normalization + dependent-default inference; `enableBookmarking='url'`.
+- `R/app_ui.R` — Design A defaults; advanced-tab radios; `bookmarkButton()`; ~48 `global_or_param()` defaults.
+- `R/app_server.R` — Design C `update*Input()` calls; Design B `renderUI` controls; advanced-tab→main syncs.
+- `inst/global_defaults_*.R` — the default values (package / shiny / shiny_public).
+- `vignettes/dev-app-settings.Rmd` — the customizing vignette (covers bookmarking + defaults; missing launch-URL + alias docs).
+- Launch-URL params: `R/app_server.R` on branch `ejscreen-multisite-selection` (PR #413), pattern `url_x() %||% global_or_param("x")`.

--- a/data-raw/refactoring_app_settings_analysis.md
+++ b/data-raw/refactoring_app_settings_analysis.md
@@ -60,7 +60,7 @@ golem_opts  ──►  global_or_param("name")   [R/utils_global_or_param.R]
    └─► app_server : Design C  (update*Input(..., selected = global_or_param("name")))
 ```
 
-**Role of `get_global_defaults_or_user_options()`** (the user asked about this): it is the single place that collects the **startup** settings from the 4 sources above and consolidates them into one list (`golem_opts`) that both UI and server read via `global_or_param()`. The merge helper `update_global_defaults_or_user_options()` only adds a key if it is **not already set**, so earlier (higher-priority) sources win — user `ejamapp()` params override the files. 
+**Role of `get_global_defaults_or_user_options()`** (the user asked about this): it is the single place that collects the **startup** settings from the 4 sources above and consolidates them into one list (`golem_opts`) that both UI and server read via `global_or_param()`. The merge helper `update_global_defaults_or_user_options()` only adds a key if it is **not already set**, so earlier (higher-priority) sources win — user `ejamapp()` params override the files.
 
 **Is it a good way to collect the various ways params get set?** For the **startup/config layer, yes** — it is centralized, ordered, first-writer-wins, and easy to reason about. Caveats / things to know:
 - It only covers the **startup** layer. It does **not** incorporate the *runtime* overrides below (advanced-tab inputs, bookmarks, launch-URL params). So it is "the collector" for config-at-launch, not a single unifying point for *all* ways a value can be set.
@@ -68,13 +68,13 @@ golem_opts  ──►  global_or_param("name")   [R/utils_global_or_param.R]
 - It depends on each file defining a specific named list (`global_defaults_package`, `global_defaults_shiny`, `global_defaults_shiny_public`) in the sourced env — implicit coupling, but stable.
 - Recommendation: keep it. Just document clearly that it owns the **startup** layer, and give the **launch-URL** layer a parallel single helper (see the deferred plan) so runtime precedence is as centralized as startup precedence.
 
-**Role of `ejamapp()` alias handling** (the user asked about this): before the merge, `ejamapp()` normalizes a set of **convenience aliases** on its `...` dots and, for some, **cross-sets related defaults** so a one-liner "just works." Examples (`R/ejamapp.R ~275-388`):
-- `pts` → `sitepoints`; `lat`+`lon` → `sitepoints`; and `sitepoints` ⇒ also sets `default_upload_dropdown="upload"`, `default_selected_type_of_site_upload="latlon"`.
-- `shp` → `shapefile`; and `shapefile` ⇒ `default_upload_dropdown="upload"`, `…upload="SHP"`.
-- `fips` ⇒ `default_upload_dropdown="upload"`, `…upload="FIPS"`.
-- `naics` → `default_naics`; and `default_naics` ⇒ `default_upload_dropdown="dropdown"`, `…category="NAICS"`. Similarly `sic`/`mact`.
+**Role of `ejamapp()` alias handling** (the user asked about this): before the merge, `ejamapp()` normalizes a set of **convenience aliases** on its `...` dots and, for some, **cross-sets related defaults** so a one-liner "just works." (The site-selection method param is now `default_site_method`; the former name `default_upload_dropdown` still works as a back-compat alias.) Examples (`R/ejamapp.R ~275-388`):
+- `pts` → `sitepoints`; `lat`+`lon` → `sitepoints`; and `sitepoints` ⇒ also sets `default_site_method="upload"`, `default_selected_type_of_site_upload="latlon"`.
+- `shp` → `shapefile`; and `shapefile` ⇒ `default_site_method="upload"`, `…upload="SHP"`.
+- `fips` ⇒ `default_site_method="upload"`, `…upload="FIPS"`.
+- `naics` → `default_naics`; and `default_naics` ⇒ `default_site_method="dropdown"`, `…category="NAICS"`. Similarly `sic`/`mact`.
 - `radius`/`default_radius`; `report_title`/`default_report_title`/`default_report_title_multisite`; `analysis_title`/`default_analysis_title`; `testing`; etc.
-This is a **third param-setting concern** (alias normalization + dependent-default inference) that runs *upstream* of the merge. It is convenient and mostly good, but it is also where some of the "many ways to set the same thing" feeling comes from — e.g. the method (`default_upload_dropdown`) can be set directly, or implicitly via `fips`/`shp`/`pts`/`naics`/`sitepoints`/`shapefile`. Worth documenting the alias table in one place.
+This is a **third param-setting concern** (alias normalization + dependent-default inference) that runs *upstream* of the merge. It is convenient and mostly good, but it is also where some of the "many ways to set the same thing" feeling comes from — e.g. the method (`default_site_method`) can be set directly, or implicitly via `fips`/`shp`/`pts`/`naics`/`sitepoints`/`shapefile`. Worth documenting the alias table in one place.
 
 ### Runtime overrides (each wired separately — this is where harmonization helps)
 
@@ -106,7 +106,7 @@ Layers 3–4 are consolidated and consistent (via `get_global_defaults_or_user_o
 | `naics_digits_shown` (`app_server.R:~261`) | an `observe` resets it whenever `default_naics` changes — silently overrides a user's manual pick | low |
 | `default_naics` / `default_sic` | belt-and-suspenders: Category-C server populate that re-fetches the same `global_or_param` the static UI "knows" — confusing but harmless | low |
 | Launch-URL `%||%` precedence (#413) | repeated per-reactive instead of one helper → easy to apply inconsistently as more URL params are added | medium (growing) |
-| `default_upload_dropdown` name | now selects 3 methods (dropdown / upload / mapclick) — the name is a misnomer | cosmetic |
+| `default_upload_dropdown` name | selected 3 methods (dropdown / upload / mapclick) — the name was a misnomer; **renamed to `default_site_method`** (old name kept as a back-compat alias) | resolved |
 
 ---
 

--- a/data-raw/refactoring_app_settings_analysis.md
+++ b/data-raw/refactoring_app_settings_analysis.md
@@ -82,7 +82,7 @@ This is a **third param-setting concern** (alias normalization + dependent-defau
 |---|---|---|---|
 | **Advanced-tab → main control** | `observeEvent(input$default_ss_choose_method, updateRadioButtons('ss_choose_method', …))` and similar | app_server.R | ad hoc per control |
 | **Shiny native bookmarking** | `enableBookmarking='url'` (default in `ejamapp()`); `bookmarkButton()`; `?_inputs_&id=val…` restores all `input$` on load | ejamapp.R, app_ui.R | framework-level; only `input$` vars; no `onBookmark`/`onRestore` customization yet |
-| **Launch-URL custom params** (PR #413, *not on this branch yet*) | parse `session$clientData$url_search`; `url_*()` reactiveVals; precedence via `url_x() %||% global_or_param("x")` in each `data_up_*` reactive; also `update*Input` to reflect in UI | app_server.R on `ejscreen-multisite-selection` | **ad hoc** — repeated `%||%` per reactive; precedence not centralized |
+| **Launch-URL custom params** (PR #413, now merged to `development`) | parse `session$clientData$url_search`; `url_*()` reactiveVals; precedence resolved by `global_or_shinyparam_or_urlparam()` in each `data_up_*` reactive; also `update*Input` to reflect in UI | app_server.R | **now centralized** via the `global_or_shinyparam_or_urlparam()` helper (Item 1) |
 
 ---
 

--- a/data-raw/refactoring_app_settings_plan.md
+++ b/data-raw/refactoring_app_settings_plan.md
@@ -1,20 +1,19 @@
 # Plan — `refactoring_app_settings`
 
-Branch `refactoring_app_settings`, based on `development`.
-Worktree: `/Users/markcorrales/R PACKAGES/EJAM-refactoring-app-settings`.
+Branch `refactoring_app_settings`, based on `development` (developed in a dedicated git worktree).
 Companion analysis: [`refactoring_app_settings_analysis.md`](refactoring_app_settings_analysis.md) (full two-axis audit of how app settings get set).
 
 Goal: targeted harmonization of how the EJAM web-app gets its input defaults/values — **not a rewrite**. The architecture (two orthogonal axes: how the widget is built A/B/C × where the value comes from) is sound. We clean up ~5 specific spots.
 
 ---
 
-## STATUS: plan committed, all code ON HOLD (decided 2026-06-28)
+## STATUS: IMPLEMENTED (2026-06-30)
 
-User decision: **do the plan only; hold ALL code changes** until BOTH PR #418 and PR #413
-are merged into `development`, then do the whole refactor in one pass on a clean baseline
-(so nothing collides with the owner's open PRs). The Wave 1 / Wave 2 split below is retained
-for reference, but with this decision there is effectively a single wave AFTER the PRs land.
-Resume trigger: #418 and #413 both merged into `development`.
+All items below are implemented in this branch, rebased on `development` after PRs #418
+(mapclick) and #413 (launch-URL) both merged. The plan originally held all code until those
+two PRs landed (to avoid colliding with the owner's open PRs); that gate has cleared, so the
+Wave 1 / Wave 2 split below is now **historical context only** — everything was done in one
+pass on the clean baseline.
 
 ---
 

--- a/data-raw/refactoring_app_settings_plan.md
+++ b/data-raw/refactoring_app_settings_plan.md
@@ -8,6 +8,16 @@ Goal: targeted harmonization of how the EJAM web-app gets its input defaults/val
 
 ---
 
+## STATUS: plan committed, all code ON HOLD (decided 2026-06-28)
+
+User decision: **do the plan only; hold ALL code changes** until BOTH PR #418 and PR #413
+are merged into `development`, then do the whole refactor in one pass on a clean baseline
+(so nothing collides with the owner's open PRs). The Wave 1 / Wave 2 split below is retained
+for reference, but with this decision there is effectively a single wave AFTER the PRs land.
+Resume trigger: #418 and #413 both merged into `development`.
+
+---
+
 ## Sequencing constraint (READ FIRST)
 
 This branch is downstream of two OPEN PRs into `development`:

--- a/data-raw/refactoring_app_settings_plan.md
+++ b/data-raw/refactoring_app_settings_plan.md
@@ -1,0 +1,61 @@
+# Plan — `refactoring_app_settings`
+
+Branch `refactoring_app_settings`, based on `development`.
+Worktree: `/Users/markcorrales/R PACKAGES/EJAM-refactoring-app-settings`.
+Companion analysis: [`refactoring_app_settings_analysis.md`](refactoring_app_settings_analysis.md) (full two-axis audit of how app settings get set).
+
+Goal: targeted harmonization of how the EJAM web-app gets its input defaults/values — **not a rewrite**. The architecture (two orthogonal axes: how the widget is built A/B/C × where the value comes from) is sound. We clean up ~5 specific spots.
+
+---
+
+## Sequencing constraint (READ FIRST)
+
+This branch is downstream of two OPEN PRs into `development`:
+
+- **PR #418** `mapclick-app-integration` — already removes the dead Design-B `ss_choose_method_ui` renderUI, adds the `observeEvent(input$default_ss_choose_method, updateRadioButtons('ss_choose_method', …))` sync, and adds the `mapclick` choice. **It edits the exact lines our Item 2 touches.**
+- **PR #413** `ejscreen-multisite-selection` — introduces the launch-URL `url_*` reactives and `url_x() %||% global_or_param("x")` pattern. **Our Item 1 helper has nothing to wire to until this lands.**
+
+Because we base on `development` (where neither PR is merged yet), the items split into two waves:
+
+**Wave 1 — conflict-free, do now:**
+- Item 3 — fix the two anti-patterns (`max_mb_upload_react`, `naics_digits_shown`).
+- Item 1a — *define* the `global_or_shinyparam_or_urlparam` helper additively in `R/utils_global_or_param.R` (safe: degrades to `global_or_param` when no URL params exist). Do NOT rewire call sites yet.
+- Item 5 — documentation pass (`vignettes/dev-app-settings.Rmd`): two-axis model, alias table, precedence stack.
+
+**Wave 2 — hold until #418 and #413 merge into `development`, then rebase:**
+- Item 1b — replace ad-hoc `%||%` chains at the `url_*` call sites with the helper.
+- Item 2 — consolidate the `ss_choose_method` writers into one precedence-ordered observer (builds on #418's already-cleaned baseline).
+- Item 4 — rename `default_upload_dropdown` → `default_site_method` with back-compat alias (touches #418's mapclick handling; safer once #418 is in).
+
+This ordering avoids guaranteed merge conflicts with the repo owner's own open PRs.
+
+---
+
+## Items (from the analysis report's deferred plan)
+
+### Item 1 — centralize launch-URL precedence
+Add `global_or_shinyparam_or_urlparam(name)` in `R/utils_global_or_param.R`, returning `url_param(name) %||% global_or_param(name)` (launch-URL value wins over ejamapp/global default). Replace hand-written `%||%` chains at the `url_*` call sites (from #413). Defines layer-2 precedence in one place.
+- 1a (Wave 1): define helper, degrade gracefully when `url_param` / URL params absent.
+- 1b (Wave 2): rewire call sites after #413 merges.
+
+### Item 2 — consolidate `ss_choose_method` writers (Wave 2)
+Today the radio has multiple writers: the advanced-tab sync plus three `="upload"` updates from shapefile/sitepoints/fips ejamapp params (last-writer-wins, no documented precedence). Consolidate into one observer with explicit, commented precedence: **URL > ejamapp data param > advanced-tab > static**.
+*User flagged: good but tricky — do carefully, double-check.* Build on #418's cleaned baseline (no dead renderUI; `mapclick` present).
+
+### Item 3 — fix the two anti-patterns (Wave 1)
+- `max_mb_upload_react` (`app_server.R:~202`): a `reactive()` that calls `updateNumericInput()` inside itself (side-effect in a reactive). Split into `observe`-writes (clamp + update the widget) and a pure `reactive`-read for `shiny.maxRequestSize`.
+- `naics_digits_shown` (`app_server.R:~261`): an `observe` resets it whenever `default_naics` changes, silently overriding a user's manual pick. Make it respect a user override (only force `detailed` when a detailed `default_naics` requires it; otherwise don't clobber).
+
+### Item 4 — rename `default_upload_dropdown` → `default_site_method` (Wave 2)
+The value now selects dropdown / upload / mapclick, so the name is a misnomer. Rename with a back-compat alias so existing `ejamapp()` calls, bookmarks, and URLs keep working. Touch points: `R/ejamapp.R`, `R/app_server.R`, `R/app_ui.R`, `inst/global_defaults_shiny*.R`, `vignettes/dev-app-settings.Rmd`, regenerate `man/`.
+*User flagged: good but tricky — do extremely carefully; keep the alias.*
+
+### Item 5 — documentation pass (Wave 1)
+`vignettes/dev-app-settings.Rmd` ("Defaults and Custom Settings for the Web App"): document the two-axis model, the `ejamapp()` alias table, and the precedence stack (incl. launch-URL once #413 merges, and the renamed param once Item 4 lands).
+
+---
+
+## Test / verification notes
+- Adding/renaming any `tests/testthat/` file requires updating `R/test_ejam.R` group lists + timing (no auto-discovery).
+- Item 3 and Item 2 are behavioral — add/adjust tests where feasible and smoke-test the app launch.
+- Item 4 alias: add a test that an old `ejamapp(default_upload_dropdown=...)` call still resolves.

--- a/inst/global_defaults_shiny.R
+++ b/inst/global_defaults_shiny.R
@@ -118,8 +118,9 @@ msg <- utils::capture.output({
 
     # method of site selection: "dropdown" (select a category), "upload" (upload a file of
     # points/IDs/FIPS/shapefile), or "mapclick" (click or draw on the map to specify points)
-    default_upload_dropdown = "upload",
-    # global_default or ejamapp() parameter: default_upload_dropdown, which is the initial selected value of
+    default_site_method = "upload",
+    # global_default or ejamapp() parameter: default_site_method (formerly named default_upload_dropdown,
+    # which still works as a back-compat alias), which is the initial selected value of
     # input in advanced tab: input$default_ss_choose_method, which (via updateRadioButtons in the server) sets
     # input in server:              input$ss_choose_method
 

--- a/inst/global_defaults_shiny_public.R
+++ b/inst/global_defaults_shiny_public.R
@@ -58,7 +58,7 @@ global_defaults_shiny_public <- list(
   ############################################################################## #
 
   ## SITE SELECTION  ####
-  ## The top-level method is chosen by default_upload_dropdown: "dropdown" (select a category),
+  ## The top-level method is chosen by default_site_method: "dropdown" (select a category),
   ## "upload" (upload a file), or "mapclick" (click or draw on the map to specify points).
   ## The default_choices_* settings below configure the sub-options for the "dropdown" and
   ## "upload" methods only; the "mapclick" method has no sub-options.
@@ -70,7 +70,7 @@ global_defaults_shiny_public <- list(
   ## default_choices_for_type_of_site_category defines the range of options
   ## If you want all the options available but want the app to default to NAICS, in ejamapp() use these params:
   # ejamapp(
-  #   default_upload_dropdown = "dropdown",
+  #   default_site_method = "dropdown",
   #   default_choices_for_type_of_site_category = c(
   #     'by Industry (NAICS) Code' = 'NAICS',
   #     'by Census place name (Cities, Counties, States)' = 'FIPS_PLACE',
@@ -109,7 +109,7 @@ global_defaults_shiny_public <- list(
   ## If you want all the options available but want the app to default to polygons, in ejamapp() use these params:
   #
   # ejamapp(
-  #   default_upload_dropdown = "upload",
+  #   default_site_method = "upload",
   #   default_choices_for_type_of_site_upload = c(
   #     'Shapefile of polygons file upload'              = 'SHP',
   #     'Latitude/Longitude file upload'                 = 'latlon',

--- a/man/app_run_EJAM.Rd
+++ b/man/app_run_EJAM.Rd
@@ -173,7 +173,7 @@ ejamapp(
   ## Cities dropdown list as default shown at launch:
 
 ejamapp(
-  default_upload_dropdown = "dropdown",
+  default_site_method = "dropdown",
   default_selected_type_of_site_category = "FIPS_PLACE",
   fipspicker_fips_type2pick_default = "Cities or Places"
 )
@@ -181,7 +181,7 @@ ejamapp(
   ## Specific cities are preselected at launch
 
   ejamapp(
-  default_upload_dropdown = "dropdown",
+  default_site_method = "dropdown",
   default_selected_type_of_site_category = "FIPS_PLACE",
   fipspicker_fips_type2pick_default = "Cities or Places",
   default_cities_picked = name2fips(c("akutan,ak", "syracuse city,ny") )
@@ -202,7 +202,7 @@ ejamapp(
   ## Polygons upload as the default shown at launch:
 
 ejamapp(
-  default_upload_dropdown = "upload",
+  default_site_method = "upload",
   default_selected_type_of_site_upload = "SHP"
 )
   #default_choices_for_type_of_site_upload = c(
@@ -215,10 +215,11 @@ ejamapp(
 
   ## Click-or-draw-on-map as the default site-selection method shown at launch.
   ## The user clicks the map to specify one or more lat/lon points to analyze.
-  ## (default_upload_dropdown accepts "dropdown", "upload", or "mapclick".)
+  ## (default_site_method accepts "dropdown", "upload", or "mapclick".
+  ##  It was formerly named default_upload_dropdown, which still works as an alias.)
 
 ejamapp(
-  default_upload_dropdown = "mapclick"
+  default_site_method = "mapclick"
 )
 
  ## Count how many of some indicator are >= some cutoff

--- a/man/ejamapp.Rd
+++ b/man/ejamapp.Rd
@@ -173,7 +173,7 @@ ejamapp(
   ## Cities dropdown list as default shown at launch:
 
 ejamapp(
-  default_upload_dropdown = "dropdown",
+  default_site_method = "dropdown",
   default_selected_type_of_site_category = "FIPS_PLACE",
   fipspicker_fips_type2pick_default = "Cities or Places"
 )
@@ -181,7 +181,7 @@ ejamapp(
   ## Specific cities are preselected at launch
 
   ejamapp(
-  default_upload_dropdown = "dropdown",
+  default_site_method = "dropdown",
   default_selected_type_of_site_category = "FIPS_PLACE",
   fipspicker_fips_type2pick_default = "Cities or Places",
   default_cities_picked = name2fips(c("akutan,ak", "syracuse city,ny") )
@@ -202,7 +202,7 @@ ejamapp(
   ## Polygons upload as the default shown at launch:
 
 ejamapp(
-  default_upload_dropdown = "upload",
+  default_site_method = "upload",
   default_selected_type_of_site_upload = "SHP"
 )
   #default_choices_for_type_of_site_upload = c(
@@ -215,10 +215,11 @@ ejamapp(
 
   ## Click-or-draw-on-map as the default site-selection method shown at launch.
   ## The user clicks the map to specify one or more lat/lon points to analyze.
-  ## (default_upload_dropdown accepts "dropdown", "upload", or "mapclick".)
+  ## (default_site_method accepts "dropdown", "upload", or "mapclick".
+  ##  It was formerly named default_upload_dropdown, which still works as an alias.)
 
 ejamapp(
-  default_upload_dropdown = "mapclick"
+  default_site_method = "mapclick"
 )
 
  ## Count how many of some indicator are >= some cutoff

--- a/man/run_app.Rd
+++ b/man/run_app.Rd
@@ -173,7 +173,7 @@ ejamapp(
   ## Cities dropdown list as default shown at launch:
 
 ejamapp(
-  default_upload_dropdown = "dropdown",
+  default_site_method = "dropdown",
   default_selected_type_of_site_category = "FIPS_PLACE",
   fipspicker_fips_type2pick_default = "Cities or Places"
 )
@@ -181,7 +181,7 @@ ejamapp(
   ## Specific cities are preselected at launch
 
   ejamapp(
-  default_upload_dropdown = "dropdown",
+  default_site_method = "dropdown",
   default_selected_type_of_site_category = "FIPS_PLACE",
   fipspicker_fips_type2pick_default = "Cities or Places",
   default_cities_picked = name2fips(c("akutan,ak", "syracuse city,ny") )
@@ -202,7 +202,7 @@ ejamapp(
   ## Polygons upload as the default shown at launch:
 
 ejamapp(
-  default_upload_dropdown = "upload",
+  default_site_method = "upload",
   default_selected_type_of_site_upload = "SHP"
 )
   #default_choices_for_type_of_site_upload = c(
@@ -215,10 +215,11 @@ ejamapp(
 
   ## Click-or-draw-on-map as the default site-selection method shown at launch.
   ## The user clicks the map to specify one or more lat/lon points to analyze.
-  ## (default_upload_dropdown accepts "dropdown", "upload", or "mapclick".)
+  ## (default_site_method accepts "dropdown", "upload", or "mapclick".
+  ##  It was formerly named default_upload_dropdown, which still works as an alias.)
 
 ejamapp(
-  default_upload_dropdown = "mapclick"
+  default_site_method = "mapclick"
 )
 
  ## Count how many of some indicator are >= some cutoff

--- a/tests/testthat/test-webapp-ui_and_server.R
+++ b/tests/testthat/test-webapp-ui_and_server.R
@@ -281,6 +281,61 @@ test_that("app_server validates invalid FRS uploads without falling through to s
 })
 ################################################# #
 
+test_that("app_server override latch: a programmatic set_site_method() write does not latch, but a real user change of the main radio does", {
+  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
+  ## Item 2 regression (PR #420): set_site_method() records its own writes in site_method_last_set so the
+  ## ss_choose_method observer can tell a programmatic update apart from a real user click. Only a user
+  ## click latches site_method_user_override, which then protects the pick from the layer-2
+  ## belt-and-suspenders ejamapp writes (each guarded by if (!site_method_user_override())).
+  ## Mock global_or_param for the hide-tab flags so app_server init runs in testServer (same
+  ## workaround the other testServer tests in this file use; golem_options isn't visible here).
+  orig_global_or_param <- EJAM:::global_or_param
+  local_mocked_bindings(
+    global_or_param = function(vname) {
+      if (vname %in% c("default_hide_about_tab", "default_hide_written_report",
+                       "default_hide_plot_barplot_tab", "default_hide_plot_histo_tab")) {
+        return(FALSE)
+      }
+      orig_global_or_param(vname)
+    },
+    .package = "EJAM"
+  )
+  testServer(app = app_server, expr = {
+    session$setInputs(testing = FALSE)
+    expect_false(site_method_user_override())                # no override at start
+
+    set_site_method("upload", source = "test-programmatic")  # our own write -> records site_method_last_set("upload")
+    session$setInputs(ss_choose_method = "upload")           # simulated radio round-trip to that same value
+    expect_false(site_method_user_override())                # value == last_set -> NOT treated as a user change
+
+    session$setInputs(ss_choose_method = "dropdown")         # user changes the MAIN radio to a different value
+    expect_true(site_method_user_override())                 # latched -> now protected from layer-2 clobber
+  })
+})
+################################################# #
+
+test_that("app_server override latch: an advanced-tab Site Selection Method pick latches the override", {
+  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
+  orig_global_or_param <- EJAM:::global_or_param
+  local_mocked_bindings(
+    global_or_param = function(vname) {
+      if (vname %in% c("default_hide_about_tab", "default_hide_written_report",
+                       "default_hide_plot_barplot_tab", "default_hide_plot_histo_tab")) {
+        return(FALSE)
+      }
+      orig_global_or_param(vname)
+    },
+    .package = "EJAM"
+  )
+  testServer(app = app_server, expr = {
+    session$setInputs(testing = FALSE)
+    expect_false(site_method_user_override())
+    session$setInputs(default_ss_choose_method = "upload")   # advanced-tab radio = explicit runtime choice (layer 3)
+    expect_true(site_method_user_override())
+  })
+})
+################################################# #
+
 test_that("shinytest category selection waits for input values and saves failure logs", {
   setup_file <- testthat::test_path("setup-shinytest2.R")
   setup_lines <- readLines(setup_file, warn = FALSE)

--- a/tests/testthat/test-webapp-ui_and_server.R
+++ b/tests/testthat/test-webapp-ui_and_server.R
@@ -430,3 +430,27 @@ rm(global_defaults_or_user_options)
 
 
 ################################################# #
+# Item 4: default_site_method back-compat alias (param renamed from default_upload_dropdown) #
+
+test_that("global_or_param() resolves default_upload_dropdown as a back-compat alias for default_site_method", {
+  prev <- shiny::getShinyOption("golem_options")
+  on.exit(shiny::shinyOptions(golem_options = prev), add = TRUE)
+
+  # only the OLD key is set -> the new name still resolves (alias fallback)
+  shiny::shinyOptions(golem_options = list(default_upload_dropdown = "dropdown"))
+  expect_equal(EJAM:::global_or_param("default_site_method"), "dropdown")
+
+  # the NEW key is set -> resolves directly
+  shiny::shinyOptions(golem_options = list(default_site_method = "upload"))
+  expect_equal(EJAM:::global_or_param("default_site_method"), "upload")
+
+  # both set -> the new (canonical) key wins over the old alias
+  shiny::shinyOptions(golem_options = list(default_site_method = "mapclick", default_upload_dropdown = "dropdown"))
+  expect_equal(EJAM:::global_or_param("default_site_method"), "mapclick")
+
+  # a name with no alias is unaffected (no spurious fallback) -> NULL when unset
+  shiny::shinyOptions(golem_options = list())
+  expect_null(EJAM:::global_or_param("a_param_with_no_such_name_xyz"))
+})
+
+################################################# #

--- a/vignettes/dev-app-settings.Rmd
+++ b/vignettes/dev-app-settings.Rmd
@@ -153,8 +153,8 @@ any user-specified versions of those options given as arguments in `ejamapp()`.
 infers related defaults. For example `pts` (or `lat`+`lon`) is an alias for `sitepoints`, `shp` is
 an alias for `shapefile`, and `naics`/`sic`/`mact` are aliases for `default_naics`/etc. Some of these
 also set the method automatically -- e.g. passing `fips`, `shapefile`, or `sitepoints` sets
-`default_upload_dropdown = "upload"` (and the upload sub-type), while `default_naics` sets
-`default_upload_dropdown = "dropdown"`. See `?ejamapp` and the alias-handling block near the top of
+`default_site_method = "upload"` (and the upload sub-type), while `default_naics` sets
+`default_site_method = "dropdown"`. See `?ejamapp` and the alias-handling block near the top of
 `R/ejamapp.R`.
 
 ### app launch
@@ -295,7 +295,7 @@ One such example:
 ```{r run-app, eval=FALSE}
 ejamapp(
   default_standard_analysis_title="Custom NAICS Analysis",
-  default_upload_dropdown="dropdown",
+  default_site_method="dropdown",
   default_selected_type_of_site_category="NAICS",
   default_naics_digits_shown="detailed",
   default_naics="562211",
@@ -337,7 +337,7 @@ Launch using parameters that are saved in a named vector or list
 ```{r run-with-paramlist, eval=FALSE}
 myparams <- c(
   default_standard_analysis_title="Custom NAICS Analysis",
-  default_upload_dropdown="dropdown",
+  default_site_method="dropdown",
   default_selected_type_of_site_category="NAICS",
   default_naics_digits_shown="detailed",
   default_naics="562211",
@@ -354,7 +354,7 @@ Save a custom reusable function you can use to launch with preset parameters
 
 myparams <- c(
   default_standard_analysis_title="Custom NAICS Analysis",
-  default_upload_dropdown="dropdown",
+  default_site_method="dropdown",
   default_selected_type_of_site_category="NAICS",
   default_naics_digits_shown="detailed",
   default_naics="562211",
@@ -432,7 +432,7 @@ myparams <- c(
 )
 
 params <- c('standard_analysis_title="Custom NAICS Analysis"',
-            'ss_choose_method="dropdown"',   # like ejamapp( default_upload_dropdown="dropdown" )
+            'ss_choose_method="dropdown"',   # like ejamapp( default_site_method="dropdown" )
             'ss_choose_method_drop="NAICS"', # see ?ejamapp()
             'naics_digits_shown="detailed"', # like ejamapp( default_naics_digits_shown = "detailed")
             # 'ss_select_naics=313',           # like ejamapp(default_naics=313)

--- a/vignettes/dev-app-settings.Rmd
+++ b/vignettes/dev-app-settings.Rmd
@@ -157,6 +157,21 @@ also set the method automatically -- e.g. passing `fips`, `shapefile`, or `sitep
 `default_site_method = "dropdown"`. See `?ejamapp` and the alias-handling block near the top of
 `R/ejamapp.R`.
 
+The aliases and the defaults they cross-set (kept in sync with the alias block near the top of `R/ejamapp.R`):
+
+| You pass to `ejamapp()` | Canonical param | Also cross-sets |
+|---|---|---|
+| `pts`, or `lat`+`lon` | `sitepoints` | `default_site_method="upload"`, `default_selected_type_of_site_upload="latlon"` |
+| `shp` or `shape` | `shapefile` | `default_site_method="upload"`, `default_selected_type_of_site_upload="SHP"` |
+| `shapefile` | `shapefile` | `default_site_method="upload"`, `default_selected_type_of_site_upload="SHP"` |
+| `fips` | `fips` | `default_site_method="upload"`, `default_selected_type_of_site_upload="FIPS"` |
+| `naics` | `default_naics` | `default_site_method="dropdown"`, `default_selected_type_of_site_category="NAICS"`, `default_naics_digits_shown="detailed"` |
+| `sic` | `default_sic` | `default_site_method="dropdown"`, `default_selected_type_of_site_category="SIC"` |
+| `mact` | `default_mact` | `default_site_method="dropdown"`, `default_selected_type_of_site_category="MACT"` |
+
+The site-selection method param `default_site_method` was formerly named `default_upload_dropdown`;
+the old name still works as a back-compat alias (normalized to the new name inside `ejamapp()`).
+
 ### app launch
 
 `ejamapp()` launches the app -- it uses a function called `golem::with_golem_options()`, 
@@ -199,13 +214,31 @@ Beyond `ejamapp()` params and the global_defaults_ files, the app can also read 
 
 ### how an input control actually gets its default
 
-Because the UI is built once before any reactive `input$` exists, a control's `selected=`/`value=` in
-`app_ui.R` must be a **non-reactive** value -- `global_or_param("...")` -- not `input$...`. Controls
-whose choices load server-side (large selectize lists like NAICS/SIC/MACT) or whose value must change
-in response to an event (Advanced-Tab sync, upload→method switch) are instead populated from the
-server via `update*Input()`. A few controls whose structure is itself reactive (e.g. the radius
-slider) are built server-side with `renderUI()`. The precedence order, top to bottom, is: Shiny
-bookmark `?_inputs_&` > launch-URL custom param > `ejamapp()` param > `global_defaults_*.R`.
+Two orthogonal things determine an input control: **(Axis 1) how the widget is built**, and
+**(Axis 2) where its value comes from**.
+
+**Axis 1 -- how the widget is built** (a UI-mechanics choice, almost always forced by the widget, not stylistic):
+
+| Pattern | Use when | Example |
+|---|---|---|
+| **A. static UI default** -- `selected=`/`value=` set in `app_ui.R` to `global_or_param("...")` | the default is a plain value known at page-load, with a fixed choice set | most controls |
+| **B. server `renderUI`** (`uiOutput()` in UI + `output$x <- renderUI({...})`) | the widget's *structure* (which choices exist, min/max, conditional sub-controls) depends on reactive state | radius slider (`radius_now`) |
+| **C. static-empty UI + server `update*Input()`** | choices load server-side (large selectize lists) OR the value must change on a later event | NAICS/SIC/MACT selectize; advanced-tab -> main-control sync |
+
+Because the UI is built once before any reactive `input$` exists, an Axis-1-A control's `selected=`/`value=`
+must be a **non-reactive** value -- `global_or_param("...")` -- never `input$...` (that errors at UI build).
+To make an advanced-tab setting change a main control, sync it server-side via `update*Input()` (Axis-1-C).
+
+**Axis 2 -- where the value comes from** (the precedence stack, highest wins):
+
+1. **Shiny bookmark** `?_inputs_&...` -- restores saved `input$` values on load (framework-level; orthogonal to the rest).
+2. **Launch-URL custom params** `?lat=&lon=`, `?fips=`, `?shape=`, `?handoff=`, `?radius=` -- read via the `url_*`
+   reactives and resolved by `global_or_shinyparam_or_urlparam(name)`, so a launch-URL value wins over the default.
+3. **`ejamapp()` params** (after alias normalization) -- override the global-default files.
+4. **`global_defaults_*.R`** files (package < shiny < shiny_public).
+
+The advanced-tab -> main-control sync sits *alongside* this stack: it applies a user's runtime change after load
+(e.g. the "Site Selection Method" radio updates `ss_choose_method` via `update*Input()`).
 
 To view the Advanced tab in the web app, click the About tab and then the Show advanced button on that page. If that button is not visible, use ejamapp(default_can_show_advanced_settings=TRUE). To show the advanced tab at launch, use ejamapp(default_show_advanced_settings=TRUE).
 


### PR DESCRIPTION
Targeted harmonization of how the EJAM web app gets its input defaults/values — **not a rewrite**. The two-axis architecture (how a widget is built × where its value comes from) is sound; this cleans up ~5 specific spots identified in the committed analysis. Unblocked now that #418 (mapclick) and #413 (launch-URL) are both in `development`; rebased on the current tip.

Plan + audit: `data-raw/refactoring_app_settings_plan.md` and `data-raw/refactoring_app_settings_analysis.md` (included in this branch).

## Changes

- **Item 2 — consolidate `ss_choose_method` writers** (`app_server.R`). All non-static writers (advanced-tab sync, the 3 launch-URL paths, the 3 ejamapp data-param belt-and-suspenders) now go through one `set_site_method()` helper with documented precedence **URL > ejamapp-data-param > advanced-tab > static**. **Bugfix:** a `site_method_user_override` latch stops the lazy belt-and-suspenders writes from clobbering an explicit runtime method change (previously last-writer-wins).

- **Item 3 — fix two anti-patterns** (`app_server.R`).
  - `max_mb_upload_react` is now a pure reactive (read + clamp, no side-effect); the `updateNumericInput()` side-effect moved into the adjacent `observe` alongside `shiny.maxRequestSize` + file-input resets. Behavior-identical (same value, same trigger, same dedup-driven settling).
  - The `naics_digits_shown` observe now only **forces** `"detailed"` when `default_naics` contains a >3-digit code (a visibility requirement); otherwise it leaves the radio alone. **Bugfix:** no longer clobbers a user's manual pick on every `default_naics` change.

- **Item 1 — centralize launch-URL precedence** (`app_server.R`). Added `url_param()` + `global_or_shinyparam_or_urlparam()` closures and rewired the 3 `url_*() %||% global_or_param()` call sites (`data_up_shp/latlon/fips`). Behavior-identical — the helper expands to exactly `url_X() %||% global_or_param("X")`. (Closures live in the server fn because the `url_*` reactiveVals are local there.)

- **Item 4 — rename `default_upload_dropdown` → `default_site_method`** (the param now selects dropdown/upload/mapclick) **with a back-compat alias**. `ejamapp()` normalizes the old name → new before alias inference; `global_or_param()` falls back to the old key (no-op for any non-aliased name); `inst/global_defaults_shiny.R` key + UI reads updated; `man/` regenerated from roxygen. Old `ejamapp(default_upload_dropdown=…)` calls, bookmarks, and user `global_defaults` files keep working.

- **Item 5 — docs pass** (`vignettes/dev-app-settings.Rmd`): the two-axis model (A/B/C widget construction × value-source precedence stack), an `ejamapp()` alias lookup table, and the `default_site_method` rename note.

## Verification
- `devtools::load_all()` clean; `R/app_server.R`, `app_ui.R`, `ejamapp.R`, `utils_global_or_param.R` parse.
- `tests/testthat/test-webapp-ui_and_server.R` passes (0 failed; the `testServer(app_server)` tests exercise these paths) and gains a new `global_or_param()` alias unit test.
- End-to-end: the startup pipeline carries `default_site_method = "upload"` and drops the old key; the `ejamapp()` shim normalizes old→new.
- Adversarial multi-lens review (behavior-preservation, reactive-safety, back-compat, integration) with independent verification of each finding: **0 confirmed regressions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
