### PR TITLE
Fix dev container crash-loop: CMD must call ejamapp(), not unexported run_app()

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,7 @@ RUN R -e "remotes::install_github('mikejohnson51/AOI')" && \
 # build context -- makes the deployed version explicit and reproducible. The
 # package's data/*.rda ship in the release tarball; the large ejamdata arrow files
 # are fetched separately below. (Container entrypoint runs the installed
-# EJAM::run_app(), so no local app source is needed in the image.)
+# EJAM::ejamapp(), so no local app source is needed in the image.)
 RUN R -e "remotes::install_github(paste0('Public-Environmental-Data-Partners/EJAM@', Sys.getenv('EJAM_VERSION')), dependencies = TRUE, upgrade = 'never')" && \
     rm -rf /tmp/downloaded_packages /tmp/*.rds
 
@@ -178,4 +178,8 @@ RUN RESOLVED_VERSION="${EJAMDATA_VERSION:-$(curl -fsSL \
 EXPOSE 2000 2001
 
 WORKDIR /root
-CMD ["R", "-e", "httpuv::startServer('0.0.0.0', 2001, list(call = function(req) { list(status = 200, body = 'OK', headers = list('Content-Type' = 'text/plain')) })); library(EJAM); EJAM::run_app(isPublic = TRUE, options = list(host = '0.0.0.0', port = 2000))"]
+# EJAM v3.x exports ejamapp() as the app launcher; run_app() is no longer exported
+# (calling it here made every ECS task exit 1 with "'run_app' is not an exported
+# object from 'namespace:EJAM'"). ejamapp(isPublic=...) is supported and its
+# options= list is passed to shinyApp() for host/port.
+CMD ["R", "-e", "httpuv::startServer('0.0.0.0', 2001, list(call = function(req) { list(status = 200, body = 'OK', headers = list('Content-Type' = 'text/plain')) })); library(EJAM); EJAM::ejamapp(isPublic = TRUE, options = list(host = '0.0.0.0', port = 2000))"]


### PR DESCRIPTION
## Root cause (diagnosed via the read-only ECS diagnostics workflow)
Every v3.2022.1 task booted fine — R started, all arrow data loaded, versions matched — then died in ~5s of R runtime with:
```
Error: 'run_app' is not an exported object from 'namespace:EJAM'
Execution halted
```
`stopCode: EssentialContainerExited`, exit 1, **31 failed launches** while old task def ejam-dev:3 kept serving 2.32.8.001. NOT a health-check/grace issue (that theory is now refuted — Public-Environmental-Data-Partners/EJAM#438 is optional hardening at most).

## Fix
The v3.x line exports **`ejamapp()`** as the launcher (v3.2022.1 NAMESPACE has `export(ejamapp)`, no `run_app`). `isPublic=` is supported (documented example `ejamapp(isPublic = TRUE)`), and `options=` passes host/port to `shinyApp()`. One-line CMD change + comment.

## ⚠️ Merging deploys
Merge triggers the dev build+deploy (~25 min). Expect `aws ecs wait services-stable` to go green for the first time since ~May 29, and the dev ALB to serve **v3.2022.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)