### PR TITLE
Fix ECS prod deploy: use github.token instead of expired EJAMDATA_PAT

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -47,11 +47,11 @@ jobs:
         run: |
           FULL_IMAGE=$REGISTRY/$ECR_REPOSITORY
 
-          # Use the auto-generated, always-valid GITHUB_TOKEN (mirrors the R CI
+          # Use the auto-generated GITHUB_TOKEN for this workflow run (mirrors the R CI
           # workflows, e.g. check-standard.yaml `GITHUB_PAT: ${{ github.token }}`).
-          # Both EJAM and ejamdata are public repos, so a token with public read
-          # access is sufficient; a stored PAT secret (EJAMDATA_PAT) is unneeded
-          # and had expired, causing HTTP 401 "Bad credentials" during the build.
+          # The token is short-lived and expires after the job; it's sufficient for
+          # authenticated reads of public repos. Avoid using a stored PAT (EJAMDATA_PAT),
+          # which can expire and cause HTTP 401 "Bad credentials" during the build.
           docker build \
             --build-arg GITHUB_PAT=${{ github.token }} \
             -t $FULL_IMAGE:$IMAGE_TAG .

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -47,8 +47,13 @@ jobs:
         run: |
           FULL_IMAGE=$REGISTRY/$ECR_REPOSITORY
 
+          # Use the auto-generated, always-valid GITHUB_TOKEN (mirrors the R CI
+          # workflows, e.g. check-standard.yaml `GITHUB_PAT: ${{ github.token }}`).
+          # Both EJAM and ejamdata are public repos, so a token with public read
+          # access is sufficient; a stored PAT secret (EJAMDATA_PAT) is unneeded
+          # and had expired, causing HTTP 401 "Bad credentials" during the build.
           docker build \
-            --build-arg GITHUB_PAT=${{ secrets.EJAMDATA_PAT }} \
+            --build-arg GITHUB_PAT=${{ github.token }} \
             -t $FULL_IMAGE:$IMAGE_TAG .
 
           docker push $FULL_IMAGE:$IMAGE_TAG

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -67,8 +67,13 @@ jobs:
         run: |
           FULL_IMAGE=$REGISTRY/$ECR_REPOSITORY
 
+          # Use the auto-generated, always-valid GITHUB_TOKEN (mirrors the R CI
+          # workflows, e.g. check-standard.yaml `GITHUB_PAT: ${{ github.token }}`).
+          # Both EJAM and ejamdata are public repos, so a token with public read
+          # access is sufficient; a stored PAT secret (EJAMDATA_PAT) is unneeded
+          # and had expired, causing HTTP 401 "Bad credentials" during the build.
           docker build \
-            --build-arg GITHUB_PAT=${{ secrets.EJAMDATA_PAT }} \
+            --build-arg GITHUB_PAT=${{ github.token }} \
             -t $FULL_IMAGE:$IMAGE_TAG .
 
           docker push $FULL_IMAGE:$IMAGE_TAG

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -67,11 +67,11 @@ jobs:
         run: |
           FULL_IMAGE=$REGISTRY/$ECR_REPOSITORY
 
-          # Use the auto-generated, always-valid GITHUB_TOKEN (mirrors the R CI
+          # Use the auto-generated GITHUB_TOKEN for this workflow run (mirrors the R CI
           # workflows, e.g. check-standard.yaml `GITHUB_PAT: ${{ github.token }}`).
-          # Both EJAM and ejamdata are public repos, so a token with public read
-          # access is sufficient; a stored PAT secret (EJAMDATA_PAT) is unneeded
-          # and had expired, causing HTTP 401 "Bad credentials" during the build.
+          # The token is short-lived and expires after the job; it's sufficient for
+          # authenticated reads of public repos. Avoid using a stored PAT (EJAMDATA_PAT),
+          # which can expire and cause HTTP 401 "Bad credentials" during the build.
           docker build \
             --build-arg GITHUB_PAT=${{ github.token }} \
             -t $FULL_IMAGE:$IMAGE_TAG .


### PR DESCRIPTION
## Problem
Same expired-PAT issue as dev (fixed in #434). The prod deploy workflow builds with `--build-arg GITHUB_PAT=${{ secrets.EJAMDATA_PAT }}`, a stored PAT that has expired → `install_github` gets HTTP 401 'Bad credentials', breaking even the public-repo installs.

## Fix
Switch both deploy workflows to `${{ github.token }}` (auto-generated, never expires), matching every passing R CI workflow. Both `EJAM` and `ejamdata` are public, so a repo-scoped token has sufficient read access.

## ⚠️ Deployment note
Merging this to `prod-deploy` triggers a **live production** ECS Fargate deployment. Merge deliberately when you're ready to redeploy prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)