### PR TITLE
Fix deep-link ?radius=/?buffer= (renderUI slider clobbered the post-hoc update)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -77,6 +77,12 @@ web app with the sites already loaded and ready to analyze. The supporting piece
 
 ## Bug Fixes
 
+- Deep-link `?radius=` / `?buffer=` now reliably sets the analysis radius at app
+  launch. Previously the launch handler patched the `radius_now` slider via
+  `updateSliderInput()`, but that slider is built by `renderUI`, so the update raced
+  the (re)render and was clobbered when the site-selection method changed. The launch
+  radius is now stored in a reactive value the slider reads at render time. (The other
+  deep-link params -- `lat`/`lon`, `fips`, `shape`, `handoff` -- were unaffected.)
 - Census API key (tidycensus >= 1.8 breaking change): tidycensus now *errors*
   (no longer warns) without a key -- including for the `load_variables()`
   metadata lookup. `calc_blockgroupstats_acs()` and `acs_table_info()` now fail

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -492,6 +492,7 @@ app_server <- function(input, output, session) {
   url_sitepoints <- reactiveVal(NULL)
   url_shapefile  <- reactiveVal(NULL)
   url_fips       <- reactiveVal(NULL)
+  url_radius     <- reactiveVal(NULL)  # launch-URL ?radius=/?buffer=; read at radius_now slider render time (below)
 
   # Launch-URL precedence helper (single home for layer-2 precedence). url_param(name) maps a
   # parameter name to its launch-URL reactiveVal -- the only URL-provided params are these three
@@ -609,10 +610,15 @@ app_server <- function(input, output, session) {
         loaded <- TRUE
       }
     }
-    ## radius / buffer
+    ## radius / buffer -- store in a reactiveVal that the radius_now slider reads at
+    ## render time (see output$radius_slider_ui below). Do NOT updateSliderInput() here:
+    ## radius_now is a renderUI slider, so a post-hoc update races the (re)render and is
+    ## clobbered when the slider re-renders (e.g. after set_site_method() above changes
+    ## the upload method). Reading url_radius() inside the renderUI makes setting it here
+    ## re-render the slider with the launch value, which is reliable in both orderings.
     if (!is.null(spec$radius)) {
       radval <- suppressWarnings(as.numeric(spec$radius))
-      if (!is.na(radval)) {try(shiny::updateSliderInput(session, inputId = "radius_now", value = radval), silent = TRUE)}
+      if (!is.na(radval) && radval > 0) url_radius(radval)
     }
   }, priority = 1000)
 
@@ -1806,7 +1812,7 @@ app_server <- function(input, output, session) {
         label = "",
         min = current_slider_min[[current_upload_method()]],
         max = input$max_miles,
-        value = input$radius_default,
+        value = url_radius() %||% input$radius_default,  # launch-URL ?radius=/?buffer= wins at render time
         step = global_or_param("stepradius"),
         post = ' miles'
       )


### PR DESCRIPTION
## Bug
A deep-link like `…/?fips=10001&radius=5` (or `&buffer=5`) **did not set the analysis radius** — the slider stayed at the configured default. The other deep-link params (`lat`/`lon`, `fips`, `shape`, `handoff`) worked.

## Root cause
The launch-URL handler parsed the radius correctly (`spec$radius <- q$radius %||% q$buffer`) but applied it with `updateSliderInput(session, "radius_now", value=…)` inside an `observe(..., priority = 1000)`. But **`radius_now` is a `renderUI` slider** (`output$radius_slider_ui`, `value = input$radius_default`) that **re-renders** whenever `current_upload_method()` / `input$max_miles` / `input$radius_default` change. So the post-hoc update either:
- fired **before the slider existed** → the message was silently dropped (and it was wrapped in `try(silent=TRUE)`), or
- was **clobbered** moments later when the same handler called `set_site_method()`, changing `current_upload_method()` and re-rendering the slider back to `input$radius_default`.

The site inputs work because they flow through server-side reactiveVals (`url_sitepoints`/`url_fips`/`url_shapefile`) read where the data is built; radius had no such reactiveVal.

## Fix
Store the launch radius in a **`url_radius` reactiveVal** and read it **at render time**:
```r
url_radius <- reactiveVal(NULL)                 # set from q$radius %||% q$buffer in the launch observe
# in output$radius_slider_ui:
value = url_radius() %||% input$radius_default  # launch-URL radius wins at render time
```
Because the `renderUI` now depends on `url_radius()`, setting it re-renders the slider with the launch value — reliable regardless of ordering. The racy `updateSliderInput()` is removed. NEWS updated.

**Design note:** this follows the principle that URL/launch values should be fed into an input's `value=`/`selected=` **at render time**, not patched afterward with `update*Input()` (which races `renderUI` and gets clobbered). It's the template for the broader deep-link-param work (see the `refactoring_app_settings` plan).

## Verification
`R/app_server.R` parses clean; change is scoped to the radius path (3 edits). **Recommend a quick live check** after merge: open `…/?fips=10001&radius=5` and confirm the radius slider shows 5 (and that changing the site method keeps it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)