### PR TITLE
NEWS.md: date the 3.2022.1 release header (July 2026)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# EJAM 3.2022.1 / 3.2023.1 / 3.2024.1 (unreleased)
+# EJAM 3.2022.1 (July 2026)
 
 Patch release for the v3.YYYY.0 annual-vintage line (v3.2022.1, v3.2023.1,
 v3.2024.1). Functionality is identical across all three ACS vintages


### PR DESCRIPTION
One-line NEWS.md change: retitle the top header from `(unreleased)` to `# EJAM 3.2022.1 (July 2026)` so the changelog linked from the v3.2022.1 release reads as released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)