### PR TITLE
docs(url_ejamapi): drop WIP note, fix API repo URL, clarify sitenumber

### DIFF
--- a/R/ejamapi.R
+++ b/R/ejamapi.R
@@ -45,8 +45,8 @@
 #'   Like the sitepoints param in [url_ejamapi()]
 #'
 #' @param shape,shapefile  Only one of these should be provided - they are synonymous.
-#'   A GeoJSON string representing the area of interest,
-#'   like shapefile param in [url_ejamapi()]
+#'   The area of interest, as either an `sf` polygon object (auto-converted to GeoJSON) or a
+#'   ready-made GeoJSON string, like the shapefile param in [url_ejamapi()].
 #' @param shp alias (synonym) for shapefile/shape
 #' @param fips A FIPS code for a specific US Census geography, like "050014801001",
 #'   and must be consistent with the scale parameter
@@ -65,7 +65,9 @@
 #'   that is found within the specified fips. For example, all counties in specified State fips,
 #'   or all blockgroups in specified County fips.
 #'
-#' @param baseurl base API URL without the endpoint path
+#' @param baseurl base API URL without the endpoint path. Defaults to [url_package()] with
+#'   type="api" (the DESCRIPTION `ejam_api_url`), the single source of the API endpoint; pass a
+#'   different value only to target another API (e.g. a staging server).
 #'
 #' @param endpoint "data", "report", or "query".
 #'
