### PR TITLE
[codex] Fix report maps for zero-geometry FIPS results

### DIFF
--- a/R/MAP_FUNCTIONS.R
+++ b/R/MAP_FUNCTIONS.R
@@ -106,7 +106,8 @@ map_ejam_plus_shp <- function(shp, out, radius_buffer = NULL, circle_color = '#0
 
   if (NROW(shpout) == 0) {
     mymap <- leaflet::leaflet(width = if (isTRUE(getOption("shiny.testmode"))) 1000 else NULL) %>%
-      leaflet::addTiles()
+      leaflet::addTiles() %>%
+      leaflet::fitBounds(-115, 37, -65, 48)
   } else {
     # linkcolnames = sapply(global_or_param("default_reports"), function(x) x$header)
     pops <- popup_from_ejscreen(

--- a/R/MAP_FUNCTIONS.R
+++ b/R/MAP_FUNCTIONS.R
@@ -104,27 +104,32 @@ map_ejam_plus_shp <- function(shp, out, radius_buffer = NULL, circle_color = '#0
   }
   shpout <- shpout[shpout$valid, ] # Drop invalid polygons, dont try to map
 
-  # linkcolnames = sapply(global_or_param("default_reports"), function(x) x$header)
-  pops <- popup_from_ejscreen(
-    shpout %>% sf::st_drop_geometry()
-  )
-  if (is.null(radius_buffer)) {
-    radius_buffer <- out$results_bysite$radius.miles[1]
-  }
-  if (!is.na(radius_buffer) && radius_buffer > 0) {
-    shpout <- sf::st_buffer(shpout, # was "ESRI:102005" but want 4269
-                            dist = units::set_units(radius_buffer, "mi"))
+  if (NROW(shpout) == 0) {
+    mymap <- leaflet::leaflet(width = if (isTRUE(getOption("shiny.testmode"))) 1000 else NULL) %>%
+      leaflet::addTiles()
   } else {
-    ## why was it doing this ?
-    shpout <- shpout %>%
-      sf::st_zm() %>% sf::as_Spatial()
-  }
+    # linkcolnames = sapply(global_or_param("default_reports"), function(x) x$header)
+    pops <- popup_from_ejscreen(
+      shpout %>% sf::st_drop_geometry()
+    )
+    if (is.null(radius_buffer)) {
+      radius_buffer <- out$results_bysite$radius.miles[1]
+    }
+    if (!is.na(radius_buffer) && radius_buffer > 0) {
+      shpout <- sf::st_buffer(shpout, # was "ESRI:102005" but want 4269
+                              dist = units::set_units(radius_buffer, "mi"))
+    } else {
+      ## why was it doing this ?
+      shpout <- shpout %>%
+        sf::st_zm() %>% sf::as_Spatial()
+    }
 
-  mymap <- leaflet::leaflet(shpout, width = if (isTRUE(getOption("shiny.testmode"))) 1000 else NULL) %>%
-    leaflet::addTiles()  %>%
-    leaflet::addPolygons(color = circle_color,
-                         popup = pops,
-                         popupOptions = leaflet::popupOptions(maxHeight = 200))
+    mymap <- leaflet::leaflet(shpout, width = if (isTRUE(getOption("shiny.testmode"))) 1000 else NULL) %>%
+      leaflet::addTiles()  %>%
+      leaflet::addPolygons(color = circle_color,
+                           popup = pops,
+                           popupOptions = leaflet::popupOptions(maxHeight = 200))
+  }
 
   # see in browser ### #
 

--- a/R/popup_from_ejscreen.R
+++ b/R/popup_from_ejscreen.R
@@ -69,6 +69,9 @@ popup_from_ejscreen <- function(out,
     out <- sf::st_drop_geometry(out) # or else popup is blown up by geometry points data
   }
   if (data.table::is.data.table(out)) {out <- data.table::copy(out); data.table::setDF(out)}
+  if (NROW(out) == 0) {
+    return(character(0))
+  }
 
   ############################################ #
   # SPECIFY indicators/VARIABLE NAMES  ####

--- a/tests/testthat/test-MAP_FUNCTIONS.R
+++ b/tests/testthat/test-MAP_FUNCTIONS.R
@@ -197,6 +197,7 @@ test_that("map_ejam_plus_shp() handles all shapes being dropped as invalid", {
     )
   }, "There were 1 invalid polygons.", fixed = TRUE)
   expect_true("leaflet" %in% class(x))
+  expect_equal(unlist(x$x$fitBounds[1:4]), c(37, -115, 48, -65))
 })
 ############################################## #
 

--- a/tests/testthat/test-MAP_FUNCTIONS.R
+++ b/tests/testthat/test-MAP_FUNCTIONS.R
@@ -42,6 +42,17 @@ test_that("popup_from_ejscreen() works even if 1 row or 1 indicator", {
 })
 ############################################## #
 
+test_that("popup_from_ejscreen() handles zero-row results after invalid shapes are dropped", {
+  zero_rows <- testoutput_ejamit_10pts_1miles$results_bysite[0, ]
+  popups <- NULL
+
+  expect_no_error({
+    popups <- popup_from_ejscreen(zero_rows)
+  })
+  expect_identical(popups, character(0))
+})
+############################################## #
+
 test_that("popup_from_any() works even if 1 row or 1 indicator", {
   expect_no_error({
     suppressMessages({
@@ -163,6 +174,29 @@ test_that("mapfastej() works", {
   })
   expect_true("leaflet" %in% class(x))
   expect_true("leaflet" %in% class(y))
+})
+############################################## #
+
+test_that("map_ejam_plus_shp() handles all shapes being dropped as invalid", {
+  out <- testoutput_ejamit_fips_counties
+  out$results_bysite <- out$results_bysite[1, ]
+  out$results_bysite$ejam_uniq_id <- "010039900000"
+  out$results_bysite$radius.miles <- 0
+
+  empty_shape <- sf::st_sf(
+    ejam_uniq_id = "010039900000",
+    geometry = sf::st_sfc(sf::st_geometrycollection(), crs = 4326)
+  )
+
+  expect_message({
+    x <- map_ejam_plus_shp(
+      shp = empty_shape,
+      out = out,
+      radius_buffer = 0,
+      launch_browser = FALSE
+    )
+  }, "There were 1 invalid polygons.", fixed = TRUE)
+  expect_true("leaflet" %in% class(x))
 })
 ############################################## #
 


### PR DESCRIPTION
## Summary

Fixes ejam2report()/ejam2map() failures for FIPS inputs whose boundary lookup returns no usable geometry, such as 010039900000 in #411.

## Root cause

The reported path dropped the only FIPS shape as invalid, leaving zero rows for map popup and polygon rendering. popup_from_ejscreen() still tried to build popup text for zero rows, and map_ejam_plus_shp() later tried to coerce a zero-row sf object to Spatial, which failed.

## Changes

- Return character(0) from popup_from_ejscreen() for zero-row inputs.
- Return a blank leaflet basemap from map_ejam_plus_shp() when every shape is dropped as invalid.
- Add regressions for zero-row popup results and all-invalid shape maps.

## Validation

- devtools::test(filter = "MAP_FUNCTIONS") -> 80 passed, 0 failed.
- devtools::test(filter = "MAP_FUNCTIONS|ejam2map|ejam2report") -> 133 passed, 0 failed, 2 expected skips.
- ejamit(fips = "010039900000") + ejam2map(..., launch_browser = FALSE) returns a leaflet/htmlwidget.
- ejamit(fips = "010039900000") + ejam2report(..., return_html = TRUE, launch_browser = FALSE) returns report HTML.

Closes #411.