### PR TITLE
Fix download button cursor after manual enable

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -31,6 +31,24 @@ app_server <- function(input, output, session) {
   data_processed <-  reactiveVal(NULL) # initialized so it can be set later in reaction to an event, using data_processed(newvalue)
   analysis_complete <- reactiveVal(FALSE)
 
+  # shinyjs::enable() does not clear aria-disabled/tabindex on Shiny 1.14
+  # download links that were created with enabled = FALSE.
+  download_button_selector <- function(id) {
+    jsonlite::toJSON(paste0("#", id), auto_unbox = TRUE)
+  }
+  download_button_disable_js <- function(id) {
+    shinyjs::runjs(sprintf(
+      "$(%s).addClass('disabled').attr({'aria-disabled':'true','tabindex':'-1','disabled':'disabled'}).prop('disabled', true);",
+      download_button_selector(id)
+    ))
+  }
+  download_button_enable_js <- function(id) {
+    shinyjs::runjs(sprintf(
+      "$(%s).removeClass('disabled').removeAttr('aria-disabled').removeAttr('tabindex').removeAttr('disabled').prop('disabled', false);",
+      download_button_selector(id)
+    ))
+  }
+
   sanitized_standard_analysis_title <- reactive({
     global_or_param("sanitize_text")(input$standard_analysis_title)
   })
@@ -2135,8 +2153,8 @@ app_server <- function(input, output, session) {
 
     analysis_complete(FALSE)
     # disable download buttons until finished analysis
-    shinyjs::disable(id = 'download_report_multisite')
-    shinyjs::disable(id = 'download_results_spreadsheet')
+    download_button_disable_js(id = 'download_report_multisite')
+    download_button_disable_js(id = 'download_results_spreadsheet')
     download_ready_for_report_header_and_tables(FALSE)
     download_ready_for_report_map(FALSE)
     download_ready_for_report_plot(FALSE)
@@ -2883,7 +2901,7 @@ app_server <- function(input, output, session) {
       download_ready_for_report_plot()
       # && download_ready_for_report_footer_version_date() # quick, assume ready
     ) {
-      shinyjs::enable(id = 'download_report_multisite')
+      download_button_enable_js(id = 'download_report_multisite')
     }
   })
   ####################################################### #
@@ -3211,7 +3229,7 @@ app_server <- function(input, output, session) {
                                  ## if NULL, uses all available from data_processed()
     )
     # enable download button only after DT::renderDT
-    shinyjs::enable(id = 'download_results_spreadsheet')
+    download_button_enable_js(id = 'download_results_spreadsheet')
     x
   })
   #############################################################################  #

--- a/tests/testthat/test-shiny-1-14-compat.R
+++ b/tests/testthat/test-shiny-1-14-compat.R
@@ -23,7 +23,11 @@ test_that("manually-enabled download buttons opt out of Shiny auto-enable", {
 
   manual_download_calls <- regmatches(
     app_server_source,
-    gregexpr("shinyjs::(?:disable|enable)\\(id = 'download_[^']+'", app_server_source, perl = TRUE)
+    gregexpr(
+      "(?:shinyjs::(?:disable|enable)|download_button_(?:disable|enable)_js)\\(id = 'download_[^']+'",
+      app_server_source,
+      perl = TRUE
+    )
   )[[1]]
   manually_managed_download_ids <- unique(
     sub(".*id = '([^']+)'.*", "\\1", manual_download_calls)
@@ -41,4 +45,37 @@ test_that("manually-enabled download buttons opt out of Shiny auto-enable", {
       perl = TRUE
     )
   }
+})
+
+test_that("manual download-button enable clears Shiny disabled accessibility state", {
+  app_server_source <- paste(
+    readLines(testthat::test_path("../../R/app_server.R"), warn = FALSE),
+    collapse = "\n"
+  )
+
+  expect_match(
+    app_server_source,
+    "download_button_enable_js\\s*<-\\s*function\\s*\\(",
+    perl = TRUE
+  )
+  expect_match(app_server_source, "removeClass\\(['\"]disabled['\"]\\)", perl = TRUE)
+  expect_match(app_server_source, "removeAttr\\(['\"]aria-disabled['\"]\\)", perl = TRUE)
+  expect_match(app_server_source, "removeAttr\\(['\"]tabindex['\"]\\)", perl = TRUE)
+  expect_match(app_server_source, "removeAttr\\(['\"]disabled['\"]\\)", perl = TRUE)
+  expect_match(app_server_source, "prop\\(['\"]disabled['\"],\\s*false\\)", perl = TRUE)
+
+  expect_false(
+    grepl(
+      "shinyjs::enable\\(id = 'download_report_multisite'\\)",
+      app_server_source,
+      perl = TRUE
+    )
+  )
+  expect_false(
+    grepl(
+      "shinyjs::enable\\(id = 'download_results_spreadsheet'\\)",
+      app_server_source,
+      perl = TRUE
+    )
+  )
 })


### PR DESCRIPTION
## Summary
- Keep the two manually managed download buttons opted out of Shiny 1.14 auto-enable (`enabled = FALSE`).
- Replace `shinyjs::enable()/disable()` for those download links with helpers that manage the full disabled link state: `.disabled`, `disabled`, `aria-disabled`, and `tabindex`.
- Extend the Shiny 1.14 compatibility test so future changes cannot reintroduce direct `shinyjs::enable()` for these manually managed downloads.

## Root Cause
Commit `d8bf74bb` had a valid reason to change the two buttons back to `enabled = FALSE`: these downloads are manually gated until content exists, and Shiny 1.14 auto-enable would fight that manual state. The remaining bug was that `shinyjs::enable()` removes `.disabled`/`disabled`, but it does not remove Shiny 1.14's `aria-disabled="true"` or `tabindex="-1"` from download anchors created with `enabled = FALSE`. EPA/USWDS styling then keeps the cursor as `not-allowed` even after Shiny has provided a valid `href`.

## Verification
- `git diff --check`
- `R --vanilla -q -e "parse('R/app_server.R'); parse('tests/testthat/test-shiny-1-14-compat.R')"`
- Targeted source contract check for the two managed download buttons and the helper behavior: passed.
- Deployed dev app reproduction at `http://ejam-dev-alb-971929002.us-east-1.elb.amazonaws.com`: after uploading a two-point lat/lon CSV and running analysis, `download_report_multisite` had a valid `href` but still had `aria-disabled="true"`, `tabindex="-1"`, and computed `cursor: not-allowed`.

Note: I also tried the repo's direct `testthat::test_file('tests/testthat/test-shiny-1-14-compat.R')` path. It entered shared EJAM test setup and then hung in unrelated installed-package Arrow data acquisition, so I used the targeted source contract check instead for this regression.