@@ -206,7 +208,7 @@ ejamapi <- function(
 ) {
   # shp is an alias (synonym) for shape/shapefile
   if (is.null(shape) && is.null(shapefile) && !is.null(shp)) {shape <- shp}
-  # API repo at https://github.com/edgi-govdata-archiving/EJAM-API/blob/main/rest_controller.r
+  # API repo at https://github.com/Public-Environmental-Data-Partners/EJAM-API/blob/main/rest_controller.r
 
   ############################################################## #
 

--- a/R/url_ejamapi.R
+++ b/R/url_ejamapi.R
@@ -1,7 +1,7 @@
 
 
 #' Get URL(s) of HTML summary reports for use with EJAM-API
-#' @seealso [ejamapi()] [url_ejamapp()]
+#' @seealso [ejamapi()] [url_ejamapp()] [url_package()]
 #' @details
 #' - Relies on the EJAM REST API, whose source code is at
 #'   https://github.com/Public-Environmental-Data-Partners/EJAM-API
@@ -12,7 +12,9 @@
 #'   pre-loaded with sites, see [url_ejamapp()], which uses the same query
 #'   vocabulary (lat, lon, fips, shape, radius, handoff).
 #'
-#' - Will try to use the same input parameters as [ejamit()] does.
+#' - Accepts a subset of [ejamit()]'s input-parameter names (sitepoints, lat, lon, radius,
+#'   fips, shapefile); it does not accept every [ejamit()]/[ejam2report()] option (see the
+#'   note below on unsupported options).
 #'
 #' - The API honors the `sitenumber` parameter passed through to [ejam2report()]:
 #'   `sitenumber = 1` requests a single-site report (the API's per-request default when
@@ -28,16 +30,20 @@
 #'
 #' @param sitepoints see [ejamit()]
 #' @param lat,lon can be provided as vectors of coordinates instead of providing sitepoints table
-#' @param radius  see [ejamit()], default is 0 if fips or shapefile specified
+#' @param radius  analysis radius in miles; see [ejamit()]. Default is 3 miles for point
+#'   (lat/lon/sitepoints) analysis, but 0 (no buffer) when fips or shapefile is specified.
 #'
 #' @param fips  see [ejamit()]
 #'
 #' @param shapefile  see [ejamit()], but each polygon is encoded as geojson string
 #'   which might get too long for encoding in a URL for the API using GET
 #' @param shape,shp aliases (synonyms) for shapefile
-#' @param dTolerance number of meters tolerance to use in [sf::st_simplify()] to simplify polygons to fit as url-encoded text geojson
+#' @param dTolerance number of meters tolerance to use in [sf::st_simplify()] to simplify polygons
+#'   to fit as url-encoded text geojson. Only used when a shapefile/polygon is provided; ignored
+#'   for point (lat/lon) or fips analysis.
 #'
-#' @param as_html Whether to return as just the urls or as html hyperlinks to use in a DT::datatable() for example
+#' @param as_html if FALSE (default) returns plain character URL(s); if TRUE returns HTML
+#'   hyperlinks (via [url_linkify()]) suitable for use in a [DT::datatable()] or other HTML context
 #' @param linktext used as text for hyperlinks, if supplied and as_html=TRUE
 #' @param ifna URL shown for missing, NA, NULL, bad input values. Default NULL
 #'   (and an explicitly passed NULL) resolves to the EJAM API base URL from
@@ -59,6 +65,10 @@
 #'
 #'  - `N` (a number `> 0`) -- returns a single URL for just the Nth site found in the
 #'    inputs (e.g. the 3rd point, fips, or polygon).
+#'
+#'  Single-site auto-override: when the inputs resolve to exactly one site (one row of
+#'  sitepoints, one fips code, or one polygon), sitenumber is coerced to `1` regardless of what
+#'  was requested, so a lone place yields a single-site report URL.
 #'
 #' @param ... a named list of other query parameters passed to the API,
 #'   to allow for expansion of allowed parameters
@@ -88,6 +98,9 @@
 #'  # Polygons
 #'  shp = testinput_shapes_2[2, c("geometry", "FIPS", "NAME")]
 #'  z = url_ejamapi(shapefile = shp)
+#'
+#'  # HTML hyperlinks (e.g. for a DT::datatable cell) instead of plain URLs
+#'  x_links = url_ejamapi(pts2, as_html = TRUE, linktext = "Report")
 #'
 #'  \dontrun{
 #'  browseURL(paste0(url_package("api"), "/report?lat=33&lon=-112&buffer=4"))  # API base from DESCRIPTION

--- a/R/url_ejamapi.R
+++ b/R/url_ejamapi.R
@@ -3,10 +3,10 @@
 #' Get URL(s) of HTML summary reports for use with EJAM-API
 #' @seealso [ejamapi()] [url_ejamapp()]
 #' @details
-#' - This is work in progress to some extent -- this and the API may be add features in later releases.
-#'
-#' - Relies on API from
-#'   https://github.com/edgi-govdata-archiving/EJAM-API
+#' - Relies on the EJAM REST API, whose source code is at
+#'   https://github.com/Public-Environmental-Data-Partners/EJAM-API
+#'   (the API base URL itself comes from `url_package("api")`; see the `ejam_api_url`
+#'   field in DESCRIPTION).
 #'
 #' - To construct a "deep link" that launches the live EJAM *app* (not the API)
 #'   pre-loaded with sites, see [url_ejamapp()], which uses the same query
@@ -14,9 +14,11 @@
 #'
 #' - Will try to use the same input parameters as [ejamit()] does.
 #'
-#' - The API now honors the `sitenumber` parameter passed through to [ejam2report()]:
-#'   the default is `sitenumber = 1` (a single-site report), and `sitenumber = 0`
-#'   (or "overall") produces an aggregate *multisite* report. The API leaves the
+#' - The API honors the `sitenumber` parameter passed through to [ejam2report()]:
+#'   `sitenumber = 1` requests a single-site report (the API's per-request default when
+#'   none is supplied), and `sitenumber = 0` (or "overall") produces an aggregate
+#'   *multisite* report. (Note `url_ejamapi()`'s own default is `sitenumber = "each"` --
+#'   see the parameter docs below.) The API leaves the
 #'   report title to [ejam2report()], which uses "EJSCREEN Community Report" for a
 #'   single site and "EJSCREEN Multisite Summary" for the aggregate. Many or large
 #'   polygons can exceed URL length for this GET-based path; the API also provides
@@ -44,28 +46,19 @@
 #'   (and an explicitly passed NULL) resolves to the DESCRIPTION `ejam_api_url`
 #'   followed by "/report?". See [ejamapi()] for a better way to handle choice of endpoint.
 #'
-#' @param sitenumber
+#' @param sitenumber controls how many URLs are returned and which site(s) each covers:
 #'
-#'  - "each" (or -1) means return each site's URL
+#'  - `"each"` (or `-1`) -- **the default** -- returns a vector of URLs, one per site
+#'    (one single-site report per site). Unlike [ejam2report()]/[ejam2map()], which never
+#'    return a vector, the `url_*` helpers can; that vector-per-site output is the main
+#'    reason this parameter exists.
 #'
-#'  - "overall" (or 0) means return one URL, combining all sites
+#'  - `"overall"` (or `0`, `NULL`, or `""`) -- returns a single URL requesting one
+#'    aggregate *multisite* report combining all sites (sent to the API as `sitenumber=0`;
+#'    assumes >1 site was provided).
 #'
-#'  - N (a number > 0) means return just the Nth site's URL
-#'
-#'  Like with other url_xyz functions, the default is to output
-#'   a vector of URLs, one per site. The default value for sitenumber is
-#'   "each" or -1 which means we want one url for each site.
-#'   Note there is no comparable value of sitenumber in the [ejam2report()] or [ejam2map()] or similar functions,
-#'   which never return a vector of reports, maps, etc. Getting a vector of 1 per site is useful mainly for
-#'   the url_xyz functions.
-#'
-#'   Like the sitenumber parameter in [ejam2report()],
-#'   a value of NULL or 0 or "" or "overall" in url_ejamapi() means
-#'   a single URL is returned that requests one
-#'   overall summary report (assuming >1 sites were provided).
-#'
-#'   Specifying sitenumber as a number like 3 means a report based on the third site
-#'   found in the inputs (third point or third fips or third polygon).
+#'  - `N` (a number `> 0`) -- returns a single URL for just the Nth site found in the
+#'    inputs (e.g. the 3rd point, fips, or polygon).
 #'
 #' @param ... a named list of other query parameters passed to the API,
 #'   to allow for expansion of allowed parameters
@@ -230,7 +223,7 @@ url_ejamapi = function(
   ################################################## #  ################################################## #
   # (baseurl and ifna were already resolved from url_package("api") near the top.)
   shp_one_site_fallback_url <- "https://ejanalysis.com/ejamapp"
-  # see https://github.com/edgi-govdata-archiving/EJAM-API/tree/main
+  # see https://github.com/Public-Environmental-Data-Partners/EJAM-API/tree/main
   # baseurl = "https://ejamapi-84652557241.us-central1.run.app/report?"
   # e.g.,
   # https://ejamapi-84652557241.us-central1.run.app/report?lat=33&lon=-112&buffer=4

--- a/R/url_ejamapp.R
+++ b/R/url_ejamapp.R
@@ -11,7 +11,8 @@
 #' of [ejamapp()].
 #'
 #' The query vocabulary matches [url_ejamapi()]: `lat`, `lon`, `fips`,
-#' `shape` (GeoJSON text), `radius`, and `handoff`. Only one place-type is used
+#' `shape` (GeoJSON text; alias `shapefile`/`shp`), `radius` (alias `buffer`), and `handoff`.
+#' Only one place-type is used
 #' per launch (points, else FIPS, else polygons), matching the app's
 #' one-method-per-analysis model. See the launch-URL handler described in the
 #' "Defaults and Custom Settings for the Web App" vignette.
@@ -48,6 +49,9 @@
 #'  url_ejamapp(lat = c(33, 34), lon = c(-112, -114), radius = 3)
 #'  url_ejamapp(fips = c("10001", "10003"))
 #'  url_ejamapp(handoff = "abc123token")
+#'
+#'  # sitepoints data.frame, and the buffer alias for radius
+#'  url_ejamapp(sitepoints = data.frame(lat = c(33, 34), lon = c(-112, -114)), buffer = 5)
 #'
 #' @export
 #'

--- a/R/url_package.R
+++ b/R/url_package.R
@@ -19,7 +19,7 @@
 #'     source-code repo and is informational only -- it is not the API endpoint.)
 #'
 #' @param get_full_url logical, whether to return full URL or just the owner/reponame info.
-#'   Ignored if type = "docs", where full URL is always returned.
+#'   Ignored if type = "docs" or "api", where a full URL is always returned.
 #'
 #' @param desc_or_alias must be "desc" or "alias" to use info from DESCRIPTION file
 #'   or the URL based on a redirect from the aliases at
@@ -36,6 +36,8 @@
 #'   within the version being built. `desc_or_alias = "alias"` shortcuts always point
 #'   to the root docs site only.
 #' @param domain obsolete parameter - do not use
+#' @seealso [url_ejamapi()] [ejamapi()] [url_ejamapp()] -- the functions that build/call EJAM API
+#'   and app URLs; `url_package("api")` is their single source for the API base URL.
 #' @details
 #' See https://ejanalysis.com/ejam-code   for a list of URLs
 #'

--- a/man/ejamapi.Rd
+++ b/man/ejamapi.Rd
@@ -43,8 +43,8 @@ sites or sitepoints, if provided, must be a data.frame with colnames "lat" and "
 Like the sitepoints param in \code{\link[=url_ejamapi]{url_ejamapi()}}}
 
 \item{shape, shapefile}{Only one of these should be provided - they are synonymous.
-A GeoJSON string representing the area of interest,
-like shapefile param in \code{\link[=url_ejamapi]{url_ejamapi()}}}
+The area of interest, as either an \code{sf} polygon object (auto-converted to GeoJSON) or a
+ready-made GeoJSON string, like the shapefile param in \code{\link[=url_ejamapi]{url_ejamapi()}}.}
 
 \item{fips}{A FIPS code for a specific US Census geography, like "050014801001",
 and must be consistent with the scale parameter}
