### PR TITLE
Add dev-deployment vignette (AWS ECS Fargate hosting + deploy procedure)

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -70,6 +70,7 @@ articles:
   - dev-app-settings
   - dev-api
   - dev-deploy-app
+  - dev-deployment
   - dev-run-shinytests
   - dev-run-unit-tests
   - dev-github-actions-install-tests

--- a/vignettes/dev-deploy-app.Rmd
+++ b/vignettes/dev-deploy-app.Rmd
@@ -40,6 +40,9 @@ Update the branch from which the app will be deployed, which could be a differen
 
 ### 1. Using Docker/AWS for hosting
 
+> For the current AWS ECS Fargate hosting architecture and the step-by-step deploy
+> procedure, see [Deploying the Web App to AWS (Infrastructure & Procedure)](dev-deployment.html).
+
 The live EJAM app in 2025 was being hosted via AWS and Docker using the Dockerfile now included with the EJAM package, and is hosted at a URL you can be directed to from this shortcut: https://ejanalysis.org/ejamapp The EJAM fork at https://github.com/Environmental-Policy-Innovation-Center/ejam-mc-pedp shows how the deployment works, but essentially it is based on the Dockerfile.
 
 The [EJAM-API](https://github.com/edgi-govdata-archiving/EJAM-API) is deployed via Docker as well, and that repository shows how the deployment works.

--- a/vignettes/dev-deploy-app.Rmd
+++ b/vignettes/dev-deploy-app.Rmd
@@ -43,9 +43,9 @@ Update the branch from which the app will be deployed, which could be a differen
 > For the current AWS ECS Fargate hosting architecture and the step-by-step deploy
 > procedure, see [Deploying the Web App to AWS (Infrastructure & Procedure)](dev-deployment.html).
 
-The live EJAM app in 2025 was being hosted via AWS and Docker using the Dockerfile now included with the EJAM package, and is hosted at a URL you can be directed to from this shortcut: https://ejanalysis.org/ejamapp The EJAM fork at https://github.com/Environmental-Policy-Innovation-Center/ejam-mc-pedp shows how the deployment works, but essentially it is based on the Dockerfile.
+The live EJAM app is hosted via AWS ECS Fargate and Docker, at <https://ejam.publicenvirodata.org>. The build/deploy files (`Dockerfile`, Terraform config, and GitHub Actions workflows) live on the `dev-deploy`/`prod-deploy` branches of the EJAM repository. For the full hosting architecture and the step-by-step deploy procedure, see [Deploying the Web App to AWS (Infrastructure & Procedure)](dev-deployment.html).
 
-The [EJAM-API](https://github.com/edgi-govdata-archiving/EJAM-API) is deployed via Docker as well, and that repository shows how the deployment works.
+The [EJAM-API](https://github.com/Public-Environmental-Data-Partners/EJAM-API) is deployed via Docker as well (on Google Cloud Run); that repository shows how its deployment works. See also the [Using the EJAM API](dev-api.html) article.
 
 The EPA-hosted (pre-2025) app used [Posit Connect](https://posit.co/products/enterprise/connect/) for hosting.
 

--- a/vignettes/dev-deployment.Rmd
+++ b/vignettes/dev-deployment.Rmd
@@ -94,31 +94,29 @@ there if in doubt.
 
 ## Branching and deploy model
 
-Each environment has its own long-lived branch, and **each is updated by a
-separate pull request from `main` (or a feature branch)**:
+The two environments are promoted **in sequence** — code is validated on **dev**,
+then the *same commit* is promoted to **prod**:
 
 ```
-feature / fix  ──PR──►  main
-                         │
-                         ├──PR──►  dev-deploy    (deploys to dev; validate here)
-                         └──PR──►  prod-deploy   (deploys to prod, after validation)
+feature / fix  ──PR──►  main  ──PR──►  dev-deploy  ──PR──►  prod-deploy
+                                       (deploys dev;        (deploys prod)
+                                        validate here)
 ```
 
-- Merging a PR into `dev-deploy` triggers a **dev** deploy; merging a PR into
-  `prod-deploy` triggers a **prod** deploy.
-- `dev` is the **validation step**: deploy there, confirm it works, then open a
-  *separate* PR to `prod-deploy`. **Do not merge `dev-deploy` into `prod-deploy`** —
-  both deploy branches take their code from `main`/a feature branch, so their
-  histories stay clean and comparable.
+- Merging a PR into `dev-deploy` triggers a **dev** deploy; merging into
+  `prod-deploy` triggers a **prod** deploy. The environment is chosen by *which
+  branch you push to* — each branch's workflow uses its own `*.tfvars` and its own
+  AWS resources — so the same tree can deploy to either environment.
+- `dev` is the **validation step**: merge `main` → `dev-deploy`, confirm it works,
+  then promote by merging **`dev-deploy` → `prod-deploy`**. Promoting the validated
+  branch (rather than re-merging `main`) guarantees prod deploys the *exact* commit
+  that was tested on dev, with no chance of `main` having moved on in between.
+- **Hotfix exception:** for an urgent prod-only fix you can open a PR straight from
+  `main` (or a fix branch) → `prod-deploy`, skipping dev. Use sparingly — it bypasses
+  dev validation.
 - Both `dev-deploy` and `prod-deploy` are **protected**: a PR is required (direct
   pushes are blocked for everyone, including admins); no approvals are required
   (a maintainer may merge their own PR).
-
-> **Note on this model.** An earlier version of the deploy docs described a
-> sequential `main → dev-deploy → prod-deploy` merge chain. The current, supported
-> model is the one above — *separate* PRs from `main` to each deploy branch, with
-> `dev` used only for validation. If you maintain the deployment, confirm this is
-> still how you want it before relying on it.
 
 ## Routine deploy (GitHub Actions) — the normal path
 
@@ -128,8 +126,9 @@ feature / fix  ──PR──►  main
    On merge, GitHub Actions builds the image, pushes it to ECR, and updates the dev
    ECS service (~15 min).
 3. **Validate on dev** at the dev URL. A human must green-light before promoting.
-4. **Deploy to prod:** open a *separate* PR from `main` (or the same feature branch)
-   → `prod-deploy`. On merge, Actions deploys to production.
+4. **Promote to prod:** open a PR to merge **`dev-deploy` → `prod-deploy`**. On
+   merge, Actions deploys the *same validated commit* to production. (For an urgent
+   prod-only hotfix you can instead PR `main` → `prod-deploy` directly, skipping dev.)
 
 The workflows can also be run manually from **GitHub → Actions → (deploy workflow)
 → Run workflow**.
@@ -290,11 +289,13 @@ maintainer's call; it is noted here as the recommended target state.
 
 This article consolidates two documents that previously lived only on the deploy
 branches: `DEPLOY-GUIDE.md` (root) and `ejam-infra/README.md`. Where they
-disagreed, this article follows the newer `ejam-infra/README.md` and current
-practice: **GitHub Actions deploys are live** (not "coming soon"), the container
-**port is 3838** (an earlier draft said 2000/2001), and each deploy branch is
-updated by a **separate PR from `main`** (not a `dev-deploy → prod-deploy` merge
-chain). Concrete AWS account IDs and individual contact names have been replaced
-with `<ACCOUNT_ID>` and role descriptions; substitute the real values from the
-deploy branch files. If you own the deployment, treat this as the single source of
-truth and retire the two originals (or replace them with a pointer here).
+disagreed, it follows current practice: **GitHub Actions deploys are live** (the
+older `DEPLOY-GUIDE.md` said "coming soon") and the container **port is 3838** (an
+earlier draft said 2000/2001). For the branch model it follows the **sequential**
+`main → dev-deploy → prod-deploy` promotion (as in `DEPLOY-GUIDE.md`), which
+guarantees prod deploys the exact commit validated on dev; the `dev-deploy`/`prod-deploy`
+workflows themselves are branch-triggered, so either model works mechanically.
+Concrete AWS account IDs and individual contact names have been replaced with
+`<ACCOUNT_ID>` and role descriptions; substitute the real values from the deploy
+branch files. If you own the deployment, treat this as the single source of truth
+and retire the two originals (or replace them with a pointer here).

--- a/vignettes/dev-deployment.Rmd
+++ b/vignettes/dev-deployment.Rmd
@@ -144,14 +144,14 @@ The workflows can also be run manually from **GitHub → Actions → (deploy wor
 | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | deploy credentials for ECR/ECS |
 | `EJAMDATA_PAT` | a GitHub PAT, passed to the build as the `GITHUB_PAT` build-arg, used to download the `ejamdata` arrow files from the ejamdata GitHub release |
 
-> **Which EJAM version deploys:** the `Dockerfile` installs EJAM from the **local
-> build context** (`remotes::install_local(...)`), so the deployed version is
-> simply **whatever EJAM source is on the deploy branch** — there is no version tag
-> to set. To ship a specific release (for example `v3.2022.1`), make sure the deploy
-> branch holds that code (sync it from `main`) before deploying. The `ejamdata`
-> arrow files are fetched separately from the ejamdata GitHub release via the
-> `EJAMDATA_VERSION` build-arg (leave unset for the latest release, or pin it — e.g.
-> `v3.2022.0` — to match the release's `ejamdata_required_tag`).
+> **Which EJAM version deploys:** the `Dockerfile` installs EJAM from a **pinned
+> GitHub release tag** via the `EJAM_VERSION` build-arg (default `v3.2022.1`;
+> override with `--build-arg EJAM_VERSION=vX.Y.Z`), so the deployed version is
+> explicit and reproducible rather than tied to whatever source happens to be
+> checked out on the deploy branch. The `ejamdata` arrow files are fetched
+> separately from the ejamdata GitHub release via the `EJAMDATA_VERSION` build-arg
+> (default `v3.2022.0` — the release that `v3.2022.1` requires, i.e. its
+> `ejamdata_required_tag`); keep the two in sync when bumping to a new release.
 
 ## First-time setup (manual / infrastructure)
 

--- a/vignettes/dev-deployment.Rmd
+++ b/vignettes/dev-deployment.Rmd
@@ -1,0 +1,300 @@
+---
+title: "Deploying the Web App to AWS (Infrastructure & Procedure)"
+description: "How the live EJAM Shiny app is hosted on AWS ECS Fargate, and the routine procedure for deploying updates"
+output:
+  rmarkdown::html_vignette:
+    toc: true
+vignette: >
+  %\VignetteIndexEntry{Deploying the Web App to AWS (Infrastructure & Procedure)}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+editor_options:
+  markdown:
+    wrap: 100
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(eval = FALSE, comment = "#>")
+```
+
+This article documents how the **live EJAM Shiny web app** is hosted on
+**AWS ECS Fargate**, and the routine procedure for deploying updates. It is a
+companion to [Deploying the Web App](dev-deploy-app.html), which covers the
+higher-level *choices* (Docker/AWS vs. Posit Connect) and the app-configuration
+options (`isPublic`, logos, titles); this article is the concrete, current
+AWS procedure.
+
+> **Not to be confused with the EJAM API.** This is the **Shiny app** (the
+> interactive website), hosted on **AWS ECS Fargate**. The separate
+> [EJAM REST API](dev-api.html) is hosted on **Google Cloud Run** and deployed
+> from the [EJAM-API repository](https://github.com/Public-Environmental-Data-Partners/EJAM-API).
+
+## Where the operational files live
+
+The files that actually build and deploy the app are kept on the two
+**deploy branches** (`dev-deploy` and `prod-deploy`) of the EJAM repository, **not
+on `main`/`development`**. This keeps the branch-triggered deploy workflows and
+AWS/Terraform config out of the package source (so they cannot misfire on a
+`main` push and do not clutter the R package). This article is the human-readable
+guide to those files; edit the files themselves on the deploy branches.
+
+| File (on the deploy branches) | Purpose |
+|---|---|
+| [`ejam-infra/main.tf`](https://github.com/Public-Environmental-Data-Partners/EJAM/blob/dev-deploy/ejam-infra/main.tf) | Terraform — the full AWS infrastructure definition (VPC, ALB, ECR, ECS, IAM, logs) |
+| [`ejam-infra/prod.tfvars`](https://github.com/Public-Environmental-Data-Partners/EJAM/blob/dev-deploy/ejam-infra/prod.tfvars), [`ejam-infra/dev.tfvars`](https://github.com/Public-Environmental-Data-Partners/EJAM/blob/dev-deploy/ejam-infra/dev.tfvars) | Per-environment Terraform variables (task size, retention, etc.) |
+| `Dockerfile` | Container image build for the Shiny app |
+| `app.R` | The Shiny app entry point run inside the container (also sets `isPublic`) |
+| `.dockerignore` | Files excluded from the Docker build context |
+| `.github/workflows/deploy.yaml` | GitHub Actions — build + deploy to **prod** (on push to `prod-deploy`) |
+| `.github/workflows/deploy-dev.yaml` | GitHub Actions — build + deploy to **dev** (on push to `dev-deploy`) |
+
+## Architecture at a glance
+
+| Layer | Technology |
+|---|---|
+| App | R Shiny (rocker/rstudio base image) |
+| PDF generation | Google Chrome stable + chromote/pagedown |
+| Containerization | Docker |
+| Container registry | AWS ECR (shared repo `ejam`; the prod stack owns it, dev shares it) |
+| Hosting | AWS ECS Fargate (region `us-east-1`) |
+| Load balancing | AWS Application Load Balancer (ALB) |
+| HTTPS / TLS | AWS ACM (DNS-validated) |
+| Infrastructure-as-code | Terraform (S3 state backend, separate state per environment) |
+| CI/CD | GitHub Actions |
+| DNS | Squarespace (CNAME → ALB) |
+
+```
+                 GitHub                                   AWS (us-east-1)
+  main ──PR──► dev-deploy ──push──► deploy-dev.yaml ──► ECR (ejam)  ──► ECS Fargate: ejam-dev
+       ──PR──► prod-deploy ─push──► deploy.yaml     ──► image        ──► ECS Fargate: ejam-prod
+                                                        prod-<sha>          │
+                                                        dev-<sha>           ▼
+                                                                     ALB ──► Squarespace CNAME
+                                                                            ejam.publicenvirodata.org
+```
+
+**URLs**
+
+| Environment | URL |
+|---|---|
+| Production | <https://ejam.publicenvirodata.org> (Squarespace CNAME → prod ALB, ACM TLS) |
+| Dev | the dev ALB DNS name printed by `terraform output` (an `…elb.amazonaws.com` address) |
+
+**Task sizing** (set in the `.tfvars` files)
+
+| | vCPU / memory | Task count | Logs |
+|---|---|---|---|
+| Prod | 2 vCPU / 7 GB | 2 | CloudWatch `/ecs/ejam-prod`, 30-day retention |
+| Dev | 1 vCPU / 6 GB | 1 | CloudWatch `/ecs/ejam-dev`, 7-day retention |
+
+The container listens on **port 3838** (the R Shiny default for the rocker image).
+The authoritative value is the container port in the ECS task definition
+(`ejam-infra/main.tf`) and the `EXPOSE`/app port in the `Dockerfile` — confirm
+there if in doubt.
+
+## Branching and deploy model
+
+Each environment has its own long-lived branch, and **each is updated by a
+separate pull request from `main` (or a feature branch)**:
+
+```
+feature / fix  ──PR──►  main
+                         │
+                         ├──PR──►  dev-deploy    (deploys to dev; validate here)
+                         └──PR──►  prod-deploy   (deploys to prod, after validation)
+```
+
+- Merging a PR into `dev-deploy` triggers a **dev** deploy; merging a PR into
+  `prod-deploy` triggers a **prod** deploy.
+- `dev` is the **validation step**: deploy there, confirm it works, then open a
+  *separate* PR to `prod-deploy`. **Do not merge `dev-deploy` into `prod-deploy`** —
+  both deploy branches take their code from `main`/a feature branch, so their
+  histories stay clean and comparable.
+- Both `dev-deploy` and `prod-deploy` are **protected**: a PR is required (direct
+  pushes are blocked for everyone, including admins); no approvals are required
+  (a maintainer may merge their own PR).
+
+> **Note on this model.** An earlier version of the deploy docs described a
+> sequential `main → dev-deploy → prod-deploy` merge chain. The current, supported
+> model is the one above — *separate* PRs from `main` to each deploy branch, with
+> `dev` used only for validation. If you maintain the deployment, confirm this is
+> still how you want it before relying on it.
+
+## Routine deploy (GitHub Actions) — the normal path
+
+1. **Develop**, and merge your changes to `main` via PR (or keep them on a feature
+   branch ready to deploy).
+2. **Deploy to dev:** open a PR from `main` (or your feature branch) → `dev-deploy`.
+   On merge, GitHub Actions builds the image, pushes it to ECR, and updates the dev
+   ECS service (~15 min).
+3. **Validate on dev** at the dev URL. A human must green-light before promoting.
+4. **Deploy to prod:** open a *separate* PR from `main` (or the same feature branch)
+   → `prod-deploy`. On merge, Actions deploys to production.
+
+The workflows can also be run manually from **GitHub → Actions → (deploy workflow)
+→ Run workflow**.
+
+**Required GitHub Actions secrets** (repo → Settings → Secrets and variables → Actions):
+
+| Secret | Purpose |
+|---|---|
+| `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | deploy credentials for ECR/ECS |
+| `PIGGYBACK_TOKEN` | fetch `ejamdata` release assets during the image build |
+| `GITHUB_TOKEN` | provided automatically by Actions |
+
+> **Deploying a specific EJAM version:** the app image installs the EJAM package
+> during the Docker build. Which version it installs is determined by the
+> `Dockerfile` / deploy workflow on the deploy branch — **not** by anything in
+> `ejam-infra/` (that directory is pure infrastructure). To ship a specific
+> release (for example a new `v3.YYYY.x`), make sure the deploy branch's build
+> installs that tag before you deploy.
+
+## First-time setup (manual / infrastructure)
+
+Only needed when standing up the infrastructure or running Terraform locally;
+day-to-day app deploys use GitHub Actions (above).
+
+**Prerequisites** (macOS shown; use your platform's package manager):
+
+```bash
+# Homebrew, then:
+brew install hashicorp/tap/terraform
+brew install awscli
+# plus Docker Desktop (docker.com), running before any Docker step
+```
+
+**AWS credentials.** Request credentials from the AWS account administrator, then:
+
+```bash
+aws configure          # region us-east-1, output json
+aws sts get-caller-identity   # verify
+```
+
+Your IAM user needs the custom `ejam-terraform-deploy` policy to provision
+infrastructure — request the policy JSON from the deployment manager and attach it
+(AWS Console → IAM → Users → your user → Add permissions).
+
+**Provision / update infrastructure with Terraform.** Run from `ejam-infra/`.
+State lives in the S3 bucket `ejam-terraform-state-<ACCOUNT_ID>`, with a **separate
+state key per environment**:
+
+```bash
+cd ejam-infra
+
+# Prod
+terraform init -backend-config="key=prod/terraform.tfstate"
+terraform plan  -var-file=prod.tfvars -var="aws_account_id=<ACCOUNT_ID>"
+terraform apply -var-file=prod.tfvars -var="aws_account_id=<ACCOUNT_ID>"
+
+# Dev (separate state; -reconfigure switches the backend key)
+terraform init -backend-config="key=dev/terraform.tfstate" -reconfigure
+terraform apply -var-file=dev.tfvars -var="aws_account_id=<ACCOUNT_ID>"
+```
+
+Get your account ID with
+`aws sts get-caller-identity --query Account --output text`.
+
+### Manual Docker build & push (fallback)
+
+Prefer GitHub Actions — the uncompressed image is large (~4 GB) and local pushes
+are slow. If you must build/push by hand (from the deploy branch, which has the
+`Dockerfile`):
+
+```bash
+# Authenticate Docker to ECR
+aws ecr get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin \
+    <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com
+
+docker build -t ejam .
+docker tag  ejam:latest <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/ejam:latest
+docker push <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/ejam:latest
+```
+
+The `.dockerignore` (on the deploy branch) excludes `.RData`, `.Rhistory`,
+`.Rproj.user`, `.git`, `.github`, and `ejam-infra/` from the build context.
+
+## Infrastructure changes (Terraform)
+
+App **code** deploys happen via GitHub Actions. AWS **infrastructure** changes
+(resize a task, add HTTPS, change retention) are made by editing the `.tf`/`.tfvars`
+files and running `terraform apply` locally from `ejam-infra/` as shown above.
+
+**Custom domain / HTTPS:** set `domain_name = "ejam.yourdomain.com"` in the relevant
+`.tfvars`, run `terraform apply`; Terraform outputs the CNAME records to add at the
+DNS provider (Squarespace) for ACM certificate validation. Run `terraform apply`
+once more after adding them — HTTP then redirects to HTTPS automatically.
+
+## Rollback
+
+Point the ECS service back at an earlier task-definition revision:
+
+```bash
+# List recent revisions
+aws ecs list-task-definitions --family-prefix ejam --sort DESC \
+  --query 'taskDefinitionArns[:5]' --output text
+
+# Prod
+aws ecs update-service --cluster ejam-prod-cluster \
+  --service ejam-prod-service --task-definition ejam:<REVISION>
+
+# Dev
+aws ecs update-service --cluster ejam-dev-cluster \
+  --service ejam-dev-service --task-definition ejam-dev:<REVISION>
+```
+
+## Logs and debugging
+
+```bash
+# Service health (running vs. desired)
+aws ecs describe-services --cluster ejam-prod-cluster --services ejam-prod-service \
+  --query 'services[0].{Status:status,Running:runningCount,Desired:desiredCount}'
+
+# Recent errors in the last 30 minutes (prod)
+aws logs filter-log-events --log-group-name /ecs/ejam-prod \
+  --filter-pattern "Error" \
+  --start-time $(($(date -v-30M +%s) * 1000)) \
+  --query 'events[*].message' --output text
+```
+
+| Symptom | Likely fix |
+|---|---|
+| `UnauthorizedOperation` on an EC2/ECS/IAM action | add the missing action to the `ejam-terraform-deploy` IAM policy |
+| Docker build fails | confirm Docker Desktop is running and `.dockerignore` is present |
+| ECS tasks failing health checks | confirm the container serves HTTP 200 on the health path and the port matches the task definition (3838) |
+| Slow local Docker push | use GitHub Actions instead |
+
+## Teardown
+
+```bash
+cd ejam-infra
+terraform destroy -var-file=prod.tfvars -var="aws_account_id=<ACCOUNT_ID>"
+```
+
+The prod ALB has **deletion protection** enabled; disable it in the AWS Console
+first (EC2 → Load Balancers → `ejam-prod-alb` → Edit attributes → Deletion
+protection: off) before `terraform destroy` will succeed on prod.
+
+## Future direction
+
+The long-lived `dev-deploy` / `prod-deploy` branches are a workable pattern, but
+they drift from `main` and must be re-synced before each release. The modern,
+trunk-based alternative is to keep the infra + `Dockerfile` in subdirectories on
+`main` (marked in `.Rbuildignore` so they don't affect the R package build) and
+deploy via `workflow_dispatch`/tag triggers targeting **GitHub Environments**
+(`dev`/`prod`) with approval gates — which removes the environment branches and
+their divergence entirely. This is a larger change and is the deployment
+maintainer's call; it is noted here as the recommended target state.
+
+## About this document
+
+This article consolidates two documents that previously lived only on the deploy
+branches: `DEPLOY-GUIDE.md` (root) and `ejam-infra/README.md`. Where they
+disagreed, this article follows the newer `ejam-infra/README.md` and current
+practice: **GitHub Actions deploys are live** (not "coming soon"), the container
+**port is 3838** (an earlier draft said 2000/2001), and each deploy branch is
+updated by a **separate PR from `main`** (not a `dev-deploy → prod-deploy` merge
+chain). Concrete AWS account IDs and individual contact names have been replaced
+with `<ACCOUNT_ID>` and role descriptions; substitute the real values from the
+deploy branch files. If you own the deployment, treat this as the single source of
+truth and retire the two originals (or replace them with a pointer here).

--- a/vignettes/dev-deployment.Rmd
+++ b/vignettes/dev-deployment.Rmd
@@ -70,7 +70,7 @@ guide to those files; edit the files themselves on the deploy branches.
     dev-deploy   ──push──► deploy-dev.yaml ──► ECR (ejam) ──► ECS Fargate: ejam-dev   ──► dev ALB
     prod-deploy  ──push──► deploy.yaml     ──► ECR (ejam) ──► ECS Fargate: ejam-prod  ──► prod ALB
                                                image tags:                                 │
-                                               dev-<sha> / prod-<sha>                      ▼
+                                               dev = dev-<sha>, prod = <sha>               ▼
                                                                           Squarespace CNAME ──► ejam.publicenvirodata.org
 
   How code gets onto dev-deploy / prod-deploy -- the main -> dev-deploy -> prod-deploy
@@ -152,6 +152,11 @@ The workflows can also be run manually from **GitHub → Actions → (deploy wor
 > separately from the ejamdata GitHub release via the `EJAMDATA_VERSION` build-arg
 > (default `v3.2022.0` — the release that `v3.2022.1` requires, i.e. its
 > `ejamdata_required_tag`); keep the two in sync when bumping to a new release.
+>
+> *(These pinned build-args are set in the deploy-branch `Dockerfile`. A deploy
+> branch whose `Dockerfile` predates that update instead installs EJAM from the
+> build context via `remotes::install_local` and defaults `EJAMDATA_VERSION` to the
+> latest ejamdata release — so confirm the `Dockerfile` on the branch you deploy.)*
 
 ## First-time setup (manual / infrastructure)
 

--- a/vignettes/dev-deployment.Rmd
+++ b/vignettes/dev-deployment.Rmd
@@ -64,13 +64,17 @@ guide to those files; edit the files themselves on the deploy branches.
 | DNS | Squarespace (CNAME → ALB) |
 
 ```
-                 GitHub                                   AWS (us-east-1)
-  main ──PR──► dev-deploy ──push──► deploy-dev.yaml ──► ECR (ejam)  ──► ECS Fargate: ejam-dev
-       ──PR──► prod-deploy ─push──► deploy.yaml     ──► image        ──► ECS Fargate: ejam-prod
-                                                        prod-<sha>          │
-                                                        dev-<sha>           ▼
-                                                                     ALB ──► Squarespace CNAME
-                                                                            ejam.publicenvirodata.org
+  Each deploy branch triggers its own GitHub Actions workflow, which builds the
+  image, pushes it to ECR, and updates that environment's ECS Fargate service:
+
+    dev-deploy   ──push──► deploy-dev.yaml ──► ECR (ejam) ──► ECS Fargate: ejam-dev   ──► dev ALB
+    prod-deploy  ──push──► deploy.yaml     ──► ECR (ejam) ──► ECS Fargate: ejam-prod  ──► prod ALB
+                                               image tags:                                 │
+                                               dev-<sha> / prod-<sha>                      ▼
+                                                                          Squarespace CNAME ──► ejam.publicenvirodata.org
+
+  How code gets onto dev-deploy / prod-deploy -- the main -> dev-deploy -> prod-deploy
+  promotion -- is described under "Branching and deploy model" below.
 ```
 
 **URLs**
@@ -206,9 +210,13 @@ aws ecr get-login-password --region us-east-1 \
   | docker login --username AWS --password-stdin \
     <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com
 
-docker build -t ejam .
-docker tag  ejam:latest <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/ejam:latest
-docker push <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/ejam:latest
+# The ECR repo is created with image_tag_mutability = IMMUTABLE, so every push
+# needs a UNIQUE tag -- re-pushing an existing tag (e.g. :latest) will fail.
+# Match the workflows' commit-SHA convention:
+TAG="manual-$(git rev-parse --short HEAD)"
+docker build -t ejam:$TAG .
+docker tag  ejam:$TAG <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/ejam:$TAG
+docker push <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/ejam:$TAG
 ```
 
 The `.dockerignore` (on the deploy branch) excludes `.RData`, `.Rhistory`,
@@ -250,10 +258,11 @@ aws ecs update-service --cluster ejam-dev-cluster \
 aws ecs describe-services --cluster ejam-prod-cluster --services ejam-prod-service \
   --query 'services[0].{Status:status,Running:runningCount,Desired:desiredCount}'
 
-# Recent errors in the last 30 minutes (prod)
+# Recent errors in the last 30 minutes (prod). `date +%s` (current epoch) is
+# portable across macOS and Linux; 1800 s = 30 min. CloudWatch wants milliseconds.
 aws logs filter-log-events --log-group-name /ecs/ejam-prod \
   --filter-pattern "Error" \
-  --start-time $(($(date -v-30M +%s) * 1000)) \
+  --start-time $(( ($(date +%s) - 1800) * 1000 )) \
   --query 'events[*].message' --output text
 ```
 

--- a/vignettes/dev-deployment.Rmd
+++ b/vignettes/dev-deployment.Rmd
@@ -87,10 +87,10 @@ guide to those files; edit the files themselves on the deploy branches.
 | Prod | 2 vCPU / 7 GB | 2 | CloudWatch `/ecs/ejam-prod`, 30-day retention |
 | Dev | 1 vCPU / 6 GB | 1 | CloudWatch `/ecs/ejam-dev`, 7-day retention |
 
-The container listens on **port 3838** (the R Shiny default for the rocker image).
-The authoritative value is the container port in the ECS task definition
-(`ejam-infra/main.tf`) and the `EXPOSE`/app port in the `Dockerfile` — confirm
-there if in doubt.
+The container serves the app on **port 2000** and a health-check endpoint on
+**port 2001** (`app_port` / `health_check_port` in `ejam-infra/main.tf`, which
+default to 2000/2001; the `Dockerfile` `EXPOSE`s `2000 2001` and runs
+`run_app(port = 2000)` with a small health server on 2001).
 
 ## Branching and deploy model
 
@@ -138,15 +138,16 @@ The workflows can also be run manually from **GitHub → Actions → (deploy wor
 | Secret | Purpose |
 |---|---|
 | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | deploy credentials for ECR/ECS |
-| `PIGGYBACK_TOKEN` | fetch `ejamdata` release assets during the image build |
-| `GITHUB_TOKEN` | provided automatically by Actions |
+| `EJAMDATA_PAT` | a GitHub PAT, passed to the build as the `GITHUB_PAT` build-arg, used to download the `ejamdata` arrow files from the ejamdata GitHub release |
 
-> **Deploying a specific EJAM version:** the app image installs the EJAM package
-> during the Docker build. Which version it installs is determined by the
-> `Dockerfile` / deploy workflow on the deploy branch — **not** by anything in
-> `ejam-infra/` (that directory is pure infrastructure). To ship a specific
-> release (for example a new `v3.YYYY.x`), make sure the deploy branch's build
-> installs that tag before you deploy.
+> **Which EJAM version deploys:** the `Dockerfile` installs EJAM from the **local
+> build context** (`remotes::install_local(...)`), so the deployed version is
+> simply **whatever EJAM source is on the deploy branch** — there is no version tag
+> to set. To ship a specific release (for example `v3.2022.1`), make sure the deploy
+> branch holds that code (sync it from `main`) before deploying. The `ejamdata`
+> arrow files are fetched separately from the ejamdata GitHub release via the
+> `EJAMDATA_VERSION` build-arg (leave unset for the latest release, or pin it — e.g.
+> `v3.2022.0` — to match the release's `ejamdata_required_tag`).
 
 ## First-time setup (manual / infrastructure)
 
@@ -260,7 +261,7 @@ aws logs filter-log-events --log-group-name /ecs/ejam-prod \
 |---|---|
 | `UnauthorizedOperation` on an EC2/ECS/IAM action | add the missing action to the `ejam-terraform-deploy` IAM policy |
 | Docker build fails | confirm Docker Desktop is running and `.dockerignore` is present |
-| ECS tasks failing health checks | confirm the container serves HTTP 200 on the health path and the port matches the task definition (3838) |
+| ECS tasks failing health checks | confirm the container serves HTTP 200 on the health-check port (2001) and the app port (2000) matches the task definition |
 | Slow local Docker push | use GitHub Actions instead |
 
 ## Teardown
@@ -289,12 +290,14 @@ maintainer's call; it is noted here as the recommended target state.
 
 This article consolidates two documents that previously lived only on the deploy
 branches: `DEPLOY-GUIDE.md` (root) and `ejam-infra/README.md`. Where they
-disagreed, it follows current practice: **GitHub Actions deploys are live** (the
-older `DEPLOY-GUIDE.md` said "coming soon") and the container **port is 3838** (an
-earlier draft said 2000/2001). For the branch model it follows the **sequential**
-`main → dev-deploy → prod-deploy` promotion (as in `DEPLOY-GUIDE.md`), which
-guarantees prod deploys the exact commit validated on dev; the `dev-deploy`/`prod-deploy`
-workflows themselves are branch-triggered, so either model works mechanically.
+disagreed, it follows the **actual deploy-branch files** (`main.tf`, `Dockerfile`,
+the deploy workflows): **GitHub Actions deploys are live** (the older
+`DEPLOY-GUIDE.md` said "coming soon"), and the container serves on **ports
+2000/2001** (as in `DEPLOY-GUIDE.md` and the current `main.tf`/`Dockerfile` — the
+`ejam-infra/README.md` wireframe's "3838" was inaccurate). For the branch model it
+follows the **sequential** `main → dev-deploy → prod-deploy` promotion (as in
+`DEPLOY-GUIDE.md`), which guarantees prod deploys the exact commit validated on
+dev; the deploy workflows are branch-triggered, so either model works mechanically.
 Concrete AWS account IDs and individual contact names have been replaced with
 `<ACCOUNT_ID>` and role descriptions; substitute the real values from the deploy
 branch files. If you own the deployment, treat this as the single source of truth


### PR DESCRIPTION
Brings the EJAM Shiny app **deployment documentation** onto the source branch as a
single pkgdown article — A choice to store the documentation on `main` and publish them
as part of the documentation webpages, while operational files stay on the deploy branches.

### What
- **New `vignettes/dev-deployment.Rmd`** — 
  consolidates and makes more available the two overlapping docs that previously
  lived only on the deploy branches (`DEPLOY-GUIDE.md` + `ejam-infra/README.md`):
  architecture (AWS ECS Fargate / ECR / ALB / Terraform), the branching + GitHub
  Actions deploy procedure, first-time setup, Terraform infra changes, rollback,
  logs/debug, teardown, and a short "future direction" (trunk-based / GitHub
  Environments) note.
- Registered in `_pkgdown.yml` under **Developing & Hosting**; cross-linked from the
  existing `dev-deploy-app.Rmd` overview.

### Contradictions resolved (the two source docs disagreed)
- GitHub Actions deploys are **live** (the older `DEPLOY-GUIDE.md` said "coming soon").
- Container serves on **ports 2000/2001** (the `ejam-infra/README.md` wireframe's "3838" was inaccurate — confirmed against `main.tf` + the Dockerfile).
- Deploy branches use **sequential promotion** — `main → dev-deploy → prod-deploy`, promoting `dev-deploy → prod-deploy` so prod deploys the exact commit validated on dev (Gabe's preferred model; the vignette's "Branching and deploy model" section is the single source of truth).

### Public-site hygiene
- Real AWS account IDs → `<ACCOUNT_ID>`
- individual contact names → role descriptions.

### Not included (by design)
- The operational files (`Dockerfile`, `app.R`, `deploy*.yaml`, `ejam-infra/*.tf`,
  `.dockerignore`) stay on the `dev-deploy`/`prod-deploy` branches (where the build
  context and branch-triggered workflows live); the vignette links to them.

Separate from the v3.2022.1 version-bump work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)