### PR TITLE
Fix 2 unit-test failures (shiny 1.14 download-button opt-out; version-tolerant ejamit URL test)

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -589,7 +589,10 @@ app_ui <- function(request) {
                                  downloadButton('download_report_multisite',
                                                 label = 'Download Multisite Summary Report',
                                                 class = 'usa-button',
-                                                enabled = TRUE), style = 'text-align: center;'
+                                                # start disabled; app_server.R enables it once the report is ready.
+                                                # enabled = FALSE opts out of Shiny 1.14 auto-enable so the manual
+                                                # shinyjs::disable/enable in app_server.R is respected.
+                                                enabled = FALSE), style = 'text-align: center;'
                                )
                              ),  # end report tab
 
@@ -632,7 +635,9 @@ app_ui <- function(request) {
                                                               downloadButton('download_results_spreadsheet',
                                                                              label = 'Download Results Table',
                                                                              class = 'usa-button',
-                                                                             enabled = TRUE)
+                                                                             # start disabled; app_server.R enables it after the table renders
+                                                                             # (enabled = FALSE opts out of Shiny 1.14 auto-enable).
+                                                                             enabled = FALSE)
                                                        )
                                                      ),
                                                      br(), ## vertical space

--- a/tests/testthat/test-ejamit.R
+++ b/tests/testthat/test-ejamit.R
@@ -414,10 +414,14 @@ test_that("ejamit() still returns results_bysite with same EJAM Report column", 
     suppressMessages({
       # if (!exists("ejamitoutnow")) {stop("ejamitoutnow is missing but should have been created by EJAM/tests/testthat/setup.R")}
       # ejamitoutnow <- ejamit(testpoints_10, radius = 1, quiet = T, silentinteractive = TRUE) # see setup.R - takes roughly 5-10 seconds
+      ## Compare column 1, the EJAM Report URLs. Each URL embeds the current package
+      ## version (version=X.Y.Z), which legitimately changes every release, so
+      ## normalize it before comparing -- otherwise this structural check breaks on
+      ## each version bump (the saved reference was built at an earlier version).
+      norm_report_version <- function(x) gsub("version=[0-9]+\\.[0-9]+\\.[0-9]+", "version=VER", x)
       expect_equal(
-        ## Compare column 1, the EJAM Report URLs
-        as.vector(unlist(ejamitoutnow$results_bysite[,1])),
-        as.vector(unlist(testoutput_ejamit_10pts_1miles$results_bysite[,1]))
+        norm_report_version(as.vector(unlist(ejamitoutnow$results_bysite[,1]))),
+        norm_report_version(as.vector(unlist(testoutput_ejamit_10pts_1miles$results_bysite[,1])))
       )
       # all.equal(    ejamitoutnow$results_bysite,
       #               testoutput_ejamit_10pts_1miles$results_bysite)


### PR DESCRIPTION
Running the full `test_ejam()` suite before the v3.2022.1 release surfaced **3 failures in 2 files**. Both fixed here.

### 1. `test-shiny-1-14-compat.R` — real bug (app UI)
`app_server.R` manages `download_report_multisite` and `download_results_spreadsheet` with `shinyjs::disable/enable` (disabled until analysis finishes, then enabled when the report/table is ready), but `app_ui.R` defined both with `enabled = TRUE`. Under Shiny ≥ 1.14's auto-enable that fights the manual management and can leave the buttons clickable before there's anything to download. **Fix:** `enabled = FALSE` on both, so they start disabled and the server controls them (which is what the compat test enforces).

### 2. `test-ejamit.R` — brittle test (not a code bug)
The `results_bysite` "EJAM Report" URL embeds the package version (`version=X.Y.Z`), which legitimately changes every release, so the exact column-1 comparison against the shipped `testoutput_ejamit_10pts_1miles` fixture broke on the `3.2022.0 → 3.2022.1` bump. **Fix:** normalize the `version=` param before comparing, so the structural check is stable across releases (rather than regenerating a binary fixture every version bump).

### Verification
Re-ran the affected groups (ejamit + shiny-1-14-compat + webapp): **`[ FAIL 0 | PASS 146 ]`**. Letting CI's shinytest2 `test-webapp-functionality` re-confirm the download-button behavior before merge.

Prereq for the v3.2022.1 release (cut from `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)