### PR TITLE
Deploy Dockerfile: pin EJAM via install_github(@EJAM_VERSION) instead of install_local of the build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,9 +154,12 @@ RUN R -e "remotes::install_github(paste0('Public-Environmental-Data-Partners/EJA
 
 # Download ejamdata arrow files from GitHub release
 # Must run AFTER the EJAM package install so the data/ folder is not overwritten by the installer
-# EJAMDATA_VERSION: leave unset (or pass empty string) to auto-resolve to the latest
-#   release of ejamdata, or pin to a specific tag (e.g. --build-arg EJAMDATA_VERSION=v2.32.8.001)
-ARG EJAMDATA_VERSION
+# EJAMDATA_VERSION: pinned by default to v3.2022.0 -- the ejamdata release that
+#   EJAM v3.2022.1 requires (its DESCRIPTION `ejamdata_required_tag`). Keep this in
+#   sync with EJAM_VERSION when bumping releases; override with
+#   --build-arg EJAMDATA_VERSION=vX.Y.Z. (An explicit empty string falls back to the
+#   latest ejamdata release via the GitHub API below.)
+ARG EJAMDATA_VERSION=v3.2022.0
 RUN RESOLVED_VERSION="${EJAMDATA_VERSION:-$(curl -fsSL \
       -H "Authorization: token ${GITHUB_PAT}" \
       "https://api.github.com/repos/Public-Environmental-Data-Partners/ejamdata/releases/latest" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,18 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/aws
 
 ARG GITHUB_PAT
 
-RUN mkdir -p /home/epic
-WORKDIR /home/epic
+# EJAM package version to install: a released git tag. Pinned by default to the
+# current release; override with --build-arg EJAM_VERSION=vX.Y.Z. Mirrors the
+# EJAM-API image's EJAM_VERSION build-arg so both deploys pin EJAM the same way,
+# and makes the deployed version EXPLICIT (rather than implicitly tied to whatever
+# source happens to be checked out on this deploy branch).
+ARG EJAM_VERSION=v3.2022.1
+ENV EJAM_VERSION=${EJAM_VERSION}
+
+WORKDIR /root
 
 # Install R packages — sourced from DESCRIPTION Imports + runtime-relevant Suggests
-# Explicit pre-install avoids install_local having to resolve everything from scratch
+# Explicit pre-install avoids the EJAM install having to resolve everything from scratch
 # and improves Docker layer caching (this layer only rebuilds if the list changes).
 RUN install2.r --error \
     \
@@ -136,15 +143,17 @@ RUN R -e "remotes::install_github('mikejohnson51/AOI')" && \
     R -e "remotes::install_github('hrbrmstr/hrbrthemes')" && \
     rm -rf /tmp/downloaded_packages /tmp/*.rds
 
-# Copy app files
-ADD . /home/epic/
-
-# Install local package
-RUN R -e "remotes::install_local('/home/epic/', dependencies = TRUE)" && \
+# Install the EJAM package from its pinned GitHub release tag (EJAM is a public
+# repo, so no token is needed). Installing a released tag -- rather than the local
+# build context -- makes the deployed version explicit and reproducible. The
+# package's data/*.rda ship in the release tarball; the large ejamdata arrow files
+# are fetched separately below. (Container entrypoint runs the installed
+# EJAM::run_app(), so no local app source is needed in the image.)
+RUN R -e "remotes::install_github(paste0('Public-Environmental-Data-Partners/EJAM@', Sys.getenv('EJAM_VERSION')), dependencies = TRUE, upgrade = 'never')" && \
     rm -rf /tmp/downloaded_packages /tmp/*.rds
 
 # Download ejamdata arrow files from GitHub release
-# Must run AFTER install_local so the data/ folder is not overwritten by the installer
+# Must run AFTER the EJAM package install so the data/ folder is not overwritten by the installer
 # EJAMDATA_VERSION: leave unset (or pass empty string) to auto-resolve to the latest
 #   release of ejamdata, or pin to a specific tag (e.g. --build-arg EJAMDATA_VERSION=v2.32.8.001)
 ARG EJAMDATA_VERSION
@@ -165,5 +174,5 @@ RUN RESOLVED_VERSION="${EJAMDATA_VERSION:-$(curl -fsSL \
 
 EXPOSE 2000 2001
 
-WORKDIR /home/epic
+WORKDIR /root
 CMD ["R", "-e", "httpuv::startServer('0.0.0.0', 2001, list(call = function(req) { list(status = 200, body = 'OK', headers = list('Content-Type' = 'text/plain')) })); library(EJAM); EJAM::run_app(isPublic = TRUE, options = list(host = '0.0.0.0', port = 2000))"]


### PR DESCRIPTION
Addresses the `remotes::install_local('/home/epic/')` concern in the deploy-branch Dockerfile.

### What it was actually doing
`/home/epic/` was **not** a reference to anyone's local machine — the Dockerfile did `mkdir -p /home/epic`, then `ADD . /home/epic/` (copy the **build context** = this deploy branch's checkout), then `install_local('/home/epic/')`. So it installed **whatever EJAM source is on the deploy branch**. That branch is currently the **stale 2.32.8.001 snapshot**, so a deploy today would install 2.32.8.001 — the version was implicit and easy to get wrong.

### The fix
- **`ADD .`+`install_local` → `remotes::install_github('Public-Environmental-Data-Partners/EJAM@' + EJAM_VERSION)`**, pinned via a new **`ARG EJAM_VERSION=v3.2022.1`** build-arg (same mechanism as the EJAM-API image). EJAM is a **public** repo and its `data/*.rda` ship in the release tarball, so **no token and no Git-LFS** are needed (LFS only covers dev-only `data-raw/` files).
- Removed the `/home/epic` scaffolding (`WORKDIR /root`).
- The container entrypoint runs the **installed** `EJAM::run_app()`, so nothing else needed the copied build context.

### Why it's better
Explicit, reproducible, version-pinned deploys, decoupled from deploy-branch drift, and consistent with the API. To ship a different version, set `--build-arg EJAM_VERSION=vX.Y.Z` (or change the default) — no branch-code sync required.

### ⚠️ Semantic change to be aware of
The deployed EJAM version is now the **`EJAM_VERSION` build-arg (default v3.2022.1)**, not the branch's checked-out source. The `deploy-dev.yaml` workflow currently passes only `--build-arg GITHUB_PAT=…`, so the **default (v3.2022.1) governs**. If you later want the workflow to choose the version, add `--build-arg EJAM_VERSION=…` there.

### Related follow-up (not in this PR)
The ejamdata download still defaults `EJAMDATA_VERSION` to the **latest** ejamdata release; for a matched v3.2022.1 build it should be pinned to **v3.2022.0** (EJAM v3.2022.1's `ejamdata_required_tag`). Happy to add that (either a `v3.2022.0` default or derive it from the installed EJAM's DESCRIPTION).

### Testing / merge note
Not validated by a local build (the image is large). **Merging this into `dev-deploy` triggers `deploy-dev.yaml`, which builds + deploys to the dev ECS service — that's the real test.** Hold the merge until you're ready to test-deploy to **dev** (never prod). `prod-deploy` needs the identical change in a follow-up PR after dev validates. Opened for review, **not** auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)