### PR TITLE
Fix ECS dev/prod deploy: use github.token instead of expired EJAMDATA_PAT

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -47,8 +47,13 @@ jobs:
         run: |
           FULL_IMAGE=$REGISTRY/$ECR_REPOSITORY
 
+          # Use the auto-generated, always-valid GITHUB_TOKEN (mirrors the R CI
+          # workflows, e.g. check-standard.yaml `GITHUB_PAT: ${{ github.token }}`).
+          # Both EJAM and ejamdata are public repos, so a token with public read
+          # access is sufficient; a stored PAT secret (EJAMDATA_PAT) is unneeded
+          # and had expired, causing HTTP 401 "Bad credentials" during the build.
           docker build \
-            --build-arg GITHUB_PAT=${{ secrets.EJAMDATA_PAT }} \
+            --build-arg GITHUB_PAT=${{ github.token }} \
             -t $FULL_IMAGE:$IMAGE_TAG .
 
           docker push $FULL_IMAGE:$IMAGE_TAG

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -67,8 +67,13 @@ jobs:
         run: |
           FULL_IMAGE=$REGISTRY/$ECR_REPOSITORY
 
+          # Use the auto-generated, always-valid GITHUB_TOKEN (mirrors the R CI
+          # workflows, e.g. check-standard.yaml `GITHUB_PAT: ${{ github.token }}`).
+          # Both EJAM and ejamdata are public repos, so a token with public read
+          # access is sufficient; a stored PAT secret (EJAMDATA_PAT) is unneeded
+          # and had expired, causing HTTP 401 "Bad credentials" during the build.
           docker build \
-            --build-arg GITHUB_PAT=${{ secrets.EJAMDATA_PAT }} \
+            --build-arg GITHUB_PAT=${{ github.token }} \
             -t $FULL_IMAGE:$IMAGE_TAG .
 
           docker push $FULL_IMAGE:$IMAGE_TAG


### PR DESCRIPTION
## Problem
The `dev-deploy` run [28534348571](https://github.com/Public-Environmental-Data-Partners/EJAM/actions/runs/28534348571) failed at the Docker build step:

```
remotes::install_github('mikejohnson51/AOI')  →  HTTP error 401  Bad credentials
```

The build passes `--build-arg GITHUB_PAT=${{ secrets.EJAMDATA_PAT }}`, a stored PAT (last set 2026-04-30) that has **expired**. A non-empty-but-invalid token makes `remotes` authenticate every GitHub API call and get 401 — breaking even the two **public** repo installs (AOI, hrbrthemes) that need no token.

## Fix
Switch both deploy workflows (`deploy-dev.yaml`, `deploy.yaml`) to `${{ github.token }}` — the auto-generated, never-expiring per-run token. This matches every **passing** R CI workflow in the repo (`check-standard.yaml`, `install-quick-check.yaml`, `install-release-user-check.yaml`), which already use `GITHUB_PAT: ${{ github.token }}`.

Both `EJAM` and `ejamdata` are **public** repos, so a repo-scoped token has sufficient read access for the package installs and the ejamdata release-asset downloads. Verified the `ejamdata@v3.2022.0` release assets exist and are publicly fetchable.

Merging this PR re-triggers the dev build + ECS Fargate deployment, validating the fix. `deploy.yaml` (prod) is fixed here too but only runs on `prod-deploy` pushes, so prod is untouched by this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)