### PR TITLE
Sync main with development: report-maps fix for zero-geometry FIPS results (#433)

### DIFF
--- a/R/MAP_FUNCTIONS.R
+++ b/R/MAP_FUNCTIONS.R
@@ -104,27 +104,33 @@ map_ejam_plus_shp <- function(shp, out, radius_buffer = NULL, circle_color = '#0
   }
   shpout <- shpout[shpout$valid, ] # Drop invalid polygons, dont try to map
 
-  # linkcolnames = sapply(global_or_param("default_reports"), function(x) x$header)
-  pops <- popup_from_ejscreen(
-    shpout %>% sf::st_drop_geometry()
-  )
-  if (is.null(radius_buffer)) {
-    radius_buffer <- out$results_bysite$radius.miles[1]
-  }
-  if (!is.na(radius_buffer) && radius_buffer > 0) {
-    shpout <- sf::st_buffer(shpout, # was "ESRI:102005" but want 4269
-                            dist = units::set_units(radius_buffer, "mi"))
+  if (NROW(shpout) == 0) {
+    mymap <- leaflet::leaflet(width = if (isTRUE(getOption("shiny.testmode"))) 1000 else NULL) %>%
+      leaflet::addTiles() %>%
+      leaflet::fitBounds(-115, 37, -65, 48)
   } else {
-    ## why was it doing this ?
-    shpout <- shpout %>%
-      sf::st_zm() %>% sf::as_Spatial()
-  }
+    # linkcolnames = sapply(global_or_param("default_reports"), function(x) x$header)
+    pops <- popup_from_ejscreen(
+      shpout %>% sf::st_drop_geometry()
+    )
+    if (is.null(radius_buffer)) {
+      radius_buffer <- out$results_bysite$radius.miles[1]
+    }
+    if (!is.na(radius_buffer) && radius_buffer > 0) {
+      shpout <- sf::st_buffer(shpout, # was "ESRI:102005" but want 4269
+                              dist = units::set_units(radius_buffer, "mi"))
+    } else {
+      ## why was it doing this ?
+      shpout <- shpout %>%
+        sf::st_zm() %>% sf::as_Spatial()
+    }
 
-  mymap <- leaflet::leaflet(shpout, width = if (isTRUE(getOption("shiny.testmode"))) 1000 else NULL) %>%
-    leaflet::addTiles()  %>%
-    leaflet::addPolygons(color = circle_color,
-                         popup = pops,
-                         popupOptions = leaflet::popupOptions(maxHeight = 200))
+    mymap <- leaflet::leaflet(shpout, width = if (isTRUE(getOption("shiny.testmode"))) 1000 else NULL) %>%
+      leaflet::addTiles()  %>%
+      leaflet::addPolygons(color = circle_color,
+                           popup = pops,
+                           popupOptions = leaflet::popupOptions(maxHeight = 200))
+  }
 
   # see in browser ### #
 

--- a/R/popup_from_ejscreen.R
+++ b/R/popup_from_ejscreen.R
@@ -69,6 +69,9 @@ popup_from_ejscreen <- function(out,
     out <- sf::st_drop_geometry(out) # or else popup is blown up by geometry points data
   }
   if (data.table::is.data.table(out)) {out <- data.table::copy(out); data.table::setDF(out)}
+  if (NROW(out) == 0) {
+    return(character(0))
+  }
 
   ############################################ #
   # SPECIFY indicators/VARIABLE NAMES  ####

--- a/tests/testthat/test-MAP_FUNCTIONS.R
+++ b/tests/testthat/test-MAP_FUNCTIONS.R
@@ -42,6 +42,17 @@ test_that("popup_from_ejscreen() works even if 1 row or 1 indicator", {
 })
 ############################################## #
 
+test_that("popup_from_ejscreen() handles zero-row results after invalid shapes are dropped", {
+  zero_rows <- testoutput_ejamit_10pts_1miles$results_bysite[0, ]
+  popups <- NULL
+
+  expect_no_error({
+    popups <- popup_from_ejscreen(zero_rows)
+  })
+  expect_identical(popups, character(0))
+})
+############################################## #
+
 test_that("popup_from_any() works even if 1 row or 1 indicator", {
   expect_no_error({
     suppressMessages({
@@ -163,6 +174,30 @@ test_that("mapfastej() works", {
   })
   expect_true("leaflet" %in% class(x))
   expect_true("leaflet" %in% class(y))
+})
+############################################## #
+
+test_that("map_ejam_plus_shp() handles all shapes being dropped as invalid", {
+  out <- testoutput_ejamit_fips_counties
+  out$results_bysite <- out$results_bysite[1, ]
+  out$results_bysite$ejam_uniq_id <- "010039900000"
+  out$results_bysite$radius.miles <- 0
+
+  empty_shape <- sf::st_sf(
+    ejam_uniq_id = "010039900000",
+    geometry = sf::st_sfc(sf::st_geometrycollection(), crs = 4326)
+  )
+
+  expect_message({
+    x <- map_ejam_plus_shp(
+      shp = empty_shape,
+      out = out,
+      radius_buffer = 0,
+      launch_browser = FALSE
+    )
+  }, "There were 1 invalid polygons.", fixed = TRUE)
+  expect_true("leaflet" %in% class(x))
+  expect_equal(unlist(x$x$fitBounds[1:4]), c(37, -115, 48, -65))
 })
 ############################################## #
 


### PR DESCRIPTION
Routine housekeeping sync, development -> main. Brings over the single commit main was behind:

- 7761a365 [codex] Fix report maps for zero-geometry FIPS results (Public-Environmental-Data-Partners/EJAM#433) — R/MAP_FUNCTIONS.R, R/popup_from_ejscreen.R, tests/testthat/test-MAP_FUNCTIONS.R

No other content differs between the branches. Merge-commit (not squash) per the established sync-PR convention (Public-Environmental-Data-Partners/EJAM#432, #430, #427) so development and main stay convergent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)