### PR TITLE
infra: ECS health-check grace period 0 → 300s (suspected fix for dev v3.2022.1 stabilization failure)

### DIFF
--- a/ejam-infra/main.tf
+++ b/ejam-infra/main.tf
@@ -89,6 +89,11 @@ variable "health_check_port" {
   default = 2001
 }
 
+variable "health_check_grace_period_seconds" {
+  description = "How long ECS ignores ALB health-check failures after a task starts. The container CMD starts the port-2001 health endpoint in the same R process as the Shiny app, so it cannot answer until R finishes loading EJAM + arrow data; with the default of 0, the ALB (30s interval x 3 unhealthy = ~90s) kills slow-booting tasks before they are ready. Grace only suppresses health-check kills during startup - a crashed container still stops immediately."
+  default     = 300
+}
+
 variable "task_cpu" {
   description = "Fargate task CPU units (1024 = 1 vCPU)"
   default     = 2048
@@ -509,6 +514,8 @@ resource "aws_ecs_service" "app" {
   task_definition = aws_ecs_task_definition.app.arn
   desired_count   = var.desired_count
   launch_type     = "FARGATE"
+
+  health_check_grace_period_seconds = var.health_check_grace_period_seconds
 
   network_configuration {
     subnets          = aws_subnet.public[*].id


### PR DESCRIPTION
## Issue
The v3.2022.1 dev deploy was failing but now works. While looking at it, noted that the ECS service has `healthCheckGracePeriodSeconds: 0`, and the ALB health check (port 2001, path /, 30s interval × 3 unhealthy) gives a task only **~90 seconds** before it is flagged. The container CMD starts the port-2001 httpuv health endpoint **in the same R process** as the Shiny app, so it cannot answer until R finishes `library(EJAM)` + loading the arrow data — on the 1-vCPU dev task, plausibly longer than 90s for the new (Public-Environmental-Data-Partners/EJAM#431) image.

## Change
Add `health_check_grace_period_seconds` (variable, default **300**) to `aws_ecs_service.app`. Grace only suppresses *health-check-based* kills during startup — a genuinely crashed container still exits and stops the task immediately, so this cannot mask a real crash-loop.

## How to apply (ORDER MATTERS — the deploy workflow does not run terraform)
1. Apply the infra change first, either:
   - `terraform apply -var-file=dev.tfvars` from `ejam-infra/` on this branch, **or**
   - the zero-terraform equivalent: `aws ecs update-service --cluster ejam-dev-cluster --service ejam-dev-service --health-check-grace-period-seconds 300` (then merge this PR so IaC matches and a future terraform apply does not revert it).
2. Re-run the dev deploy ("Build & Deploy to ECS Fargate (dev)" has workflow_dispatch) and watch `services-stable`.
3. If it stabilizes → hypothesis confirmed, dev serves v3.2022.1. If it still fails → it is a crash inside the image; grab `aws logs tail /ecs/ejam-dev --since 1h`.

`main.tf` is identical on both deploy branches, so port this to `prod-deploy` together with the Public-Environmental-Data-Partners/EJAM#431 Dockerfile changes when promoting v3.2022.1 to prod.

Context: dev pipeline itself is proven good (build green after Public-Environmental-Data-Partners/EJAM#434; prod ran the same workflow end-to-end successfully 2026-07-01 with the old image via Public-Environmental-Data-Partners/EJAM#435).

🤖 Generated with [Claude Code](https://claude.com/claude-code)