### PR TITLE
Sync dev-deploy GITHUB_TOKEN comment wording with prod-deploy

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -47,11 +47,11 @@ jobs:
         run: |
           FULL_IMAGE=$REGISTRY/$ECR_REPOSITORY
 
-          # Use the auto-generated, always-valid GITHUB_TOKEN (mirrors the R CI
+          # Use the auto-generated GITHUB_TOKEN for this workflow run (mirrors the R CI
           # workflows, e.g. check-standard.yaml `GITHUB_PAT: ${{ github.token }}`).
-          # Both EJAM and ejamdata are public repos, so a token with public read
-          # access is sufficient; a stored PAT secret (EJAMDATA_PAT) is unneeded
-          # and had expired, causing HTTP 401 "Bad credentials" during the build.
+          # The token is short-lived and expires after the job; it's sufficient for
+          # authenticated reads of public repos. Avoid using a stored PAT (EJAMDATA_PAT),
+          # which can expire and cause HTTP 401 "Bad credentials" during the build.
           docker build \
             --build-arg GITHUB_PAT=${{ github.token }} \
             -t $FULL_IMAGE:$IMAGE_TAG .

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -67,11 +67,11 @@ jobs:
         run: |
           FULL_IMAGE=$REGISTRY/$ECR_REPOSITORY
 
-          # Use the auto-generated, always-valid GITHUB_TOKEN (mirrors the R CI
+          # Use the auto-generated GITHUB_TOKEN for this workflow run (mirrors the R CI
           # workflows, e.g. check-standard.yaml `GITHUB_PAT: ${{ github.token }}`).
-          # Both EJAM and ejamdata are public repos, so a token with public read
-          # access is sufficient; a stored PAT secret (EJAMDATA_PAT) is unneeded
-          # and had expired, causing HTTP 401 "Bad credentials" during the build.
+          # The token is short-lived and expires after the job; it's sufficient for
+          # authenticated reads of public repos. Avoid using a stored PAT (EJAMDATA_PAT),
+          # which can expire and cause HTTP 401 "Bad credentials" during the build.
           docker build \
             --build-arg GITHUB_PAT=${{ github.token }} \
             -t $FULL_IMAGE:$IMAGE_TAG .


### PR DESCRIPTION
Cosmetic-only follow-up. Corrects the GITHUB_TOKEN comment in both dev-deploy workflows (deploy.yaml + deploy-dev.yaml) to match the accurate wording already on prod-deploy: the token is minted fresh per run and short-lived, not "always-valid"/"never expires". No functional or deploy change.

Will be squash-merged with `[skip ci]` so it does not trigger a dev ECS deploy (nothing to deploy; and the dev v3.2022.1 image currently fails ECS stabilization independently of this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)