### PR TITLE
Deploy v3.2022.1 amendment 3 to dev (public FIPS upload option / ?fips= deep links)

### DIFF
--- a/inst/global_defaults_shiny_public.R
+++ b/inst/global_defaults_shiny_public.R
@@ -123,7 +123,12 @@ global_defaults_shiny_public <- list(
     c(
       'Latitude/Longitude file upload'                = 'latlon',
       'EPA Facility IDs (FRS Identifiers)'            = 'FRS',
-      'Shapefile of polygons'                         = 'SHP'
+      'Shapefile of polygons'                         = 'SHP',
+      # FIPS is included in the public app too: ?fips= deep links (and the
+      # EJScreen "Send to EJAM" handoff of FIPS place selections) select this
+      # option programmatically, and updateSelectInput() cannot select a value
+      # that is not among the choices.
+      'Census place FIPS Codes file upload'           = 'FIPS'
     )
   } else {
     c(

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.MD
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.MD
@@ -1,6 +1,6 @@
 # EJAM Open Issues — Scored by Cost & Benefit
 
-**Total open issues:** 129  |  **Generated:** 2026-07-01  |  **Source:** Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)
+**Total open issues:** 127  |  **Generated:** 2026-07-03  |  **Source:** Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)
 
 **Score payload:** `inst/issues/ejam_issues_scored_by_risk_and_value.json`
 
@@ -19,9 +19,9 @@ Each issue is scored independently on two dimensions:
 
 | Metric | Value |
 |--------|-------|
-| Previous run | 2026-06-10 |
-| Issues opened since previous run | 3 |
-| Issues closed since previous run | 10 |
+| Previous run | 2026-07-01 |
+| Issues opened since previous run | 1 |
+| Issues closed since previous run | 3 |
 | Issues whose quadrant changed | 4 |
 
 ### GitHub rank labels for a later update task
@@ -44,10 +44,10 @@ This scoring script writes the labels below into the JSON payload, but it does n
                 │  (value < median)     │  (value ≥ median)
 ────────────────┼───────────────────────┼───────────────────────
  LOW Cost       │  C — Might As Well    │  A — BEST CANDIDATES
- (cost < med.)  │  29 issues                │  35 issues
+ (cost < med.)  │  28 issues                │  34 issues
 ────────────────┼───────────────────────┼───────────────────────
  HIGH Cost      │  D — WORST CANDIDATES │  B — OK Candidates
