### PR TITLE
Route API report links through api.ejanalysis.com (latency quick win: edge-cacheable proxy)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Actively maintained non-EPA version of EJAM, the web app
 License: MIT + file LICENSE
 URL: https://public-environmental-data-partners.github.io/EJAM, https://github.com/Public-Environmental-Data-Partners/EJAM, https://ejanalysis.org
 ejam_data_repo: Public-Environmental-Data-Partners/ejamdata
-ejam_api_url: https://ejamapi-84652557241.us-central1.run.app
+ejam_api_url: https://api.ejanalysis.com
 ejam_api_repo: https://github.com/Public-Environmental-Data-Partners/EJAM-API
 Authors@R: person("Mark A.", "Corrales", , "ejam@ejanalysis.com", role = c("cre", "aut"), comment = c(ORCID = "0000-0002-1696-5638"))
 Author: Mark A. Corrales <ejam@ejanalysis.com>

--- a/R/url_package.R
+++ b/R/url_package.R
@@ -96,7 +96,7 @@ url_package <- function(
   if (type == "api") {
     one_url <- as.vector(desc::desc(file = system.file("DESCRIPTION", package = "EJAM"))$get("ejam_api_url"))
     if (length(one_url) == 0 || is.na(one_url) || !nzchar(one_url)) {
-      one_url <- "https://ejamapi-84652557241.us-central1.run.app"
+      one_url <- "https://api.ejanalysis.com"
     }
     return(sub("/+$", "", one_url[1]))
   }

--- a/tests/testthat/setup-shinytest2.R
+++ b/tests/testthat/setup-shinytest2.R
@@ -1265,7 +1265,9 @@ shinytest2_webapp_functionality <- function(test_category = "all") {
 
       ################################################ #
       shinytestLogMessage("CLICK URL LINK IN INTERACTIVE TABLE")
-      app$set_inputs(interactive_table_cell_clicked = c("1", "1", "<a href=\"https://ejamapi-84652557241.us-central1.run.app/report?fips=3684000&buffer=0&sitetype=fips&validate_regids=FALSE\" target=\"_blank\">EJAM Site Report</a>"),
+      # Build the link from the configured API base (DESCRIPTION ejam_api_url via
+      # url_package("api")) so this fixture tracks the single-sourced host.
+      app$set_inputs(interactive_table_cell_clicked = c("1", "1", paste0("<a href=\"", url_package("api"), "/report?fips=3684000&buffer=0&sitetype=fips&validate_regids=FALSE\" target=\"_blank\">EJAM Site Report</a>")),
                      allow_no_input_binding_ = TRUE, priority_ = "event")
 
       ################################################ #

--- a/tests/testthat/test-URL_FUNCTIONS_part1.R
+++ b/tests/testthat/test-URL_FUNCTIONS_part1.R
@@ -97,7 +97,7 @@ test_that("url_from_keylist for args not in a list", {
 
   expect_equal(
     url_from_keylist(lat = c(35,36), lon = c(-100,-99), radius = 3.14),
-    "https://ejamapi-84652557241.us-central1.run.app/report?lat=35,36&lon=-100,-99&radius=3.14"
+    paste0(url_package("api"), "/report?lat=35,36&lon=-100,-99&radius=3.14")
   )
 })
 

--- a/tests/testthat/test-url_ejamapi.R
+++ b/tests/testthat/test-url_ejamapi.R
@@ -217,10 +217,10 @@ test_that("url_ejamapi falls back to app URL for polygon one-site report links",
     url_ejamapi(shapefile = testinput_shapes_2, as_html = FALSE),
     rep(fallback_url, NROW(testinput_shapes_2))
   )
-  expect_match(
+  expect_true(startsWith(
     url_ejamapi(shapefile = testinput_shapes_2, sitenumber = "overall", as_html = FALSE),
-    "^https://ejamapi-84652557241\\.us-central1\\.run\\.app/report\\?"
-  )
+    paste0(url_package("api"), "/report?")
+  ))
 })
 
 # sitenumber (overall vs 1-site) ####


### PR DESCRIPTION
Split out of Public-Environmental-Data-Partners/EJAM#443 so this can land ASAP on its own; #443 now carries only the report-format (HTML/PDF) default changes.

**Change:** `ejam_api_url` in DESCRIPTION — the single source of truth read by `url_package("api")` — now points at `https://api.ejanalysis.com`, the existing Cloudflare Worker proxy of the same Cloud Run service. The `url_package()` fallback matches, and URL tests derive their expected base from `url_package("api")` instead of a hardcoded host.

**Why:** routing report links through the proxy lets identical GET /report responses be edge-cached by Cloudflare (repeat county/state reports return in milliseconds instead of 13–45 s of recompute). The cache configuration itself is a separate non-code step; the durable version-keyed cache design is Public-Environmental-Data-Partners/EJAM#446.

**Verified live:** a proxied report URL returns the full county report end-to-end against the currently-deployed API (HTTP 200, ~2.9 MB, ~10 s warm), so this is safe to merge independently of any API redeploy.

Part of the fix for Public-Environmental-Data-Partners/EJAM#293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)