@@ -64,7 +64,9 @@ the API tries to return one result for each "county" or "blockgroup"
 that is found within the specified fips. For example, all counties in specified State fips,
 or all blockgroups in specified County fips.}
 
-\item{baseurl}{base API URL without the endpoint path}
+\item{baseurl}{base API URL without the endpoint path. Defaults to \code{\link[=url_package]{url_package()}} with
+type="api" (the DESCRIPTION \code{ejam_api_url}), the single source of the API endpoint; pass a
+different value only to target another API (e.g. a staging server).}
 
 \item{endpoint}{"data", "report", or "query".
 \itemize{

--- a/man/url_ejamapi.Rd
+++ b/man/url_ejamapi.Rd
@@ -28,18 +28,22 @@ url_ejamapi(
 
 \item{lat, lon}{can be provided as vectors of coordinates instead of providing sitepoints table}
 
-\item{radius}{see \code{\link[=ejamit]{ejamit()}}, default is 0 if fips or shapefile specified}
+\item{radius}{analysis radius in miles; see \code{\link[=ejamit]{ejamit()}}. Default is 3 miles for point
+(lat/lon/sitepoints) analysis, but 0 (no buffer) when fips or shapefile is specified.}
 
 \item{fips}{see \code{\link[=ejamit]{ejamit()}}}
 
 \item{shapefile}{see \code{\link[=ejamit]{ejamit()}}, but each polygon is encoded as geojson string
 which might get too long for encoding in a URL for the API using GET}
 
-\item{dTolerance}{number of meters tolerance to use in \code{\link[sf:st_simplify]{sf::st_simplify()}} to simplify polygons to fit as url-encoded text geojson}
+\item{dTolerance}{number of meters tolerance to use in \code{\link[sf:st_simplify]{sf::st_simplify()}} to simplify polygons
+to fit as url-encoded text geojson. Only used when a shapefile/polygon is provided; ignored
+for point (lat/lon) or fips analysis.}
 
 \item{linktext}{used as text for hyperlinks, if supplied and as_html=TRUE}
 
-\item{as_html}{Whether to return as just the urls or as html hyperlinks to use in a DT::datatable() for example}
+\item{as_html}{if FALSE (default) returns plain character URL(s); if TRUE returns HTML
+hyperlinks (via \code{\link[=url_linkify]{url_linkify()}}) suitable for use in a \code{\link[DT:datatable]{DT::datatable()}} or other HTML context}
 
 \item{ifna}{URL shown for missing, NA, NULL, bad input values. Default NULL
 (and an explicitly passed NULL) resolves to the EJAM API base URL from
@@ -60,7 +64,11 @@ aggregate \emph{multisite} report combining all sites (sent to the API as \code{
 assumes >1 site was provided).
 \item \code{N} (a number \verb{> 0}) -- returns a single URL for just the Nth site found in the
 inputs (e.g. the 3rd point, fips, or polygon).
-}}
+}
+
+Single-site auto-override: when the inputs resolve to exactly one site (one row of
+sitepoints, one fips code, or one polygon), sitenumber is coerced to \code{1} regardless of what
+was requested, so a lone place yields a single-site report URL.}
 
 \item{version}{optional EJAM version tag (e.g. "3.2024.0") sent to the API as
 version=\if{html}{\out{<ver>}} so the API can serve the matching data vintage. Default NULL
@@ -86,7 +94,9 @@ field in DESCRIPTION).
 \item To construct a "deep link" that launches the live EJAM \emph{app} (not the API)
 pre-loaded with sites, see \code{\link[=url_ejamapp]{url_ejamapp()}}, which uses the same query
 vocabulary (lat, lon, fips, shape, radius, handoff).
-\item Will try to use the same input parameters as \code{\link[=ejamit]{ejamit()}} does.
+\item Accepts a subset of \code{\link[=ejamit]{ejamit()}}'s input-parameter names (sitepoints, lat, lon, radius,
+fips, shapefile); it does not accept every \code{\link[=ejamit]{ejamit()}}/\code{\link[=ejam2report]{ejam2report()}} option (see the
+note below on unsupported options).
 \item The API honors the \code{sitenumber} parameter passed through to \code{\link[=ejam2report]{ejam2report()}}:
 \code{sitenumber = 1} requests a single-site report (the API's per-request default when
 none is supplied), and \code{sitenumber = 0} (or "overall") produces an aggregate
