### PR TITLE
docs(pkgdown): pin Source-link repo branch to HEAD (stop dead R/ blob links)

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,12 @@
 url: https://public-environmental-data-partners.github.io/EJAM/
+repo:
+  # Pin the branch used in "Source: R/..." (blob) links. Without this, pkgdown
+  # falls back to GITHUB_REF_NAME (the ref the workflow run was triggered on), so
+  # a docs build dispatched from a feature branch bakes that branch name into
+  # every source link -- which 404s once the branch is deleted (see the dead
+  # blob/fix/pkgdown-docs-deps/ links from the 2026-06-03 build). "HEAD" always
+  # resolves to the repo default branch on GitHub, so these links never go dead.
+  branch: HEAD
 template:
   bootstrap: 5
   params:


### PR DESCRIPTION
Adds `repo: branch: HEAD` to `_pkgdown.yml` so the **"Source: R/..."** links on reference pages point at the repo's default branch instead of `GITHUB_REF_NAME` (the branch a docs build was dispatched from).

Without this, a docs build triggered from a feature branch bakes that branch name into every source link, which **404s once the branch is deleted** (e.g. the dead `fix/pkgdown-docs-deps` links from the 2026-06-03 build). `HEAD` always resolves to the current default branch, so the links never go dead.

YAML-only, one setting; validated to parse (`repo$branch == "HEAD"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)