### PR TITLE
Version bump to 3.2022.1 (code-and-docs patch)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,8 +6,8 @@ authors:
   email: ejam@ejanalysis.com
   orcid: https://orcid.org/0000-0002-1696-5638
 title: Environmental Justice Analysis Multisite tool (EJAM)
-version: v3.2022.0
+version: v3.2022.1
 year: 2026
-date-released: 2026-06-15
+date-released: 2026-07-01
 url: https://public-environmental-data-partners.github.io/EJAM/index.html, https://ejanalysis.com/EJAM
 repository-code: https://github.com/Public-Environmental-Data-Partners/EJAM

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: EJAM
 Title: Environmental Justice Analysis Multisite tool
-Version: 3.2022.0
+Version: 3.2022.1
 ejamdata_required_tag: v3.2022.0
-VersionDate: June 2026
-ReleaseDateEJAM: 2026-06-15
+VersionDate: July 2026
+ReleaseDateEJAM: 2026-07-01
 Description: Actively maintained non-EPA version of EJAM, the web app
     and set of tools that supported the EJSCREEN multisite capability.
     EJAM lets you easily summarize demographic and environmental indicators
@@ -22,8 +22,8 @@ ejam_api_repo: https://github.com/Public-Environmental-Data-Partners/EJAM-API
 Authors@R: person("Mark A.", "Corrales", , "ejam@ejanalysis.com", role = c("cre", "aut"), comment = c(ORCID = "0000-0002-1696-5638"))
 Author: Mark A. Corrales <ejam@ejanalysis.com>
 Maintainer: Mark A. Corrales <ejam@ejanalysis.com>
-VersionEJSCREEN: 3.2022.0
-ReleaseDateEJSCREEN: 2026-06-15
+VersionEJSCREEN: 3.2022.1
+ReleaseDateEJSCREEN: 2026-07-01
 VersionACS: 2018-2022
 ReleaseDateACS: 2023-12-07
 VersionCensus: 2020

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,21 +10,14 @@ Changes since v3.YYYY.0:
 
 ## New Features
 
-- Parameter aliases for consistency across the place-input functions -- `ejamit()`,
-  `ejamapp()`, `custom_ejamit()`, `ejamapi()`, `url_ejamapp()`, `url_ejamapi()`,
-  `ejam2report()`, `ejam2map()`, `shapefile_from_any()`, `sites_from_input()`,
-  `ejamit_compare_distances()`/`_fulloutput()`, `ejamit_compare_types_of_places()`,
-  `ejamit_sitetype_from_input()`, `latlon_from_shapefile_centroids()`,
-  `shape_buffered_from_shapefile()`, the `url_*` map/report-link builders
-  (`url_ejscreenmap`, `url_enviromapper`, `url_county_health`/`_equityatlas`,
-  `url_state_health`/`_equityatlas`), and the EJAM API:
-    - **`buffer`** is a synonym for **`radius`** (and **`buffers`** for the `radii`
-      vector) -- it reads more naturally for FIPS or polygon analysis;
-    - **`shape`** and **`shp`** are synonyms for the polygon input (**`shapefile`**).
-  Canonical names are unchanged; the aliases are accepted wherever relevant.
+### EJScreen integration via API and deep-linking to EJAM
 
-- `ejamit()` now accepts `lat` and `lon` vectors directly (it builds `sitepoints`
-  from them), in addition to a `sitepoints` data.frame. Closes #171.
+New features across the EJAM API, the EJScreen web app, and the EJAM web app now
+work together so that EJScreen users can select several places directly on the
+EJScreen map -- clicking points, picking a "Select an Area" FIPS area, or drawing
+a polygon -- and then either get a single multisite report covering all of those
+places at once, or hand the same selected places off to the EJAM ("multisite")
+web app with the sites already loaded and ready to analyze. The supporting pieces:
 
 - Launch-URL site handoff (pre-load the web app from an external site). The app
   server now reads custom launch query parameters so another app -- notably the
@@ -51,10 +44,7 @@ Changes since v3.YYYY.0:
   `url_ejamapp(handoff=<token>)`, using the same query vocabulary as
   `url_ejamapi()`. The default app base is now **`https://ejamapp.ejanalysis.com/`**,
   a Cloudflare-fronted shortcut on ejanalysis.com that forwards the query string
-  (302 redirect) to the live app so launch parameters arrive intact. Docs for
-  `ejamapp()`, `ejamapi()`, and `url_ejamapi()` were updated to reflect that the
-  EJAM API now supports multisite reports (`sitenumber=0`) and a POST `/report`
-  endpoint for many/large polygons.
+  (302 redirect) to the live app so launch parameters arrive intact.
 
 - The EJAM API base URL is now **single-sourced**: functions read it from
   `DESCRIPTION` (`ejam_api_url`) via `url_package("api")`, so the endpoint can be
@@ -62,6 +52,28 @@ Changes since v3.YYYY.0:
   alias, `https://api.ejanalysis.com/` (also `https://ejamapi.ejanalysis.com/`), is
   available via Cloudflare and can be set as `ejam_api_url` if desired; the default
   remains the Cloud Run URL. See the new `dev-api` article.