@@ -124,6 +134,9 @@ radius_donut_lower_edge).
  shp = testinput_shapes_2[2, c("geometry", "FIPS", "NAME")]
  z = url_ejamapi(shapefile = shp)
 
+ # HTML hyperlinks (e.g. for a DT::datatable cell) instead of plain URLs
+ x_links = url_ejamapi(pts2, as_html = TRUE, linktext = "Report")
+
  \dontrun{
  browseURL(paste0(url_package("api"), "/report?lat=33&lon=-112&buffer=4"))  # API base from DESCRIPTION
 
@@ -134,5 +147,5 @@ radius_donut_lower_edge).
 
 }
 \seealso{
-\code{\link[=ejamapi]{ejamapi()}} \code{\link[=url_ejamapp]{url_ejamapp()}}
+\code{\link[=ejamapi]{ejamapi()}} \code{\link[=url_ejamapp]{url_ejamapp()}} \code{\link[=url_package]{url_package()}}
 }

--- a/man/url_ejamapi.Rd
+++ b/man/url_ejamapi.Rd
@@ -49,26 +49,18 @@ DESCRIPTION (\code{ejam_api_url}), via \code{\link[=url_package]{url_package()}}
 (and an explicitly passed NULL) resolves to the DESCRIPTION \code{ejam_api_url}
 followed by "/report?". See \code{\link[=ejamapi]{ejamapi()}} for a better way to handle choice of endpoint.}
 
