### PR TITLE
Report links: request pdf for single-site, html for multisite reports

### DIFF
--- a/R/url_ejamapi.R
+++ b/R/url_ejamapi.R
@@ -483,7 +483,9 @@ url_ejamapi = function(
   # so unvalidated text could inject extra query parameters or break the URL.
   if (!is.null(fileextension) && !identical(fileextension, "")) {
     fileextension <- tolower(trimws(as.character(fileextension)))
-    if (length(fileextension) != 1 || !fileextension %in% c("auto", "html", "pdf")) {
+    # Note %in% returns FALSE (not NA) for NA input, so NA already failed this
+    # validation with the intended message; is.na() just makes that explicit.
+    if (length(fileextension) != 1 || is.na(fileextension) || !fileextension %in% c("auto", "html", "pdf")) {
       stop("fileextension must be 'auto', 'html', or 'pdf' (or NULL or '' to omit it from the URL)")
     }
     if (fileextension == "auto") {

--- a/R/url_ejamapi.R
+++ b/R/url_ejamapi.R
@@ -114,6 +114,18 @@
 #'   version=<ver> so the API can serve the matching data vintage. Default NULL
 #'   resolves to the installed package Version (from DESCRIPTION).
 #'
+#' @param fileextension report format requested from the API, sent as
+#'   fileextension=<ext> on each generated report URL. Default "auto" picks the
+#'   format by report type: "html" for an aggregate *multisite* report URL
+#'   (sitenumber 0/"overall" covering more than one site) since HTML renders
+#'   several times faster and displays directly in the browser tab, but "pdf"
+#'   for *single-site* report URLs (the traditional printable community report).
+#'   Use "html" or "pdf" to force one format for all URLs, or NULL/"" to omit
+#'   the parameter and get the API's own default. Case/whitespace are
+#'   normalized; any other value is an error (values are placed in a URL, so
+#'   arbitrary text is rejected rather than encoded). Only applied to actual
+#'   API /report URLs, never to app-fallback or ifna links.
+#'
 #' @export
 #'
 url_ejamapi = function(
@@ -170,6 +182,8 @@ url_ejamapi = function(
   sitenumber = "each",
 
   version = NULL,
+
+  fileextension = "auto",
 
   ...,
 
@@ -454,6 +468,29 @@ url_ejamapi = function(
         url_of_report <- NA # later will convert to ifna
       }
     }
+  }
+  ###################### #
+  # fileextension (report format) ####
+  # Appended here, after the branches above, because "auto" depends on the kind
+  # of report each URL requests: at this point sitenumber is 0 only for an
+  # aggregate MULTISITE report over >1 site (single-site and "each" links have
+  # cleared it), so auto = html for the multisite summary (renders several
+  # times faster; the link opens in a browser tab) and pdf for single-site
+  # reports (the traditional printable community report). Applied only to
+  # actual API /report URLs -- never to the app-fallback links used for
+  # single-polygon sites, nor to NA entries that become ifna below. Validated
+  # strictly rather than URL-encoded: these can be raw URLs (as_html = FALSE),
+  # so unvalidated text could inject extra query parameters or break the URL.
+  if (!is.null(fileextension) && !identical(fileextension, "")) {
+    fileextension <- tolower(trimws(as.character(fileextension)))
+    if (length(fileextension) != 1 || !fileextension %in% c("auto", "html", "pdf")) {
+      stop("fileextension must be 'auto', 'html', or 'pdf' (or NULL or '' to omit it from the URL)")
+    }
+    if (fileextension == "auto") {
+      fileextension <- if (identical(sitenumber, 0)) "html" else "pdf"
+    }
+    is_api_report_url <- !is.na(url_of_report) & startsWith(as.character(url_of_report), baseurl)
+    url_of_report[is_api_report_url] <- paste0(url_of_report[is_api_report_url], "&fileextension=", fileextension)
   }
   ###################### #
 

--- a/man/url_ejamapi.Rd
+++ b/man/url_ejamapi.Rd
@@ -18,6 +18,7 @@ url_ejamapi(
   baseurl = NULL,
   sitenumber = "each",
   version = NULL,
+  fileextension = "auto",
   ...,
   shape = NULL,
   shp = NULL
@@ -73,6 +74,18 @@ was requested, so a lone place yields a single-site report URL.}
 \item{version}{optional EJAM version tag (e.g. "3.2024.0") sent to the API as
 version=\if{html}{\out{<ver>}} so the API can serve the matching data vintage. Default NULL
 resolves to the installed package Version (from DESCRIPTION).}
+
+\item{fileextension}{report format requested from the API, sent as
+fileextension=\if{html}{\out{<ext>}} on each generated report URL. Default "auto" picks the
+format by report type: "html" for an aggregate \emph{multisite} report URL
+(sitenumber 0/"overall" covering more than one site) since HTML renders
+several times faster and displays directly in the browser tab, but "pdf"
+for \emph{single-site} report URLs (the traditional printable community report).
+Use "html" or "pdf" to force one format for all URLs, or NULL/"" to omit
+the parameter and get the API's own default. Case/whitespace are
+normalized; any other value is an error (values are placed in a URL, so
+arbitrary text is rejected rather than encoded). Only applied to actual
+API /report URLs, never to app-fallback or ifna links.}
 
 \item{...}{a named list of other query parameters passed to the API,
 to allow for expansion of allowed parameters}

--- a/tests/testthat/test-url_ejamapi.R
+++ b/tests/testthat/test-url_ejamapi.R
@@ -255,6 +255,11 @@ test_that("url_ejamapi fileextension: auto = pdf for single-site, html for multi
   expect_error(url_ejamapi(fips = fips1, fileextension = "html&sitenumber=0"), regexp = "fileextension")
   expect_error(url_ejamapi(fips = fips2, fileextension = c("html", "pdf")), regexp = "fileextension")
 
+  # NA gets the same clear validation message, not a bare
+  # "missing value where TRUE/FALSE needed" condition error
+  expect_error(url_ejamapi(fips = fips1, fileextension = NA), regexp = "fileextension")
+  expect_error(url_ejamapi(fips = fips1, fileextension = NA_character_), regexp = "fileextension")
+
   # the single-polygon app-fallback link is not an API /report URL and is untouched
   expect_equal(
     url_ejamapi(shapefile = testinput_shapes_2[1, ], as_html = FALSE),

--- a/tests/testthat/test-url_ejamapi.R
+++ b/tests/testthat/test-url_ejamapi.R
@@ -223,6 +223,45 @@ test_that("url_ejamapi falls back to app URL for polygon one-site report links",
   )
 })
 
+test_that("url_ejamapi fileextension: auto = pdf for single-site, html for multisite; overridable; validated", {
+  fips1 <- testinput_fips_counties[1]
+  fips2 <- testinput_fips_counties[1:2]
+
+  # default "auto": a single-site report link asks the API for pdf
+  # (the traditional printable community report)
+  expect_true(grepl("&fileextension=pdf", url_ejamapi(fips = fips1), fixed = TRUE))
+
+  # default "each" mode returns a vector of single-site links -> pdf on every URL
+  each_urls <- url_ejamapi(fips = fips2)
+  expect_equal(length(each_urls), 2)
+  expect_true(all(grepl("&fileextension=pdf", each_urls, fixed = TRUE)))
+
+  # aggregate MULTISITE report (sitenumber = 0 covering >1 site) -> html (much faster render)
+  expect_true(grepl("&fileextension=html", url_ejamapi(fips = fips2, sitenumber = 0), fixed = TRUE))
+
+  # but sitenumber = 0 with a single site is coerced to a single-site report -> pdf
+  expect_true(grepl("&fileextension=pdf", url_ejamapi(fips = fips1, sitenumber = 0), fixed = TRUE))
+
+  # explicit override wins in either direction; case/whitespace normalized
+  expect_true(grepl("&fileextension=html", url_ejamapi(fips = fips1, fileextension = "html"), fixed = TRUE))
+  expect_true(grepl("&fileextension=pdf", url_ejamapi(fips = fips2, sitenumber = 0, fileextension = " PDF "), fixed = TRUE))
+
+  # NULL or "" omits the parameter entirely (the API's own default applies)
+  expect_false(grepl("fileextension", url_ejamapi(fips = fips1, fileextension = NULL), fixed = TRUE))
+  expect_false(grepl("fileextension", url_ejamapi(fips = fips1, fileextension = ""), fixed = TRUE))
+
+  # anything else is rejected, not URL-encoded into a raw link
+  expect_error(url_ejamapi(fips = fips1, fileextension = "exe"), regexp = "fileextension")
+  expect_error(url_ejamapi(fips = fips1, fileextension = "html&sitenumber=0"), regexp = "fileextension")
+  expect_error(url_ejamapi(fips = fips2, fileextension = c("html", "pdf")), regexp = "fileextension")
+
+  # the single-polygon app-fallback link is not an API /report URL and is untouched
+  expect_equal(
+    url_ejamapi(shapefile = testinput_shapes_2[1, ], as_html = FALSE),
+    "https://ejanalysis.com/ejamapp"
+  )
+})
+
 # sitenumber (overall vs 1-site) ####
 
 # N  means Nth site report


### PR DESCRIPTION
Scope note: this PR originally also switched the API base URL to the Cloudflare proxy; that was **split out to Public-Environmental-Data-Partners/EJAM#447** (wanted ASAP on its own). This PR now carries ONLY the report-format defaults for generated API report links.

**Change:** `url_ejamapi()` gains a `fileextension` parameter (default `"auto"`) appended to every generated API `/report` URL:

- **auto → `pdf` for single-site report links** (the traditional printable community report — the Details-tab and map-popup per-site links), and **`html` for the aggregate MULTISITE report link** (`sitenumber=0` covering more than one site), where HTML renders several times faster (the PDF path adds two headless-Chrome steps with ~9 s of fixed waits) and displays directly in the opened browser tab.
- `"html"`/`"pdf"` force one format for all URLs; `NULL`/`""` omit the parameter so the API's own default applies.
- Values are normalized (case/whitespace) and strictly validated — anything else errors rather than being concatenated into a raw URL (query-parameter injection guard, per earlier Copilot review).
- Applied only to actual API `/report` URLs — never to the app-fallback links used for single-polygon sites, nor to `ifna` substitutes.
- `sitenumber=0` with a single site is coerced to a single-site report, so it gets `pdf` (consistent with the existing single-site auto-override).

**Tests** cover the auto defaults (single, "each" vector, multisite, single-site coercion), explicit overrides, normalization, omission, validation errors, and fallback-link safety.

Example generated links:
- single county: `.../report?fips=10001&buffer=0&version=3.2022.1&fileextension=pdf`
- two counties combined: `.../report?fips=10001,10003&buffer=0&sitenumber=0&version=3.2022.1&fileextension=html`

Part of the fix for Public-Environmental-Data-Partners/EJAM#293; see also Public-Environmental-Data-Partners/EJAM#446 (caching design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)