+
+- The EJAM API now supports multisite reports (`sitenumber=0`) and also now has a
+  POST `/report` endpoint for large or numerous polygons. Docs for `ejamapp()`,
+  `ejamapi()`, and `url_ejamapi()` were updated to reflect that.
+
+### Parameter aliases and flexible site inputs
+
+- Parameter aliases for consistency across the place-input functions -- `ejamit()`,
+  `ejamapp()`, `custom_ejamit()`, `ejamapi()`, `url_ejamapp()`, `url_ejamapi()`,
+  `ejam2report()`, `ejam2map()`, `shapefile_from_any()`, `sites_from_input()`,
+  `ejamit_compare_distances()`/`_fulloutput()`, `ejamit_compare_types_of_places()`,
+  `ejamit_sitetype_from_input()`, `latlon_from_shapefile_centroids()`,
+  `shape_buffered_from_shapefile()`, the `url_*` map/report-link builders
+  (`url_ejscreenmap`, `url_enviromapper`, `url_county_health`/`_equityatlas`,
+  `url_state_health`/`_equityatlas`), and the EJAM API:
+    - **`buffer`** is a synonym for **`radius`** (and **`buffers`** for the `radii`
+      vector) -- it reads more naturally for FIPS or polygon analysis;
+    - **`shape`** and **`shp`** are synonyms for the polygon input (**`shapefile`**).
+  Canonical names are unchanged; the aliases are accepted wherever relevant.
+
+- `ejamit()` now accepts `lat` and `lon` vectors directly (it builds `sitepoints`
+  from them), in addition to a `sitepoints` data.frame. Closes #171.
 
 ## Bug Fixes
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -25,8 +25,8 @@ footer:
     left: [datefooter]
     right: [package, versionmsg]
   components:
-    datefooter: June 2026
-    versionmsg: Version 3.2022.0
+    datefooter: July 2026
+    versionmsg: Version 3.2022.1
 development:
   mode: release
   destination: dev

--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -1,6 +1,6 @@
 default:
   golem_name: EJAM
-  golem_version: 3.2022.0
+  golem_version: 3.2022.1
   app_prod: yes
   testingnow: no
   testingnow_text: no

--- a/vignettes/dev-update-datasets.Rmd
+++ b/vignettes/dev-update-datasets.Rmd
@@ -508,6 +508,31 @@ This previously had been handled with a GitHub Actions workflow that tried to
 use Git LFS. That automatic workflow is no longer used and should not be
 restored.
 
+### Bump the package version number
+
+The package version (`Version: 3.YYYY.x` in `DESCRIPTION`) is recorded verbatim
+in several other files. When cutting a release, bump all of them together so the
+version shown in the app, the docs site, and the citation agree:
+
+- `DESCRIPTION` — `Version:`, plus the human-readable release fields
+  `VersionDate:`, `ReleaseDateEJAM:`, `VersionEJSCREEN:`, `ReleaseDateEJSCREEN:`.
+  (`ejamdata_required_tag:` is *not* a code version — see above; a code-only
+  patch keeps it at the existing `v3.YYYY.0`.)
+- `_pkgdown.yml` — the footer `components:` (`datefooter:` and `versionmsg:`),
+  shown on every docs page.
+- `CITATION.cff` — `version:` and `date-released:`. (`inst/CITATION` reads
+  `Version`/`VersionDate` from `DESCRIPTION` at build time, so it needs no edit.)
+- `inst/golem-config.yml` — `golem_version:`.
+- `NEWS.md` — when publishing, retitle the top `# EJAM 3.YYYY.x (unreleased)`
+  heading to the dated release heading (for example `# EJAM 3.2022.1 (July 2026)`).
+
+`README.md` carries no hard-coded version (only a lifecycle badge), so it needs
+no edit. The deployed-API repo (EJAM-API) selects which EJAM version to build via
+the `EJAM_VERSION` build arg in its `Dockerfile` (with a matching mention in its
+`README.md`); bump that to the new tag (for example `v3.2022.1`) when redeploying
+the API. EJScreen has no EJAM-version string of its own — it reaches EJAM through
+the API URL — so it needs no version edit for an EJAM release.
+
 
 ## Potential Improvements
 


### PR DESCRIPTION
Bumps the EJAM package version **3.2022.0 → 3.2022.1** in every file that carries
the version, ahead of cutting the `v3.2022.1` release from `main`. This is a
**code-and-docs patch**: the ejamdata arrow files are byte-identical to v3.2022.0,
so `ejamdata_required_tag` **stays `v3.2022.0`** (reuses the existing ejamdata
release — no new data release).

### Version files bumped
- `DESCRIPTION` — `Version: 3.2022.1`, `VersionDate: July 2026`,
  `ReleaseDateEJAM: 2026-07-01`, `VersionEJSCREEN: 3.2022.1`,
  `ReleaseDateEJSCREEN: 2026-07-01` (`ejamdata_required_tag` unchanged at `v3.2022.0`).
- `_pkgdown.yml` — footer `datefooter: July 2026`, `versionmsg: Version 3.2022.1`.
- `CITATION.cff` — `version: v3.2022.1`, `date-released: 2026-07-01`
  (`inst/CITATION` auto-reads DESCRIPTION, so no edit there).
- `inst/golem-config.yml` — `golem_version: 3.2022.1`.

### NEWS.md restructure (no content lost)
- New `### EJScreen integration via API and deep-linking to EJAM` subheader + intro,
  grouping the Launch-URL handoff, `url_ejamapp()` deep-link, and single-sourced
  API-URL items.
- The API's multisite (`sitenumber=0`) and `POST /report` support now gets its own bullet.
- The parameter-aliases and `ejamit()` lat/lon items moved below, under a new
  `### Parameter aliases and flexible site inputs` subheader.

### Docs
- `vignettes/dev-update-datasets.Rmd` — added a "Bump the package version number"
  subsection listing every version-bearing file (this inventory), so future
  releases have a checklist.

`README.md` carries no hard-coded version (only a lifecycle badge), so it is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)