-\item{sitenumber}{\itemize{
-\item "each" (or -1) means return each site's URL
-\item "overall" (or 0) means return one URL, combining all sites
-\item N (a number > 0) means return just the Nth site's URL
-}
-
-Like with other url_xyz functions, the default is to output
-a vector of URLs, one per site. The default value for sitenumber is
-"each" or -1 which means we want one url for each site.
-Note there is no comparable value of sitenumber in the \code{\link[=ejam2report]{ejam2report()}} or \code{\link[=ejam2map]{ejam2map()}} or similar functions,
-which never return a vector of reports, maps, etc. Getting a vector of 1 per site is useful mainly for
-the url_xyz functions.
-
-Like the sitenumber parameter in \code{\link[=ejam2report]{ejam2report()}},
-a value of NULL or 0 or "" or "overall" in url_ejamapi() means
-a single URL is returned that requests one
-overall summary report (assuming >1 sites were provided).
-
-Specifying sitenumber as a number like 3 means a report based on the third site
-found in the inputs (third point or third fips or third polygon).}
+\item{sitenumber}{controls how many URLs are returned and which site(s) each covers:
+\itemize{
+\item \code{"each"} (or \code{-1}) -- \strong{the default} -- returns a vector of URLs, one per site
+(one single-site report per site). Unlike \code{\link[=ejam2report]{ejam2report()}}/\code{\link[=ejam2map]{ejam2map()}}, which never
+return a vector, the \verb{url_*} helpers can; that vector-per-site output is the main
+reason this parameter exists.
+\item \code{"overall"} (or \code{0}, \code{NULL}, or \code{""}) -- returns a single URL requesting one
+aggregate \emph{multisite} report combining all sites (sent to the API as \code{sitenumber=0};
+assumes >1 site was provided).
+\item \code{N} (a number \verb{> 0}) -- returns a single URL for just the Nth site found in the
+inputs (e.g. the 3rd point, fips, or polygon).
+}}
 
 \item{version}{optional EJAM version tag (e.g. "3.2024.0") sent to the API as
 version=\if{html}{\out{<ver>}} so the API can serve the matching data vintage. Default NULL
@@ -87,16 +79,19 @@ Get URL(s) of HTML summary reports for use with EJAM-API
 }
 \details{
 \itemize{
-\item This is work in progress to some extent -- this and the API may be add features in later releases.
-\item Relies on API from
-https://github.com/edgi-govdata-archiving/EJAM-API
+\item Relies on the EJAM REST API, whose source code is at
+https://github.com/Public-Environmental-Data-Partners/EJAM-API
+(the API base URL itself comes from \code{url_package("api")}; see the \code{ejam_api_url}
+field in DESCRIPTION).
 \item To construct a "deep link" that launches the live EJAM \emph{app} (not the API)
 pre-loaded with sites, see \code{\link[=url_ejamapp]{url_ejamapp()}}, which uses the same query
 vocabulary (lat, lon, fips, shape, radius, handoff).
 \item Will try to use the same input parameters as \code{\link[=ejamit]{ejamit()}} does.
-\item The API now honors the \code{sitenumber} parameter passed through to \code{\link[=ejam2report]{ejam2report()}}:
-the default is \code{sitenumber = 1} (a single-site report), and \code{sitenumber = 0}
-(or "overall") produces an aggregate \emph{multisite} report. The API leaves the
+\item The API honors the \code{sitenumber} parameter passed through to \code{\link[=ejam2report]{ejam2report()}}:
+\code{sitenumber = 1} requests a single-site report (the API's per-request default when
+none is supplied), and \code{sitenumber = 0} (or "overall") produces an aggregate
+\emph{multisite} report. (Note \code{url_ejamapi()}'s own default is \code{sitenumber = "each"} --
+see the parameter docs below.) The API leaves the
 report title to \code{\link[=ejam2report]{ejam2report()}}, which uses "EJSCREEN Community Report" for a
 single site and "EJSCREEN Multisite Summary" for the aggregate. Many or large
 polygons can exceed URL length for this GET-based path; the API also provides

--- a/man/url_ejamapp.Rd
+++ b/man/url_ejamapp.Rd
@@ -67,7 +67,8 @@ of \code{\link[=ejamapp]{ejamapp()}}.
 }
 \details{
 The query vocabulary matches \code{\link[=url_ejamapi]{url_ejamapi()}}: \code{lat}, \code{lon}, \code{fips},
-\code{shape} (GeoJSON text), \code{radius}, and \code{handoff}. Only one place-type is used
+\code{shape} (GeoJSON text; alias \code{shapefile}/\code{shp}), \code{radius} (alias \code{buffer}), and \code{handoff}.
+Only one place-type is used
 per launch (points, else FIPS, else polygons), matching the app's
 one-method-per-analysis model. See the launch-URL handler described in the
 "Defaults and Custom Settings for the Web App" vignette.
@@ -81,6 +82,9 @@ then fetches the places back from \verb{GET /handoff/<token>} at startup.
  url_ejamapp(lat = c(33, 34), lon = c(-112, -114), radius = 3)
  url_ejamapp(fips = c("10001", "10003"))
  url_ejamapp(handoff = "abc123token")
+
+ # sitepoints data.frame, and the buffer alias for radius
+ url_ejamapp(sitepoints = data.frame(lat = c(33, 34), lon = c(-112, -114)), buffer = 5)
 
 }
 \seealso{

--- a/man/url_package.Rd
+++ b/man/url_package.Rd
@@ -31,7 +31,7 @@ source-code repo and is informational only -- it is not the API endpoint.)
 }}
 
 \item{get_full_url}{logical, whether to return full URL or just the owner/reponame info.
-Ignored if type = "docs", where full URL is always returned.}
+Ignored if type = "docs" or "api", where a full URL is always returned.}
 
 \item{desc_or_alias}{must be "desc" or "alias" to use info from DESCRIPTION file
 or the URL based on a redirect from the aliases at
@@ -80,5 +80,9 @@ See https://ejanalysis.com/ejam-code   for a list of URLs
  url_package("code", desc_or_alias="alias")
  url_package("data", desc_or_alias="alias")
 
+}
+\seealso{
+\code{\link[=url_ejamapi]{url_ejamapi()}} \code{\link[=ejamapi]{ejamapi()}} \code{\link[=url_ejamapp]{url_ejamapp()}} -- the functions that build/call EJAM API
+and app URLs; \code{url_package("api")} is their single source for the API base URL.
 }
 \keyword{internal}


### PR DESCRIPTION
Roxygen/help cleanup for `url_ejamapi()` (reflected on the pkgdown reference page):

- Removed the "This is work in progress to some extent" bullet.
- Updated the API source-code reference from the old `edgi-govdata-archiving/EJAM-API` to `Public-Environmental-Data-Partners/EJAM-API` (in `@details` and a code comment), and noted that the API base URL itself comes from `url_package("api")` / the `ejam_api_url` DESCRIPTION field.
- Rewrote the `@param sitenumber` section for clarity: leads with the default (`"each"`/`-1` → one URL per site), and maps `"overall"`/`0`/`NULL`/`""` → single aggregate multisite URL and `N>0` → Nth site. Clarified in `@details` that `sitenumber=1` is the API's per-request default, distinct from `url_ejamapi()`'s own `"each"` default.
- Regenerated `man/url_ejamapi.Rd`.

Docs-only; no behavior change. `R/url_ejamapi.R` parses; `document()` regenerated the Rd cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)