- (cost ≥ med.)  │  35 issues                │  30 issues
+ (cost ≥ med.)  │  33 issues                │  32 issues
 ```
 
 ---
@@ -55,7 +55,7 @@ This scoring script writes the labels below into the JSON payload, but it does n
 ## Quadrant A — BEST CANDIDATES — Low Cost, High Benefit
 *Easy fixes with clear high value. Prioritize these above all others.*
 
-**35 issues**
+**34 issues**
 
 - [#156](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/156) | Cost 0 / Benefit 17 | PRIORITY HIGH-ish but not a bug 🐛 — in app - add view of   ejam2areafeatures(out)  (info on % of pop with certain things nearby)
 - [#152](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/152) | Cost 0 / Benefit 15 | PRIORITY HIGH-ish but not a bug 🐛 — build_community_report() needs unit tests, table_signif_round_x100() or table_round() too
@@ -77,14 +77,12 @@ This scoring script writes the labels below into the JSON payload, but it does n
 - [#73](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73) | Cost 3 / Benefit 10 | PRIORITY MEDIUM — in web app, add ways to analyze multiple radii at once or even continuous radius
 - [#354](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/354) | Cost 2 / Benefit 9 | PRIORITY MEDIUM — consider if downloaded report map and/or excel can use polygons in map to do POST API request for 1-site report
 - [#166](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/166) | Cost 2 / Benefit 9 | PRIORITY MEDIUM — could simplify polygons before mapping, saving - check if useful and then implement
-- [#396](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/396) | Cost 0 / Benefit 8 | PRIORITY LOW 🐛 — correct/update the vignette on how to deploy the EJAM app
 - [#351](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/351) | Cost 2 / Benefit 8 | PRIORITY LOW 🐛 — Avoid irrelevant missing-radius warnings for FIPS report header text
 - [#223](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/223) | Cost 2 / Benefit 8 | PRIORITY LOW 🐛 — app_title parameter is not working in ejamapp()
 - [#208](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/208) | Cost 2 / Benefit 8 | PRIORITY LOW 🐛 — check/fix shapefile_from_any() handling of ejam_uniq_id (may affect ejam2map() etc.?)
 - [#119](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/119) | Cost 2 / Benefit 8 | PRIORITY LOW 🐛 — some code assumes RStudio user is in root folder of source package - check & warn/document, or fix
 - [#91](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/91) | Cost 2 / Benefit 8 | PRIORITY MEDIUM — Excel needs new tab with uploaded places or facilities found
 - [#16](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16) | Cost 2 / Benefit 8 | PRIORITY MEDIUM 🐛 — need new/updated "User Guide" ("Help" in header at right) since UI has changed a lot, etc.
-- [#417](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/417) | Cost 0 / Benefit 7 | PRIORITY MEDIUM — Let user specify points by clicking on map in EJScreen and/or map in EJAM
 - [#161](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161) | Cost 0 / Benefit 7 | PRIORITY MEDIUM — ejamapp() should be able to handle mix of fips types
 - [#361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) | Cost 1 / Benefit 7 | PRIORITY MEDIUM — Add date and time of last updated to help with deploys
 - [#163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) | Cost 1 / Benefit 7 | PRIORITY MEDIUM — put certain columns last in table of results (bg count, block count, radius)
@@ -92,6 +90,7 @@ This scoring script writes the labels below into the JSON payload, but it does n
 - [#136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | Cost 1 / Benefit 7 | PRIORITY LOW 🐛 — in web app, fix console  error msg when uploading a shapefile
 - [#288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) | Cost 2 / Benefit 7 | PRIORITY MEDIUM — ratio of 1.0 should not be yellow on community report
 - [#70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) | Cost 2 / Benefit 7 | PRIORITY MEDIUM — set up alerts that monitor and alert staff when the app goes down - ensure available
+- [#284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) | Cost 3 / Benefit 6 | PRIORITY LOW — resolve warning about datum, in logs/console, when web app tries to upload/read some shapefiles
 
 | # | Issue | Cost | Benefit | Priority | Labels (key) |
 |---|-------|------|---------|----------|--------------|
@@ -115,14 +114,12 @@ This scoring script writes the labels below into the JSON payload, but it does n
 | [73](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73) | in web app, add ways to analyze multiple radii at once or even continu… | 3 (🔵 Low) | 10 (🟩🟦 High) | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
 | [354](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/354) | consider if downloaded report map and/or excel can use polygons in map… | 2 (🔵 Low) | 9 (🟩🟦 High) | PRIORITY MEDIUM | Affects Web App, Community Report, rank:A-high-value-low-cost |
 | [166](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/166) | could simplify polygons before mapping, saving - check if useful and t… | 2 (🔵 Low) | 9 (🟩🟦 High) | PRIORITY MEDIUM | Affects Web App, API, rank:A-high-value-low-cost |
-| [396](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/396) | correct/update the vignette on how to deploy the EJAM app | 0 (🟢 Very Low) | 8 (🟦 Medium) | PRIORITY LOW | BUG, documentation, Affects R users only - NOT web app users, rank:A-high-value-low-cost |
 | [351](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/351) | Avoid irrelevant missing-radius warnings for FIPS report header text | 2 (🔵 Low) | 8 (🟦 Medium) | PRIORITY LOW | BUG, good first issue, Affects Web App, Community Report |
 | [223](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/223) | app_title parameter is not working in ejamapp() | 2 (🔵 Low) | 8 (🟦 Medium) | PRIORITY LOW | BUG, Affects Web App, rank:A-high-value-low-cost |
 | [208](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/208) | check/fix shapefile_from_any() handling of ejam_uniq_id (may affect ej… | 2 (🔵 Low) | 8 (🟦 Medium) | PRIORITY LOW | BUG, Affects Web App, rank:A-high-value-low-cost |
 | [119](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/119) | some code assumes RStudio user is in root folder of source package - c… | 2 (🔵 Low) | 8 (🟦 Medium) | PRIORITY LOW | BUG, Affects R users only - NOT web app users, rank:A-high-value-low-cost |
 | [91](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/91) | Excel needs new tab with uploaded places or facilities found | 2 (🔵 Low) | 8 (🟦 Medium) | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
 | [16](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16) | need new/updated "User Guide" ("Help" in header at right) since UI has… | 2 (🔵 Low) | 8 (🟦 Medium) | PRIORITY MEDIUM | BUG, documentation, help wanted, good first issue |
-| [417](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/417) | Let user specify points by clicking on map in EJScreen and/or map in E… | 0 (🟢 Very Low) | 7 (🟦 Medium) | PRIORITY MEDIUM | maps-related, Affects Web App, rank:A-high-value-low-cost |
 | [161](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161) | ejamapp() should be able to handle mix of fips types | 0 (🟢 Very Low) | 7 (🟦 Medium) | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
 | [361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) | Add date and time of last updated to help with deploys | 1 (🟢 Very Low) | 7 (🟦 Medium) | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
 | [163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) | put certain columns last in table of results (bg count, block count, r… | 1 (🟢 Very Low) | 7 (🟦 Medium) | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
@@ -130,13 +127,14 @@ This scoring script writes the labels below into the JSON payload, but it does n
 | [136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | in web app, fix console  error msg when uploading a shapefile | 1 (🟢 Very Low) | 7 (🟦 Medium) | PRIORITY LOW | BUG, rank:A-high-value-low-cost |
 | [288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) | ratio of 1.0 should not be yellow on community report | 2 (🔵 Low) | 7 (🟦 Medium) | PRIORITY MEDIUM | Affects Web App, Community Report, rank:A-high-value-low-cost |
 | [70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) | set up alerts that monitor and alert staff when the app goes down - en… | 2 (🔵 Low) | 7 (🟦 Medium) | PRIORITY MEDIUM | rank:A-high-value-low-cost |
+| [284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) | resolve warning about datum, in logs/console, when web app tries to up… | 3 (🔵 Low) | 6 (🟦 Medium) | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
 
 ---
 
 ## Quadrant B — OK Candidates — High Cost, High Benefit
 *Worth doing but require more effort or expertise. Plan carefully before starting.*
 
-**30 issues**
+**32 issues**
 
 - [#293](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/293) | Cost 5 / Benefit 19 | PRIORITY HIGH-ish but not a bug 🐛 — API takes too long to create a community report from when user clicks
 - [#52](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/52) | Cost 8 / Benefit 17 | PRIORITY HIGH-ish but not a bug 🐛 — Create density score /proximity score/ count-nearby functions, then provide via web app, and API
@@ -149,7 +147,6 @@ This scoring script writes the labels below into the JSON payload, but it does n
 - [#46](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46) | Cost 8 / Benefit 13 | PRIORITY HIGH-ish but not a bug 🐛 — Long Report text needed
 - [#135](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135) | Cost 4 / Benefit 11 | PRIORITY MEDIUM 🐛 — finish work in progress on default_ss_choose_method  vs input$ ?
 - [#126](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126) | Cost 4 / Benefit 11 | PRIORITY MEDIUM — enable 1-site report on Polygons / Shapefile, via links/buttons in shiny map popups and table of sites (but NOT outside shiny like in URL-based/link in Excel table)
-- [#48](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/48) | Cost 8 / Benefit 11 | PRIORITY MEDIUM 🐛 — URLs / links to EJScreen reports for shapefile analysis
 - [#279](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279) | Cost 5 / Benefit 10 | PRIORITY MEDIUM — Prepare the package to submit to CRAN (and get it accepted for hosting on CRAN)
 - [#87](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/87) | Cost 6 / Benefit 10 | PRIORITY MEDIUM — Enable shiny.telemetry log file that is not just a text file on server
 - [#31](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31) | Cost 4 / Benefit 9 | PRIORITY MEDIUM 🐛 — fix distance_avg in doaggregate()$results_bybg_people
@@ -168,6 +165,9 @@ This scoring script writes the labels below into the JSON payload, but it does n
 - [#168](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/168) | Cost 8 / Benefit 7 | PRIORITY MEDIUM — refactor/reconcile "report_logo" vs "logo_path" (parameters and/or global defaults
 - [#256](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/256) | Cost 9 / Benefit 7 | PRIORITY MEDIUM — speed up some functions by using .arrow not .rda version of each large dataset more consistently
 - [#169](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/169) | Cost 9 / Benefit 7 | PRIORITY MEDIUM — harmonize/refactor functions that create or sanitize filenames, paths
+- [#194](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194) | Cost 5 / Benefit 6 | PRIORITY MEDIUM — Create visualizations of overall results in app  - engaging & insightful
+- [#54](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/54) | Cost 9 / Benefit 6 | PRIORITY LOW 🐛 — correctly handle cases where the adjusted distance (via block_radius_miles) is > radius the user specified
+- [#66](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66) | Cost 10 / Benefit 6 | PRIORITY LOW 🐛 — EJAM & EJScreen report on avg PERSON generally but State Average or US Avg shown is avg BLOCK GROUP ! Decide how to reconcile this.
 
 | # | Issue | Cost | Benefit | Priority | Labels (key) |
 |---|-------|------|---------|----------|--------------|
@@ -182,7 +182,6 @@ This scoring script writes the labels below into the JSON payload, but it does n
 | [46](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46) | Long Report text needed | 8 (🟠 High) | 13 (🟩🟩 Very High) | PRIORITY HIGH-ish but not a bug | LongReport_output, future plan list, rank:B-high-value-high-cost |
 | [135](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135) | finish work in progress on default_ss_choose_method  vs input$ ? | 4 (🟡 Medium) | 11 (🟩🟦 High) | PRIORITY MEDIUM | BUG, Affects R users only - NOT web app users, rank:B-high-value-high-cost |
 | [126](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126) | enable 1-site report on Polygons / Shapefile, via links/buttons in shi… | 4 (🟡 Medium) | 11 (🟩🟦 High) | PRIORITY MEDIUM | Affects Web App, API, rank:B-high-value-high-cost |
-| [48](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/48) | URLs / links to EJScreen reports for shapefile analysis | 8 (🟠 High) | 11 (🟩🟦 High) | PRIORITY MEDIUM | BUG, shapefile-related, refactor, URL-related |
 | [279](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279) | Prepare the package to submit to CRAN (and get it accepted for hosting… | 5 (🟡 Medium) | 10 (🟩🟦 High) | PRIORITY MEDIUM | help wanted, Affects R users only - NOT web app users, rank:B-high-value-high-cost |
 | [87](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/87) | Enable shiny.telemetry log file that is not just a text file on server | 6 (🟡 Medium) | 10 (🟩🟦 High) | PRIORITY MEDIUM | datasets-related, Affects Web App, rank:B-high-value-high-cost |
 | [31](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31) | fix distance_avg in doaggregate()$results_bybg_people | 4 (🟡 Medium) | 9 (🟩🟦 High) | PRIORITY MEDIUM | BUG, distance-related, rank:B-high-value-high-cost |
@@ -201,15 +200,17 @@ This scoring script writes the labels below into the JSON payload, but it does n
 | [168](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/168) | refactor/reconcile "report_logo" vs "logo_path" (parameters and/or glo… | 8 (🟠 High) | 7 (🟦 Medium) | PRIORITY MEDIUM | refactor, Affects R users only - NOT web app users, Community Report, rank:B-high-value-high-cost |
 | [256](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/256) | speed up some functions by using .arrow not .rda version of each large… | 9 (🟠 High) | 7 (🟦 Medium) | PRIORITY MEDIUM | datasets-related, speed / performance (see #226), Affects Web App, rank:B-high-value-high-cost |
 | [169](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/169) | harmonize/refactor functions that create or sanitize filenames, paths | 9 (🟠 High) | 7 (🟦 Medium) | PRIORITY MEDIUM | refactor, Affects R users only - NOT web app users, rank:B-high-value-high-cost |
+| [194](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194) | Create visualizations of overall results in app  - engaging & insightf… | 5 (🟡 Medium) | 6 (🟦 Medium) | PRIORITY MEDIUM | plots-graphs-related, future plan list, rank:D-defer |
+| [54](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/54) | correctly handle cases where the adjusted distance (via block_radius_m… | 9 (🟠 High) | 6 (🟦 Medium) | PRIORITY LOW | BUG, calculate/validate to EJScreen, distance-related, rank:D-defer |
+| [66](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66) | EJAM & EJScreen report on avg PERSON generally but State Average or US… | 10 (🟠 High) | 6 (🟦 Medium) | PRIORITY LOW | BUG, calculate/validate to EJScreen, Community Report, rank:D-defer |
 
 ---
 
 ## Quadrant C — Might As Well — Low Cost, Low Benefit
 *Cheap to do; low urgency. Pick these up when bandwidth allows or combine with nearby work.*
 
-**29 issues**
+**28 issues**
 
-- [#284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) | Cost 3 / Benefit 6 | PRIORITY LOW — resolve warning about datum, in logs/console, when web app tries to upload/read some shapefiles
 - [#102](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102) | Cost 0 / Benefit 5 | PRIORITY LOW — Remove NA console messages from `doaggregate`
 - [#403](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403) | Cost 1 / Benefit 5 | PRIORITY MEDIUM — Add explanation of what "average in state" or "percentile in state" means for a multisite report
 - [#350](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350) | Cost 2 / Benefit 5 | PRIORITY LOW 🐛 — Add report regression tests for FIPS, shapefile, sitenumber, NAICS, and PDF-unavailable paths
@@ -241,7 +242,6 @@ This scoring script writes the labels below into the JSON payload, but it does n
 
 | # | Issue | Cost | Benefit | Priority | Labels (key) |
 |---|-------|------|---------|----------|--------------|
-| [284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) | resolve warning about datum, in logs/console, when web app tries to up… | 3 (🔵 Low) | 6 (🟦 Medium) | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
 | [102](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102) | Remove NA console messages from `doaggregate` | 0 (🟢 Very Low) | 5 (🟦 Medium) | PRIORITY LOW | Affects R users only - NOT web app users, rank:C-low-value-low-cost |
 | [403](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403) | Add explanation of what "average in state" or "percentile in state" me… | 1 (🟢 Very Low) | 5 (🟦 Medium) | PRIORITY MEDIUM | documentation, Affects Web App, rank:C-low-value-low-cost |
 | [350](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350) | Add report regression tests for FIPS, shapefile, sitenumber, NAICS, an… | 2 (🔵 Low) | 5 (🟦 Medium) | PRIORITY LOW | BUG, test, Community Report, rank:C-low-value-low-cost |
@@ -276,7 +276,7 @@ This scoring script writes the labels below into the JSON payload, but it does n
 ## Quadrant D — WORST CANDIDATES — High Cost, Low Benefit
 *Expensive to fix, limited payoff. Defer or deprioritize unless circumstances change.*
 
-**35 issues**
+**33 issues**
 
 - [#83](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/83) | Cost 4 / Benefit 5 | PRIORITY LOW — enable selecting a folder as way to upload shapefile(s)
 - [#74](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/74) | Cost 4 / Benefit 5 | PRIORITY MEDIUM — Develop options for defining the Reference Zone or Ref. Group - avg person vs bg vs "other 3-mile circles" - in rural, county, user-defined etc.
@@ -288,7 +288,6 @@ This scoring script writes the labels below into the JSON payload, but it does n
 - [#62](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/62) | Cost 4 / Benefit 1 | PRIORITY LOW — Enable download of 'Plot of Average Scores' and 'Plot Full Range of Scores' plots
 - [#61](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/61) | Cost 4 / Benefit 1 | PRIORITY LOW — downloading excel output with plots for 1000-2000 points takes 10-15 seconds
 - [#55](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/55) | Cost 4 / Benefit 1 | PRIORITY LOW — add links to COUNTY-LEVEL reports - on a place - from other tools/ sources
-- [#194](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194) | Cost 5 / Benefit 6 | PRIORITY MEDIUM — Create visualizations of overall results in app  - engaging & insightful
 - [#33](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/33) | Cost 5 / Benefit 5 | PRIORITY MEDIUM — Move HTML, CSS, and Javascript code into appropriate external files
 - [#80](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/80) | Cost 6 / Benefit 5 | PRIORITY LOW — make latlon_from_naics() and other naics-related functions consistent with others like frs_from_naics()
 - [#77](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/77) | Cost 6 / Benefit 5 | PRIORITY MEDIUM — MODULE: Point layer MODULE (specify URL of service with point data)
@@ -298,6 +297,7 @@ This scoring script writes the labels below into the JSON payload, but it does n
 - [#63](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/63) | Cost 6 / Benefit 1 | PRIORITY LOW — Fix use of mapping_for_names parameter
 - [#180](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/180) | Cost 7 / Benefit 4 | PRIORITY LOW — refactor functions handling sitepoints (espec in url_ functions?)
 - [#27](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/27) | Cost 7 / Benefit 3 | PRIORITY MEDIUM — ability to save/load/bookmark static report settings (and other parameters) -- need to clarify, clean, harmonize, edit documentation
+- [#446](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/446) | Cost 7 / Benefit 2 | — — Cache/precompute FIPS-based reports and boundaries (layered design: bounds, ejamit results, rendered reports)
 - [#18](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/18) | Cost 7 / Benefit 0 | — — some FIPS-related functions/data could be improved
 - [#84](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/84) | Cost 8 / Benefit 5 | PRIORITY LOW — enable an Add Data tool or otherwise harmonize with geoplatform, ejscreen, enviroatlas, echo, etc. to view or link to other layers
 - [#57](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/57) | Cost 8 / Benefit 5 | PRIORITY MEDIUM — Enable analysis of VERY large numbers of points - test limits and code solutions like batching, etc
@@ -306,8 +306,6 @@ This scoring script writes the labels below into the JSON payload, but it does n
 - [#29](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/29) | Cost 8 / Benefit 3 | PRIORITY LOW — add info about zero results/ zero pop & near other sites, to EJAM::doaggregate() outputs (as already provided by EJAMejscreenapi::ejscreenapi() output)
 - [#387](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/387) | Cost 8 / Benefit 1 | PRIORITY LOW — Refactor so 1 release can use any vintage of datasets specified (at load time or per analysis etc)
 - [#386](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/386) | Cost 8 / Benefit 0 | — — ACS table/variable numbering in tables_ejscreen_acs / formulas_ejscreen_acs is not validated against the build year (vintage-correctness risk)
-- [#54](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/54) | Cost 9 / Benefit 6 | PRIORITY LOW 🐛 — correctly handle cases where the adjusted distance (via block_radius_miles) is > radius the user specified
-- [#66](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66) | Cost 10 / Benefit 6 | PRIORITY LOW 🐛 — EJAM & EJScreen report on avg PERSON generally but State Average or US Avg shown is avg BLOCK GROUP ! Decide how to reconcile this.
 - [#32](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/32) | Cost 11 / Benefit 5 | PRIORITY MEDIUM — *** MOVE CODE OUT OF SERVER and app_ui
 - [#399](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/399) | Cost 11 / Benefit 4 | PRIORITY LOW — Pipeline: emit EJSCREEN-formatted 'extensive ACS' table (~951 demographic breakdowns) from S3-supplied indicators
 - [#85](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/85) | Cost 12 / Benefit 5 | PRIORITY LOW — Enable higher resolution analysis than getblocksnearby() does, via Dasymetric mapping
@@ -326,7 +324,6 @@ This scoring script writes the labels below into the JSON payload, but it does n
 | [62](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/62) | Enable download of 'Plot of Average Scores' and 'Plot Full Range of Sc… | 4 (🟡 Medium) | 1 (⬜ Very Low) | PRIORITY LOW | still relevant?, plots-graphs-related, rank:D-defer |
 | [61](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/61) | downloading excel output with plots for 1000-2000 points takes 10-15 s… | 4 (🟡 Medium) | 1 (⬜ Very Low) | PRIORITY LOW | still relevant?, rank:D-defer |
 | [55](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/55) | add links to COUNTY-LEVEL reports - on a place - from other tools/ sou… | 4 (🟡 Medium) | 1 (⬜ Very Low) | PRIORITY LOW | still relevant?, rank:D-defer |
-| [194](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194) | Create visualizations of overall results in app  - engaging & insightf… | 5 (🟡 Medium) | 6 (🟦 Medium) | PRIORITY MEDIUM | plots-graphs-related, future plan list, rank:D-defer |
 | [33](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/33) | Move HTML, CSS, and Javascript code into appropriate external files | 5 (🟡 Medium) | 5 (🟦 Medium) | PRIORITY MEDIUM | refactor, server, rank:D-defer |
 | [80](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/80) | make latlon_from_naics() and other naics-related functions consistent … | 6 (🟡 Medium) | 5 (🟦 Medium) | PRIORITY LOW | refactor, Affects R users only - NOT web app users, rank:D-defer |
 | [77](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/77) | MODULE: Point layer MODULE (specify URL of service with point data) | 6 (🟡 Medium) | 5 (🟦 Medium) | PRIORITY MEDIUM | refactor, server, rank:D-defer |
@@ -336,6 +333,7 @@ This scoring script writes the labels below into the JSON payload, but it does n
 | [63](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/63) | Fix use of mapping_for_names parameter | 6 (🟡 Medium) | 1 (⬜ Very Low) | PRIORITY LOW | still relevant?, refactor, rank:D-defer |
 | [180](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/180) | refactor functions handling sitepoints (espec in url_ functions?) | 7 (🟠 High) | 4 (⬜ Low) | PRIORITY LOW | refactor, Affects R users only - NOT web app users, rank:D-defer |
 | [27](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/27) | ability to save/load/bookmark static report settings (and other parame… | 7 (🟠 High) | 3 (⬜ Low) | PRIORITY MEDIUM | documentation, refactor, server, Community Report |
+| [446](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/446) | Cache/precompute FIPS-based reports and boundaries (layered design: bo… | 7 (🟠 High) | 2 (⬜ Low) | — | speed / performance (see #226), API |
 | [18](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/18) | some FIPS-related functions/data could be improved | 7 (🟠 High) | 0 (⬜ Very Low) | — | datasets-related, rank:D-defer |
 | [84](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/84) | enable an Add Data tool or otherwise harmonize with geoplatform, ejscr… | 8 (🟠 High) | 5 (🟦 Medium) | PRIORITY LOW | shapefile-related, Affects Web App, rank:D-defer |
 | [57](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/57) | Enable analysis of VERY large numbers of points - test limits and code… | 8 (🟠 High) | 5 (🟦 Medium) | PRIORITY MEDIUM | tasklist, speed / performance (see #226), rank:D-defer |
@@ -344,8 +342,6 @@ This scoring script writes the labels below into the JSON payload, but it does n
 | [29](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/29) | add info about zero results/ zero pop & near other sites, to EJAM::doa… | 8 (🟠 High) | 3 (⬜ Low) | PRIORITY LOW | still relevant?, refactor, rank:D-defer |
 | [387](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/387) | Refactor so 1 release can use any vintage of datasets specified (at lo… | 8 (🟠 High) | 1 (⬜ Very Low) | PRIORITY LOW | refactor, rank:D-defer |
 | [386](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/386) | ACS table/variable numbering in tables_ejscreen_acs / formulas_ejscree… | 8 (🟠 High) | 0 (⬜ Very Low) | — | rank:D-defer |
-| [54](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/54) | correctly handle cases where the adjusted distance (via block_radius_m… | 9 (🟠 High) | 6 (🟦 Medium) | PRIORITY LOW | BUG, calculate/validate to EJScreen, distance-related, rank:D-defer |
-| [66](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66) | EJAM & EJScreen report on avg PERSON generally but State Average or US… | 10 (🟠 High) | 6 (🟦 Medium) | PRIORITY LOW | BUG, calculate/validate to EJScreen, Community Report, rank:D-defer |
 | [32](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/32) | *** MOVE CODE OUT OF SERVER and app_ui | 11 (⛔ Very High) | 5 (🟦 Medium) | PRIORITY MEDIUM | refactor, tasklist, server, rank:D-defer |
 | [399](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/399) | Pipeline: emit EJSCREEN-formatted 'extensive ACS' table (~951 demograp… | 11 (⛔ Very High) | 4 (⬜ Low) | PRIORITY LOW | calculate/validate to EJScreen, datasets-related, Affects Web App, rank:D-defer |
 | [85](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/85) | Enable higher resolution analysis than getblocksnearby() does, via Das… | 12 (⛔ Very High) | 5 (🟦 Medium) | PRIORITY LOW | shapefile-related, maps-related, Affects Web App, future plan list |
@@ -354,7 +350,7 @@ This scoring script writes the labels below into the JSON payload, but it does n
 
 ---
 
-## Full Table — All 129 Issues
+## Full Table — All 127 Issues
 
 Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 
@@ -380,14 +376,12 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | A | [73](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73) | 3 | 10 | PRIORITY MEDIUM | in web app, add ways to analyze multiple radii at once or even continuou… |
 | A | [354](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/354) | 2 | 9 | PRIORITY MEDIUM | consider if downloaded report map and/or excel can use polygons in map t… |
 | A | [166](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/166) | 2 | 9 | PRIORITY MEDIUM | could simplify polygons before mapping, saving - check if useful and the… |
-| A | [396](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/396) | 0 | 8 | PRIORITY LOW | correct/update the vignette on how to deploy the EJAM app |
 | A | [351](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/351) | 2 | 8 | PRIORITY LOW | Avoid irrelevant missing-radius warnings for FIPS report header text |
 | A | [223](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/223) | 2 | 8 | PRIORITY LOW | app_title parameter is not working in ejamapp() |
 | A | [208](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/208) | 2 | 8 | PRIORITY LOW | check/fix shapefile_from_any() handling of ejam_uniq_id (may affect ejam… |
 | A | [119](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/119) | 2 | 8 | PRIORITY LOW | some code assumes RStudio user is in root folder of source package - che… |
 | A | [91](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/91) | 2 | 8 | PRIORITY MEDIUM | Excel needs new tab with uploaded places or facilities found |
 | A | [16](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16) | 2 | 8 | PRIORITY MEDIUM | need new/updated "User Guide" ("Help" in header at right) since UI has c… |
-| A | [417](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/417) | 0 | 7 | PRIORITY MEDIUM | Let user specify points by clicking on map in EJScreen and/or map in EJA… |
 | A | [161](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161) | 0 | 7 | PRIORITY MEDIUM | ejamapp() should be able to handle mix of fips types |
 | A | [361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) | 1 | 7 | PRIORITY MEDIUM | Add date and time of last updated to help with deploys |
 | A | [163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) | 1 | 7 | PRIORITY MEDIUM | put certain columns last in table of results (bg count, block count, rad… |
@@ -395,6 +389,7 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | A | [136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | 1 | 7 | PRIORITY LOW | in web app, fix console  error msg when uploading a shapefile |
 | A | [288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) | 2 | 7 | PRIORITY MEDIUM | ratio of 1.0 should not be yellow on community report |
 | A | [70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) | 2 | 7 | PRIORITY MEDIUM | set up alerts that monitor and alert staff when the app goes down - ensu… |
+| A | [284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) | 3 | 6 | PRIORITY LOW | resolve warning about datum, in logs/console, when web app tries to uplo… |
 | B | [293](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/293) | 5 | 19 | PRIORITY HIGH-ish but not a bug | API takes too long to create a community report from when user clicks |
 | B | [52](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/52) | 8 | 17 | PRIORITY HIGH-ish but not a bug | Create density score /proximity score/ count-nearby functions, then prov… |
 | B | [44](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/44) | 18 | 17 | PRIORITY HIGH-ish but not a bug | Investigate options for asynchronous processing in R Shiny (espec for sp… |
@@ -406,7 +401,6 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | B | [46](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46) | 8 | 13 | PRIORITY HIGH-ish but not a bug | Long Report text needed |
 | B | [135](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135) | 4 | 11 | PRIORITY MEDIUM | finish work in progress on default_ss_choose_method  vs input$ ? |
 | B | [126](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126) | 4 | 11 | PRIORITY MEDIUM | enable 1-site report on Polygons / Shapefile, via links/buttons in shiny… |
-| B | [48](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/48) | 8 | 11 | PRIORITY MEDIUM | URLs / links to EJScreen reports for shapefile analysis |
 | B | [279](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279) | 5 | 10 | PRIORITY MEDIUM | Prepare the package to submit to CRAN (and get it accepted for hosting o… |
 | B | [87](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/87) | 6 | 10 | PRIORITY MEDIUM | Enable shiny.telemetry log file that is not just a text file on server |
 | B | [31](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31) | 4 | 9 | PRIORITY MEDIUM | fix distance_avg in doaggregate()$results_bybg_people |
@@ -425,7 +419,9 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | B | [168](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/168) | 8 | 7 | PRIORITY MEDIUM | refactor/reconcile "report_logo" vs "logo_path" (parameters and/or globa… |
 | B | [256](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/256) | 9 | 7 | PRIORITY MEDIUM | speed up some functions by using .arrow not .rda version of each large d… |
 | B | [169](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/169) | 9 | 7 | PRIORITY MEDIUM | harmonize/refactor functions that create or sanitize filenames, paths |
-| C | [284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) | 3 | 6 | PRIORITY LOW | resolve warning about datum, in logs/console, when web app tries to uplo… |
+| B | [194](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194) | 5 | 6 | PRIORITY MEDIUM | Create visualizations of overall results in app  - engaging & insightful |
+| B | [54](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/54) | 9 | 6 | PRIORITY LOW | correctly handle cases where the adjusted distance (via block_radius_mil… |
+| B | [66](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66) | 10 | 6 | PRIORITY LOW | EJAM & EJScreen report on avg PERSON generally but State Average or US A… |
 | C | [102](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102) | 0 | 5 | PRIORITY LOW | Remove NA console messages from `doaggregate` |
 | C | [403](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403) | 1 | 5 | PRIORITY MEDIUM | Add explanation of what "average in state" or "percentile in state" mean… |
 | C | [350](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350) | 2 | 5 | PRIORITY LOW | Add report regression tests for FIPS, shapefile, sitenumber, NAICS, and … |
@@ -464,7 +460,6 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | D | [62](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/62) | 4 | 1 | PRIORITY LOW | Enable download of 'Plot of Average Scores' and 'Plot Full Range of Scor… |
 | D | [61](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/61) | 4 | 1 | PRIORITY LOW | downloading excel output with plots for 1000-2000 points takes 10-15 sec… |
 | D | [55](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/55) | 4 | 1 | PRIORITY LOW | add links to COUNTY-LEVEL reports - on a place - from other tools/ sourc… |
-| D | [194](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194) | 5 | 6 | PRIORITY MEDIUM | Create visualizations of overall results in app  - engaging & insightful |
 | D | [33](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/33) | 5 | 5 | PRIORITY MEDIUM | Move HTML, CSS, and Javascript code into appropriate external files |
 | D | [80](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/80) | 6 | 5 | PRIORITY LOW | make latlon_from_naics() and other naics-related functions consistent wi… |
 | D | [77](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/77) | 6 | 5 | PRIORITY MEDIUM | MODULE: Point layer MODULE (specify URL of service with point data) |
@@ -474,6 +469,7 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | D | [63](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/63) | 6 | 1 | PRIORITY LOW | Fix use of mapping_for_names parameter |
 | D | [180](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/180) | 7 | 4 | PRIORITY LOW | refactor functions handling sitepoints (espec in url_ functions?) |
 | D | [27](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/27) | 7 | 3 | PRIORITY MEDIUM | ability to save/load/bookmark static report settings (and other paramete… |
+| D | [446](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/446) | 7 | 2 | — | Cache/precompute FIPS-based reports and boundaries (layered design: boun… |
 | D | [18](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/18) | 7 | 0 | — | some FIPS-related functions/data could be improved |
 | D | [84](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/84) | 8 | 5 | PRIORITY LOW | enable an Add Data tool or otherwise harmonize with geoplatform, ejscree… |
 | D | [57](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/57) | 8 | 5 | PRIORITY MEDIUM | Enable analysis of VERY large numbers of points - test limits and code s… |
@@ -482,8 +478,6 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | D | [29](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/29) | 8 | 3 | PRIORITY LOW | add info about zero results/ zero pop & near other sites, to EJAM::doagg… |
 | D | [387](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/387) | 8 | 1 | PRIORITY LOW | Refactor so 1 release can use any vintage of datasets specified (at load… |
 | D | [386](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/386) | 8 | 0 | — | ACS table/variable numbering in tables_ejscreen_acs / formulas_ejscreen_… |
-| D | [54](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/54) | 9 | 6 | PRIORITY LOW | correctly handle cases where the adjusted distance (via block_radius_mil… |
-| D | [66](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66) | 10 | 6 | PRIORITY LOW | EJAM & EJScreen report on avg PERSON generally but State Average or US A… |
 | D | [32](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/32) | 11 | 5 | PRIORITY MEDIUM | *** MOVE CODE OUT OF SERVER and app_ui |
 | D | [399](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/399) | 11 | 4 | PRIORITY LOW | Pipeline: emit EJSCREEN-formatted 'extensive ACS' table (~951 demographi… |
 | D | [85](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/85) | 12 | 5 | PRIORITY LOW | Enable higher resolution analysis than getblocksnearby() does, via Dasym… |
@@ -497,7 +491,7 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | Dimension | Range | Median (split threshold) |
 |-----------|-------|--------------------------|
 | Cost    | 0 – 18    | 4 |
-| Benefit | 0 – 19 | 7 |
+| Benefit | 0 – 19 | 6 |
 
 Issues at or above the median are **High**; below are **Low** for that dimension.
 

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.html
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.html
@@ -174,8 +174,8 @@
 <body>
 <h1 id="ejam-open-issues-scored-by-cost-benefit">EJAM Open Issues —
 Scored by Cost &amp; Benefit</h1>
-<p><strong>Total open issues:</strong> 129 | <strong>Generated:</strong>
-2026-07-01 | <strong>Source:</strong> Live GitHub REST API open issues
+<p><strong>Total open issues:</strong> 127 | <strong>Generated:</strong>
+2026-07-03 | <strong>Source:</strong> Live GitHub REST API open issues
 (Public-Environmental-Data-Partners/EJAM)</p>
 <p><strong>Score payload:</strong>
 <code>inst/issues/ejam_issues_scored_by_risk_and_value.json</code></p>
@@ -221,15 +221,15 @@ crash/wrong-calculation signals, CRAN visibility</td>
 <tbody>
 <tr>
 <td>Previous run</td>
-<td>2026-06-10</td>
+<td>2026-07-01</td>
 </tr>
 <tr>
 <td>Issues opened since previous run</td>
-<td>3</td>
+<td>1</td>
 </tr>
 <tr>
 <td>Issues closed since previous run</td>
-<td>10</td>
+<td>3</td>
 </tr>
 <tr>
 <td>Issues whose quadrant changed</td>
@@ -273,16 +273,16 @@ but it does not apply them to GitHub.</p>
                 │  (value &lt; median)     │  (value ≥ median)
 ────────────────┼───────────────────────┼───────────────────────
  LOW Cost       │  C — Might As Well    │  A — BEST CANDIDATES
- (cost &lt; med.)  │  29 issues                │  35 issues
+ (cost &lt; med.)  │  28 issues                │  34 issues
 ────────────────┼───────────────────────┼───────────────────────
  HIGH Cost      │  D — WORST CANDIDATES │  B — OK Candidates
- (cost ≥ med.)  │  35 issues                │  30 issues</code></pre>
+ (cost ≥ med.)  │  33 issues                │  32 issues</code></pre>
 <hr />
 <h2 id="quadrant-a-best-candidates-low-cost-high-benefit">Quadrant A —
 BEST CANDIDATES — Low Cost, High Benefit</h2>
 <p><em>Easy fixes with clear high value. Prioritize these above all
 others.</em></p>
-<p><strong>35 issues</strong></p>
+<p><strong>34 issues</strong></p>
 <ul>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/156">#156</a>
@@ -376,10 +376,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/166">#16
 | Cost 2 / Benefit 9 | PRIORITY MEDIUM — could simplify polygons before
 mapping, saving - check if useful and then implement</li>
 <li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/396">#396</a>
-| Cost 0 / Benefit 8 | PRIORITY LOW 🐛 — correct/update the vignette on
-how to deploy the EJAM app</li>
-<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/351">#351</a>
 | Cost 2 / Benefit 8 | PRIORITY LOW 🐛 — Avoid irrelevant missing-radius
 warnings for FIPS report header text</li>
@@ -404,10 +400,6 @@ uploaded places or facilities found</li>
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16">#16</a>
 | Cost 2 / Benefit 8 | PRIORITY MEDIUM 🐛 — need new/updated “User
 Guide” (“Help” in header at right) since UI has changed a lot, etc.</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/417">#417</a>
-| Cost 0 / Benefit 7 | PRIORITY MEDIUM — Let user specify points by
-clicking on map in EJScreen and/or map in EJAM</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161">#161</a>
 | Cost 0 / Benefit 7 | PRIORITY MEDIUM — ejamapp() should be able to
@@ -436,6 +428,10 @@ yellow on community report</li>
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70">#70</a>
 | Cost 2 / Benefit 7 | PRIORITY MEDIUM — set up alerts that monitor and
 alert staff when the app goes down - ensure available</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">#284</a>
+| Cost 3 / Benefit 6 | PRIORITY LOW — resolve warning about datum, in
+logs/console, when web app tries to upload/read some shapefiles</li>
 </ul>
 <table>
 <colgroup>
@@ -667,16 +663,6 @@ t…</td>
 </tr>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/396">396</a></td>
-<td>correct/update the vignette on how to deploy the EJAM app</td>
-<td>0 (🟢 Very Low)</td>
-<td>8 (🟦 Medium)</td>
-<td>PRIORITY LOW</td>
-<td>BUG, documentation, Affects R users only - NOT web app users,
-rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/351">351</a></td>
 <td>Avoid irrelevant missing-radius warnings for FIPS report header
 text</td>
@@ -733,16 +719,6 @@ has…</td>
 <td>8 (🟦 Medium)</td>
 <td>PRIORITY MEDIUM</td>
 <td>BUG, documentation, help wanted, good first issue</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/417">417</a></td>
-<td>Let user specify points by clicking on map in EJScreen and/or map in
-E…</td>
-<td>0 (🟢 Very Low)</td>
-<td>7 (🟦 Medium)</td>
-<td>PRIORITY MEDIUM</td>
-<td>maps-related, Affects Web App, rank:A-high-value-low-cost</td>
 </tr>
 <tr>
 <td><a
@@ -809,6 +785,16 @@ en…</td>
 <td>PRIORITY MEDIUM</td>
 <td>rank:A-high-value-low-cost</td>
 </tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">284</a></td>
+<td>resolve warning about datum, in logs/console, when web app tries to
+up…</td>
+<td>3 (🔵 Low)</td>
+<td>6 (🟦 Medium)</td>
+<td>PRIORITY LOW</td>
+<td>Affects Web App, rank:C-low-value-low-cost</td>
+</tr>
 </tbody>
 </table>
 <hr />
@@ -816,7 +802,7 @@ en…</td>
 Candidates — High Cost, High Benefit</h2>
 <p><em>Worth doing but require more effort or expertise. Plan carefully
 before starting.</em></p>
-<p><strong>30 issues</strong></p>
+<p><strong>32 issues</strong></p>
 <ul>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/293">#293</a>
@@ -866,10 +852,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126">#12
 | Cost 4 / Benefit 11 | PRIORITY MEDIUM — enable 1-site report on
 Polygons / Shapefile, via links/buttons in shiny map popups and table of
 sites (but NOT outside shiny like in URL-based/link in Excel table)</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/48">#48</a>
-| Cost 8 / Benefit 11 | PRIORITY MEDIUM 🐛 — URLs / links to EJScreen
-reports for shapefile analysis</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279">#279</a>
 | Cost 5 / Benefit 10 | PRIORITY MEDIUM — Prepare the package to submit
@@ -945,6 +927,20 @@ consistently</li>
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/169">#169</a>
 | Cost 9 / Benefit 7 | PRIORITY MEDIUM — harmonize/refactor functions
 that create or sanitize filenames, paths</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194">#194</a>
+| Cost 5 / Benefit 6 | PRIORITY MEDIUM — Create visualizations of
+overall results in app - engaging &amp; insightful</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/54">#54</a>
+| Cost 9 / Benefit 6 | PRIORITY LOW 🐛 — correctly handle cases where
+the adjusted distance (via block_radius_miles) is &gt; radius the user
+specified</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66">#66</a>
+| Cost 10 / Benefit 6 | PRIORITY LOW 🐛 — EJAM &amp; EJScreen report on
+avg PERSON generally but State Average or US Avg shown is avg BLOCK
+GROUP ! Decide how to reconcile this.</li>
 </ul>
 <table>
 <colgroup>
@@ -1076,15 +1072,6 @@ shi…</td>
 <td>11 (🟩🟦 High)</td>
 <td>PRIORITY MEDIUM</td>
 <td>Affects Web App, API, rank:B-high-value-high-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/48">48</a></td>
-<td>URLs / links to EJScreen reports for shapefile analysis</td>
-<td>8 (🟠 High)</td>
-<td>11 (🟩🟦 High)</td>
-<td>PRIORITY MEDIUM</td>
-<td>BUG, shapefile-related, refactor, URL-related</td>
 </tr>
 <tr>
 <td><a
@@ -1251,6 +1238,38 @@ paths</td>
 <td>refactor, Affects R users only - NOT web app users,
 rank:B-high-value-high-cost</td>
 </tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194">194</a></td>
+<td>Create visualizations of overall results in app - engaging &amp;
+insightf…</td>
+<td>5 (🟡 Medium)</td>
+<td>6 (🟦 Medium)</td>
+<td>PRIORITY MEDIUM</td>
+<td>plots-graphs-related, future plan list, rank:D-defer</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/54">54</a></td>
+<td>correctly handle cases where the adjusted distance (via
+block_radius_m…</td>
+<td>9 (🟠 High)</td>
+<td>6 (🟦 Medium)</td>
+<td>PRIORITY LOW</td>
+<td>BUG, calculate/validate to EJScreen, distance-related,
+rank:D-defer</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66">66</a></td>
+<td>EJAM &amp; EJScreen report on avg PERSON generally but State Average
+or US…</td>
+<td>10 (🟠 High)</td>
+<td>6 (🟦 Medium)</td>
+<td>PRIORITY LOW</td>
+<td>BUG, calculate/validate to EJScreen, Community Report,
+rank:D-defer</td>
+</tr>
 </tbody>
 </table>
 <hr />
@@ -1258,12 +1277,8 @@ rank:B-high-value-high-cost</td>
 Might As Well — Low Cost, Low Benefit</h2>
 <p><em>Cheap to do; low urgency. Pick these up when bandwidth allows or
 combine with nearby work.</em></p>
-<p><strong>29 issues</strong></p>
+<p><strong>28 issues</strong></p>
 <ul>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">#284</a>
-| Cost 3 / Benefit 6 | PRIORITY LOW — resolve warning about datum, in
-logs/console, when web app tries to upload/read some shapefiles</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102">#102</a>
 | Cost 0 / Benefit 5 | PRIORITY LOW — Remove NA console messages from
@@ -1400,16 +1415,6 @@ with common convention</li>
 </tr>
 </thead>
 <tbody>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">284</a></td>
-<td>resolve warning about datum, in logs/console, when web app tries to
-up…</td>
-<td>3 (🔵 Low)</td>
-<td>6 (🟦 Medium)</td>
-<td>PRIORITY LOW</td>
-<td>Affects Web App, rank:C-low-value-low-cost</td>
-</tr>
 <tr>
 <td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102">102</a></td>
@@ -1688,7 +1693,7 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60">60</
 WORST CANDIDATES — High Cost, Low Benefit</h2>
 <p><em>Expensive to fix, limited payoff. Defer or deprioritize unless
 circumstances change.</em></p>
-<p><strong>35 issues</strong></p>
+<p><strong>33 issues</strong></p>
 <ul>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/83">#83</a>
@@ -1732,10 +1737,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/55">#55<
 | Cost 4 / Benefit 1 | PRIORITY LOW — add links to COUNTY-LEVEL reports
 - on a place - from other tools/ sources</li>
 <li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194">#194</a>
-| Cost 5 / Benefit 6 | PRIORITY MEDIUM — Create visualizations of
-overall results in app - engaging &amp; insightful</li>
-<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/33">#33</a>
 | Cost 5 / Benefit 5 | PRIORITY MEDIUM — Move HTML, CSS, and Javascript
 code into appropriate external files</li>
@@ -1774,6 +1775,11 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/27">#27<
 static report settings (and other parameters) – need to clarify, clean,
 harmonize, edit documentation</li>
 <li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/446">#446</a>
+| Cost 7 / Benefit 2 | — — Cache/precompute FIPS-based reports and
+boundaries (layered design: bounds, ejamit results, rendered
+reports)</li>
+<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/18">#18</a>
 | Cost 7 / Benefit 0 | — — some FIPS-related functions/data could be
 improved</li>
@@ -1810,16 +1816,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/386">#38
 | Cost 8 / Benefit 0 | — — ACS table/variable numbering in
 tables_ejscreen_acs / formulas_ejscreen_acs is not validated against the
 build year (vintage-correctness risk)</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/54">#54</a>
-| Cost 9 / Benefit 6 | PRIORITY LOW 🐛 — correctly handle cases where
-the adjusted distance (via block_radius_miles) is &gt; radius the user
-specified</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66">#66</a>
-| Cost 10 / Benefit 6 | PRIORITY LOW 🐛 — EJAM &amp; EJScreen report on
-avg PERSON generally but State Average or US Avg shown is avg BLOCK
-GROUP ! Decide how to reconcile this.</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/32">#32</a>
 | Cost 11 / Benefit 5 | PRIORITY MEDIUM — *** MOVE CODE OUT OF SERVER
@@ -1960,16 +1956,6 @@ sou…</td>
 </tr>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194">194</a></td>
-<td>Create visualizations of overall results in app - engaging &amp;
-insightf…</td>
-<td>5 (🟡 Medium)</td>
-<td>6 (🟦 Medium)</td>
-<td>PRIORITY MEDIUM</td>
-<td>plots-graphs-related, future plan list, rank:D-defer</td>
-</tr>
-<tr>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/33">33</a></td>
 <td>Move HTML, CSS, and Javascript code into appropriate external
 files</td>
@@ -2061,6 +2047,16 @@ parame…</td>
 </tr>
 <tr>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/446">446</a></td>
+<td>Cache/precompute FIPS-based reports and boundaries (layered design:
+bo…</td>
+<td>7 (🟠 High)</td>
+<td>2 (⬜ Low)</td>
+<td>—</td>
+<td>speed / performance (see #226), API</td>
+</tr>
+<tr>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/18">18</a></td>
 <td>some FIPS-related functions/data could be improved</td>
 <td>7 (🟠 High)</td>
@@ -2142,28 +2138,6 @@ formulas_ejscree…</td>
 </tr>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/54">54</a></td>
-<td>correctly handle cases where the adjusted distance (via
-block_radius_m…</td>
-<td>9 (🟠 High)</td>
-<td>6 (🟦 Medium)</td>
-<td>PRIORITY LOW</td>
-<td>BUG, calculate/validate to EJScreen, distance-related,
-rank:D-defer</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66">66</a></td>
-<td>EJAM &amp; EJScreen report on avg PERSON generally but State Average
-or US…</td>
-<td>10 (🟠 High)</td>
-<td>6 (🟦 Medium)</td>
-<td>PRIORITY LOW</td>
-<td>BUG, calculate/validate to EJScreen, Community Report,
-rank:D-defer</td>
-</tr>
-<tr>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/32">32</a></td>
 <td>*** MOVE CODE OUT OF SERVER and app_ui</td>
 <td>11 (⛔ Very High)</td>
@@ -2216,7 +2190,7 @@ code</td>
 </tbody>
 </table>
 <hr />
-<h2 id="full-table-all-129-issues">Full Table — All 129 Issues</h2>
+<h2 id="full-table-all-127-issues">Full Table — All 127 Issues</h2>
 <p>Sorted: A first (best), then B, C, D; within each group by benefit
 DESC.</p>
 <table>
@@ -2442,15 +2416,6 @@ the…</td>
 <tr>
 <td>A</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/396">396</a></td>
-<td>0</td>
-<td>8</td>
-<td>PRIORITY LOW</td>
-<td>correct/update the vignette on how to deploy the EJAM app</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/351">351</a></td>
 <td>2</td>
 <td>8</td>
@@ -2505,16 +2470,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16">16</
 <td>PRIORITY MEDIUM</td>
 <td>need new/updated “User Guide” (“Help” in header at right) since UI
 has c…</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/417">417</a></td>
-<td>0</td>
-<td>7</td>
-<td>PRIORITY MEDIUM</td>
-<td>Let user specify points by clicking on map in EJScreen and/or map in
-EJA…</td>
 </tr>
 <tr>
 <td>A</td>
@@ -2580,6 +2535,16 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70">70</
 <td>PRIORITY MEDIUM</td>
 <td>set up alerts that monitor and alert staff when the app goes down -
 ensu…</td>
+</tr>
+<tr>
+<td>A</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">284</a></td>
+<td>3</td>
+<td>6</td>
+<td>PRIORITY LOW</td>
+<td>resolve warning about datum, in logs/console, when web app tries to
+uplo…</td>
 </tr>
 <tr>
 <td>B</td>
@@ -2685,15 +2650,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126">126
 <td>PRIORITY MEDIUM</td>
 <td>enable 1-site report on Polygons / Shapefile, via links/buttons in
 shiny…</td>
-</tr>
-<tr>
-<td>B</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/48">48</a></td>
-<td>8</td>
-<td>11</td>
-<td>PRIORITY MEDIUM</td>
-<td>URLs / links to EJScreen reports for shapefile analysis</td>
 </tr>
 <tr>
 <td>B</td>
@@ -2853,14 +2809,34 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/169">169
 paths</td>
 </tr>
 <tr>
-<td>C</td>
+<td>B</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">284</a></td>
-<td>3</td>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194">194</a></td>
+<td>5</td>
+<td>6</td>
+<td>PRIORITY MEDIUM</td>
+<td>Create visualizations of overall results in app - engaging &amp;
+insightful</td>
+</tr>
+<tr>
+<td>B</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/54">54</a></td>
+<td>9</td>
 <td>6</td>
 <td>PRIORITY LOW</td>
-<td>resolve warning about datum, in logs/console, when web app tries to
-uplo…</td>
+<td>correctly handle cases where the adjusted distance (via
+block_radius_mil…</td>
+</tr>
+<tr>
+<td>B</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66">66</a></td>
+<td>10</td>
+<td>6</td>
+<td>PRIORITY LOW</td>
+<td>EJAM &amp; EJScreen report on avg PERSON generally but State Average
+or US A…</td>
 </tr>
 <tr>
 <td>C</td>
@@ -3225,16 +3201,6 @@ sourc…</td>
 <tr>
 <td>D</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194">194</a></td>
-<td>5</td>
-<td>6</td>
-<td>PRIORITY MEDIUM</td>
-<td>Create visualizations of overall results in app - engaging &amp;
-insightful</td>
-</tr>
-<tr>
-<td>D</td>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/33">33</a></td>
 <td>5</td>
 <td>5</td>
@@ -3324,6 +3290,16 @@ paramete…</td>
 <tr>
 <td>D</td>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/446">446</a></td>
+<td>7</td>
+<td>2</td>
+<td>—</td>
+<td>Cache/precompute FIPS-based reports and boundaries (layered design:
+boun…</td>
+</tr>
+<tr>
+<td>D</td>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/18">18</a></td>
 <td>7</td>
 <td>0</td>
@@ -3403,26 +3379,6 @@ formulas_ejscreen_…</td>
 <tr>
 <td>D</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/54">54</a></td>
-<td>9</td>
-<td>6</td>
-<td>PRIORITY LOW</td>
-<td>correctly handle cases where the adjusted distance (via
-block_radius_mil…</td>
-</tr>
-<tr>
-<td>D</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66">66</a></td>
-<td>10</td>
-<td>6</td>
-<td>PRIORITY LOW</td>
-<td>EJAM &amp; EJScreen report on avg PERSON generally but State Average
-or US A…</td>
-</tr>
-<tr>
-<td>D</td>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/32">32</a></td>
 <td>11</td>
 <td>5</td>
@@ -3490,7 +3446,7 @@ code</td>
 <tr>
 <td>Benefit</td>
 <td>0 – 19</td>
-<td>7</td>
+<td>6</td>
 </tr>
 </tbody>
 </table>

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.json
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generated": "2026-07-01",
+    "generated": "2026-07-03",
     "source": "Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)",
     "repository": "Public-Environmental-Data-Partners/EJAM",
-    "open_issue_count": 129,
+    "open_issue_count": 127,
     "cost_median": 4,
-    "benefit_median": 7,
+    "benefit_median": 6,
     "rank_labels": {
       "A": "rank:A-high-value-low-cost",
       "B": "rank:B-high-value-high-cost",
@@ -14,57 +14,45 @@
     },
     "report_path": "inst/issues/ejam_issues_scored_by_risk_and_value.MD",
     "run_changes": {
-      "previous_run": "2026-06-10",
-      "opened_count": 3,
-      "closed_count": 10,
+      "previous_run": "2026-07-01",
+      "opened_count": 1,
+      "closed_count": 3,
       "quadrant_changed_count": 4,
       "opened_issue_numbers": [
-        403,
-        410,
-        417
+        446
       ],
       "closed_issue_numbers": [
-        22,
-        67,
-        76,
-        94,
-        143,
-        148,
-        171,
-        173,
-        331,
-        395
+        48,
+        396,
+        417
       ],
       "quadrant_changed_issue_numbers": [
-        16,
-        19,
-        24,
-        159
+        54,
+        66,
+        194,
+        284
       ]
     }
   },
   "issues": [
     {
-      "number": 417,
-      "title": "Let user specify points by clicking on map in EJScreen and/or map in EJAM",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/417",
+      "number": 446,
+      "title": "Cache/precompute FIPS-based reports and boundaries (layered design: bounds, ejamit results, rendered reports)",
+      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/446",
       "existing_labels": [
-        "enhancement",
-        "PRIORITY MEDIUM",
-        "maps-related",
-        "Affects Web App",
-        "rank:A-high-value-low-cost"
+        "speed / performance (see #226)",
+        "API"
       ],
-      "cost": 0,
-      "benefit": 7,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "cost": 7,
+      "benefit": 2,
+      "quadrant": "D",
+      "rank_label": "rank:D-defer",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
-        "rank:D-defer"
+        "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 0\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 7\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 410,
@@ -86,7 +74,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 1\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 1\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 403,
@@ -108,7 +96,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 1\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 1\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 400,
@@ -129,7 +117,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 3\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 3\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 399,
@@ -152,29 +140,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 11\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 396,
-      "title": "correct/update the vignette on how to deploy the EJAM app",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/396",
-      "existing_labels": [
-        "BUG",
-        "documentation",
-        "PRIORITY LOW",
-        "Affects R users only - NOT web app users",
-        "rank:A-high-value-low-cost"
-      ],
-      "cost": 0,
-      "benefit": 8,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
-      "rank_labels_to_remove": [
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
-        "rank:D-defer"
-      ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 0\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 11\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 391,
@@ -196,7 +162,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 3\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 3\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 387,
@@ -217,7 +183,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 8\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 8\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 386,
@@ -235,7 +201,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 8\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 8\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 385,
@@ -257,7 +223,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 1\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 1\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 361,
@@ -278,7 +244,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 354,
@@ -300,7 +266,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 351,
@@ -323,7 +289,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 350,
@@ -345,7 +311,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 349,
@@ -370,7 +336,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 348,
@@ -394,7 +360,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 344,
@@ -417,7 +383,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 343,
@@ -435,7 +401,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 342,
@@ -457,7 +423,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 341,
@@ -479,7 +445,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 293,
@@ -502,7 +468,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 5\nBenefit score: 19\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 5\nBenefit score: 19\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 288,
@@ -524,7 +490,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 284,
@@ -538,14 +504,14 @@
       ],
       "cost": 3,
       "benefit": 6,
-      "quadrant": "C",
-      "rank_label": "rank:C-low-value-low-cost",
+      "quadrant": "A",
+      "rank_label": "rank:A-high-value-low-cost",
       "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
+        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 3\nBenefit score: 6\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 3\nBenefit score: 6\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 279,
@@ -567,7 +533,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 5\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 5\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 274,
@@ -589,7 +555,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 256,
@@ -612,7 +578,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 249,
@@ -633,7 +599,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 242,
@@ -654,7 +620,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 231,
@@ -675,7 +641,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 226,
@@ -698,7 +664,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 7\nBenefit score: 16\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 7\nBenefit score: 16\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 224,
@@ -718,7 +684,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 223,
@@ -739,7 +705,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 208,
@@ -760,7 +726,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 205,
@@ -783,7 +749,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 194,
@@ -798,14 +764,14 @@
       ],
       "cost": 5,
       "benefit": 6,
-      "quadrant": "D",
-      "rank_label": "rank:D-defer",
+      "quadrant": "B",
+      "rank_label": "rank:B-high-value-high-cost",
       "rank_labels_to_remove": [
         "rank:A-high-value-low-cost",
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost"
+        "rank:C-low-value-low-cost",
+        "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 5\nBenefit score: 6\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 5\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 193,
@@ -828,7 +794,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 5\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 5\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 192,
@@ -850,7 +816,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 184,
@@ -873,7 +839,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 183,
@@ -896,7 +862,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 0\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 0\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 182,
@@ -918,7 +884,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 181,
@@ -941,7 +907,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 180,
@@ -963,7 +929,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 7\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 7\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 179,
@@ -985,7 +951,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 177,
@@ -1006,7 +972,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 176,
@@ -1028,7 +994,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 175,
@@ -1049,7 +1015,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 174,
@@ -1071,7 +1037,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 172,
@@ -1093,7 +1059,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 170,
@@ -1115,7 +1081,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 169,
@@ -1137,7 +1103,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 168,
@@ -1160,7 +1126,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 8\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 8\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 167,
@@ -1183,7 +1149,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 166,
@@ -1205,7 +1171,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 163,
@@ -1226,7 +1192,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 162,
@@ -1247,7 +1213,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 161,
@@ -1268,7 +1234,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 0\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 0\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 159,
@@ -1291,7 +1257,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 156,
@@ -1313,7 +1279,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 0\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 0\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 153,
@@ -1335,7 +1301,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 152,
@@ -1358,7 +1324,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 0\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 0\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 144,
@@ -1380,7 +1346,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 0\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 0\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 137,
@@ -1401,7 +1367,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 1\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 1\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 136,
@@ -1421,7 +1387,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 135,
@@ -1442,7 +1408,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 127,
@@ -1463,7 +1429,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 0\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 0\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 126,
@@ -1485,7 +1451,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 119,
@@ -1506,7 +1472,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 109,
@@ -1528,7 +1494,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 1\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 1\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 103,
@@ -1550,7 +1516,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 102,
@@ -1573,7 +1539,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 0\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 0\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 96,
@@ -1596,7 +1562,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 95,
@@ -1621,7 +1587,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 8\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 8\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 93,
@@ -1644,7 +1610,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 92,
@@ -1667,7 +1633,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 91,
@@ -1690,7 +1656,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 89,
@@ -1713,7 +1679,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 87,
@@ -1737,7 +1703,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 6\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 6\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 86,
@@ -1761,7 +1727,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 6\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 6\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 85,
@@ -1787,7 +1753,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 12\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 12\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 84,
@@ -1811,7 +1777,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 8\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 8\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 83,
@@ -1835,7 +1801,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 82,
@@ -1858,7 +1824,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 81,
@@ -1881,7 +1847,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 80,
@@ -1905,7 +1871,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 6\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 6\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 77,
@@ -1929,7 +1895,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 6\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 6\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 75,
@@ -1954,7 +1920,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 6\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 6\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 74,
@@ -1976,7 +1942,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 73,
@@ -1999,7 +1965,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 3\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 3\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 72,
@@ -2023,7 +1989,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 70,
@@ -2045,7 +2011,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 69,
@@ -2067,7 +2033,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 68,
@@ -2089,7 +2055,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 66,
@@ -2106,14 +2072,14 @@
       ],
       "cost": 10,
       "benefit": 6,
-      "quadrant": "D",
-      "rank_label": "rank:D-defer",
+      "quadrant": "B",
+      "rank_label": "rank:B-high-value-high-cost",
       "rank_labels_to_remove": [
         "rank:A-high-value-low-cost",
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost"
+        "rank:C-low-value-low-cost",
+        "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 10\nBenefit score: 6\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 10\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 63,
@@ -2136,7 +2102,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 62,
@@ -2159,7 +2125,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 61,
@@ -2181,7 +2147,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 60,
@@ -2207,7 +2173,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 3\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 3\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 59,
@@ -2229,7 +2195,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 58,
@@ -2251,7 +2217,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 57,
@@ -2275,7 +2241,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 8\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 8\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 56,
@@ -2301,7 +2267,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 6\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 6\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 55,
@@ -2323,7 +2289,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 54,
@@ -2340,14 +2306,14 @@
       ],
       "cost": 9,
       "benefit": 6,
-      "quadrant": "D",
-      "rank_label": "rank:D-defer",
+      "quadrant": "B",
+      "rank_label": "rank:B-high-value-high-cost",
       "rank_labels_to_remove": [
         "rank:A-high-value-low-cost",
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost"
+        "rank:C-low-value-low-cost",
+        "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 9\nBenefit score: 6\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 9\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 53,
@@ -2371,7 +2337,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 6\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 6\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 52,
@@ -2395,7 +2361,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 8\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 8\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 51,
@@ -2420,7 +2386,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 12\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 12\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 50,
@@ -2446,33 +2412,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 8\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 48,
-      "title": "URLs / links to EJScreen reports for shapefile analysis",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/48",
-      "existing_labels": [
-        "BUG",
-        "PRIORITY MEDIUM",
-        "retain-0325",
-        "from archive",
-        "shapefile-related",
-        "refactor",
-        "URL-related",
-        "API",
-        "rank:B-high-value-high-cost"
-      ],
-      "cost": 8,
-      "benefit": 11,
-      "quadrant": "B",
-      "rank_label": "rank:B-high-value-high-cost",
-      "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
-        "rank:C-low-value-low-cost",
-        "rank:D-defer"
-      ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 8\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 8\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 46,
@@ -2496,7 +2436,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 8\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 8\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 44,
@@ -2521,7 +2461,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 18\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 18\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 43,
@@ -2544,7 +2484,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 42,
@@ -2567,7 +2507,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 41,
@@ -2590,7 +2530,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 40,
@@ -2612,7 +2552,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 39,
@@ -2635,7 +2575,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 37,
@@ -2659,7 +2599,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 35,
@@ -2683,7 +2623,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 34,
@@ -2707,7 +2647,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 6\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 6\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 33,
@@ -2731,7 +2671,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 5\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 5\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 32,
@@ -2756,7 +2696,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 11\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 11\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 31,
@@ -2779,7 +2719,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 29,
@@ -2802,7 +2742,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 8\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 8\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 27,
@@ -2828,7 +2768,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 7\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 7\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 26,
@@ -2851,7 +2791,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 4\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 4\nBenefit score: 5\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 25,
@@ -2874,7 +2814,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 12\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 12\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 24,
@@ -2897,7 +2837,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 19,
@@ -2920,7 +2860,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 6\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 6\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 18,
@@ -2940,7 +2880,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 7\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 7\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 16,
@@ -2963,7 +2903,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-01\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-03\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     }
   ]
 }

--- a/tests/testthat/test-webapp-ui_and_server.R
+++ b/tests/testthat/test-webapp-ui_and_server.R
@@ -509,3 +509,21 @@ test_that("global_or_param() resolves default_upload_dropdown as a back-compat a
 })
 
 ################################################# #
+
+test_that("upload-type choices include FIPS in public and non-public configs", {
+  # ?fips= deep links (and the EJScreen "Send to EJAM" handoff of FIPS place
+  # selections) programmatically select the FIPS upload type via
+  # updateSelectInput(), which silently keeps the old selection when the
+  # requested value is not among the configured choices. So FIPS must be
+  # present in default_choices_for_type_of_site_upload even when isPublic =
+  # TRUE (regression test: the public config used to omit it, which made
+  # ?fips= deep links a silent no-op on the hosted app).
+  old_golem <- shiny::getShinyOption("golem_options")
+  on.exit(shiny::shinyOptions(golem_options = old_golem), add = TRUE)
+  g_public <- EJAM:::get_global_defaults_or_user_options(
+    user_specified_options = list(isPublic = TRUE), bookmarking_allowed = "disable")
+  expect_true("FIPS" %in% g_public$default_choices_for_type_of_site_upload)
+  g_private <- EJAM:::get_global_defaults_or_user_options(
+    user_specified_options = list(isPublic = FALSE), bookmarking_allowed = "disable")
+  expect_true("FIPS" %in% g_private$default_choices_for_type_of_site_upload)
+})


### PR DESCRIPTION
Ships the re-cut v3.2022.1 (tag now at 1133390, Public-Environmental-Data-Partners/EJAM#456): the public app's upload-type menu now includes FIPS, fixing ?fips= deep links and the EJScreen Send-to-EJAM FIPS handoff, plus a regression test. New commit => new ECR tag. Tarball verified fresh before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)