### PR TITLE
v3.2022.1 amendment 4: url_ejscreenmap EJScreen deep links + docs (production cut)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,15 @@ web app with the sites already loaded and ready to analyze. The supporting piece
   a Cloudflare-fronted shortcut on ejanalysis.com that forwards the query string
   (302 redirect) to the live app so launch parameters arrive intact.
 
+- `url_ejscreenmap()` was rewritten to generate **deep links into EJScreen** that
+  actually draw and select the place(s) on the EJScreen map -- `?fips=` (county,
+  tract, or blockgroup, mixes allowed), `?lat=&lon=` points (with optional
+  `radius=`), or `?polygon=` vertex lists -- matching the new inbound deep-link
+  vocabulary EJScreen itself gained (so links from EJAM reports and tables select
+  the analyzed place for an EJScreen report instead of only dropping a centroid
+  pin). Stored test outputs were deliberately not regenerated for the resulting
+  URL-column changes.
+
 - The EJAM API base URL is now **single-sourced**: functions read it from
   `DESCRIPTION` (`ejam_api_url`) via `url_package("api")`, so the endpoint can be
   changed in one place instead of being hardcoded in several. The default is now

--- a/R/URL_FUNCTIONS_part2.R
+++ b/R/URL_FUNCTIONS_part2.R
@@ -800,6 +800,7 @@ url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
   if (is.null(lat) || is.null(lon) || length(lat) == 0 || length(lon) == 0) {
     ## wherestr-only, or nothing usable ####
     if (!is.null(wherestr) && length(wherestr) > 0 && any(!is.na(wherestr) & nzchar(wherestr))) {
+      wherestr <- as.character(wherestr) # e.g., a zip code passed as a number
       ok <- !is.na(wherestr) & nzchar(wherestr)
       whereq <- rep(NA_character_, length(wherestr))
       # encode the free-text value once here; the app unescape()s it

--- a/R/URL_FUNCTIONS_part2.R
+++ b/R/URL_FUNCTIONS_part2.R
@@ -625,7 +625,10 @@ url_efpoints <- function(sitecategory = c("npl", "tri", "water", "air", "tsdf", 
 #' @param radius optional buffer distance in miles for the EJScreen report around
 #'   each point (or polygon). When provided, point links use the app's
 #'   `?lat=&lon=&radius=` parameters (instead of `?wherestr=lat,lon`) so the
-#'   report buffer is prefilled.
+#'   report buffer is prefilled. Must be a single number greater than zero:
+#'   zero (or a negative or non-numeric value) means no buffer is prefilled,
+#'   so it is left out of the URL, which EJScreen treats the same way
+#'   (its deep links only apply a `radius=` that is greater than zero).
 #' @param combined set TRUE to get ONE URL that loads ALL of the sites together
 #'   in a single EJScreen session (drawn on the map and accumulated into the
 #'   app's Multisite list, ready for a Multisite Report or Send to EJAM),

--- a/R/URL_FUNCTIONS_part2.R
+++ b/R/URL_FUNCTIONS_part2.R
@@ -556,12 +556,28 @@ url_efpoints <- function(sitecategory = c("npl", "tri", "water", "air", "tsdf", 
 # functions using lat,lon (sometimes from regid) ####
 # . ####
 
-#' Get URL(s) for (new) EJSCREEN app with map centered at given point(s)
+#' Get URL(s) for (new) EJSCREEN app with the given place(s) selected on the map
+#'
+#' @details These are deep links into the EJScreen map app. For county, tract, or
+#'   blockgroup FIPS codes, for points (with a radius), and for small polygons,
+#'   the URL makes EJScreen actually draw and select the place(s) for analysis
+#'   (boundary drawn, report popup or multisite list ready), using the
+#'   `?fips=`, `?lat=&lon=&radius=`, and `?polygon=` parameters of the app.
+#'
+#'   Note the selection-drawing parameters require the version of the EJScreen app
+#'   that supports deep links (PEDP EJScreen as of mid-2026 or later); older
+#'   deployments ignore them and just open the map. The `wherestr=` style links
+#'   (the default for points when no radius is given, and the fallback for state
+#'   or city/CDP FIPS) work on all versions of the app.
 #'
 #' @param sitepoints data.frame with colnames lat, lon (or lat, lon parameters can be provided separately)
 #' @param lat,lon vectors of coordinates, ignored if sitepoints provided, can be used otherwise, if shapefile and fips not used
-#' @param fips The FIPS code of a place to center map on (blockgroup, tract, city/cdp, county, state FIPS).
-#'   It gets translated into the right wherestr parameter if fips is provided.
+#' @param fips FIPS code(s) of place(s) to select on the map.
+#'   County (5-digit), tract (11), and blockgroup (12) codes become `?fips=`
+#'   deep links that make the EJScreen app draw and select the boundary.
+#'   State (2-digit) and city/CDP (7-digit) codes are not supported by the app's
+#'   boundary services, so those are translated via [fips2name()] into a
+#'   `?wherestr=` place-name search (map centers there without a boundary).
 #'
 #' @param wherestr If fips and sitepoints (or lat and lon) are not provided,
 #'   wherestr should be the street address, zip code, or place name (not FIPS code!).
@@ -573,26 +589,43 @@ url_efpoints <- function(sitecategory = c("npl", "tri", "water", "air", "tsdf", 
 #'
 #'   For County FIPS code 10001, use url_ejscreenmap(fips = "10001")
 #'
-#'   This parameter is passed to the API as wherestr= , if point and fips are not specified.
+#'   This parameter is passed to the app as wherestr= , if point and fips are not specified.
 #'
 #'   Can be State abbrev like "NY" or full state name,
 #'   or city like "New Rochelle, NY" as from fips2name() -- using fips2name()
 #'   works for state, county, or city FIPS code converted to name,
 #'   but using the fips parameter is probably a better idea.
 #'
-#' @param shapefile shows URL of a EJSCREEN app map centered on the centroid of a given polygon,
-#'   but does not actually show the polygon.
+#' @param shapefile polygon(s) as from [shapefile_from_any()]. The outline of each
+#'   polygon (exterior ring, simplified as needed to fit in a URL) is passed via
+#'   the app's `?polygon=` parameter so EJScreen draws and selects it. If an
+#'   outline is too complex to fit even after simplification, that site falls
+#'   back to the old behavior: a `?wherestr=lat,lon` link centered on the
+#'   polygon's centroid (no boundary drawn).
 #' @param shape,shp aliases (synonyms) for shapefile
+#' @param radius optional buffer distance in miles for the EJScreen report around
+#'   each point (or polygon). When provided, point links use the app's
+#'   `?lat=&lon=&radius=` parameters (instead of `?wherestr=lat,lon`) so the
+#'   report buffer is prefilled.
+#' @param combined set TRUE to get ONE URL that loads ALL of the sites together
+#'   in a single EJScreen session (drawn on the map and accumulated into the
+#'   app's Multisite list, ready for a Multisite Report or Send to EJAM),
+#'   instead of the default of one URL per site. Works when all sites are
+#'   county/tract/blockgroup fips, or all are points, or all are small polygons.
 #' @param as_html Whether to return as just the urls or as html hyperlinks to use in a DT::datatable() for example
 #' @param linktext used as text for hyperlinks, if supplied and as_html=TRUE
 #' @param ifna URL shown for missing, NA, NULL, bad input values
 #' @param baseurl do not change unless endpoint actually changed
-#' @param ... unused
+#' @param ... regid can be provided (used to look up lat,lon as a last resort if no sites provided); other arguments ignored
 #'
-#' @return URL(s)
+#' @return URL(s), or a single URL if combined = TRUE
 #' @seealso [url_ejamapp] [url_ejamapi()]  [url_ejscreenmap()]
 #'   [url_echo_facility()] [url_frs_facility()]  [url_enviromapper()]
 #' @examples
+#' url_ejscreenmap(fips = "10001")
+#' url_ejscreenmap(fips = c("10001", "10003"))
+#' url_ejscreenmap(fips = c("10001", "10003"), combined = TRUE)
+#' url_ejscreenmap(lat = c(39, 39.7), lon = c(-75.5, -75.6), radius = 3, combined = TRUE)
 #' # browseURL(url_ejscreenmap(fips = '10001'))
 #' # browseURL(url_ejscreenmap(sitepoints = testpoints_10[1,]))
 #' # shp = shapefile_from_any(  testdata("portland.*zip")[1])[1, ]
@@ -605,6 +638,8 @@ url_efpoints <- function(sitecategory = c("npl", "tri", "water", "air", "tsdf", 
 url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
                             shapefile = NULL,
                             fips = NULL, wherestr = NULL,
+                            radius = NULL,
+                            combined = FALSE,
                             as_html = FALSE,
                             linktext = "EJSCREEN",
                             ifna = "https://pedp-ejscreen.azurewebsites.net/index.html",
@@ -620,10 +655,42 @@ url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
   ##   linktext could also} be numbered:
   # linktext = paste0("EJSCREEN Map ", 1:NROW(sitepoints))
 
-  ######################## #  ######################## #  ######################## #
+  if (!is.null(radius)) {
+    radius <- suppressWarnings(as.numeric(radius[1])) # one radius applies to all sites, as in the app
+    if (!isTRUE(radius > 0)) {radius <- NULL}
+  }
+  radpart <- if (is.null(radius)) {""} else {paste0("&radius=", radius)}
+
+  ## shared finishing: NAs become ifna, and optionally linkify, as before
+  finish_urls <- function(urlx) {
+    ok <- !is.na(urlx)
+    urlx[!ok] <- ifna
+    ok <- !is.na(urlx)  # now !ok mean it was a bad input and also  ifna=NA
+    if (as_html) {
+      urlx[ok] <- URLencode(urlx[ok]) # consider if we want  reserved = TRUE
+      urlx[ok] <- url_linkify(urlx[ok], text = linktext)
+    }
+    ## use generic URL if site is NA, ifna  again in case linkified an NA
+    urlx[!ok] <- ifna # only use non-linkified ifna for the ones where user set ifna=NA and it had to use ifna
+    return(urlx)
+  }
+
   ######################## #  ######################## #  ######################## #
 
-  # GET SITEPOINTS OR APPROX SITEPOINTS FROM FIPS/SHAPEFILE/SITEPOINTS/LAT,LON
+  ## if new API is down, return general links to info page ### #
+  if (isTRUE(global_or_param("ejamapi_is_down"))) {
+    n <- max(1, NROW(sitepoints), length(lat), length(fips), NROW(shapefile), length(wherestr))
+    if (combined) {n <- 1}
+    urlx <- rep('https://ejanalysis.org', n)
+    if (as_html) {
+      urlx <- URLencode(urlx)
+      urlx <- url_linkify(urlx, text = linktext)
+    }
+    return(urlx)
+  }
+  ######################## #  ######################## #  ######################## #
+
+  # SORT OUT WHICH TYPE OF SITES WERE PROVIDED (FIPS/SHAPEFILE/SITEPOINTS/LAT,LON)
   ## sites_from_input ####
   sites <- sites_from_input(sitepoints = sitepoints, lon = lon, lat = lat, shapefile = shapefile, fips = fips)
   sitetype <- sites$sitetype
@@ -646,80 +713,136 @@ url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
     }
   }
 
-  # GET lat,lon at EACH SITE ### #
+  ######################## #  ######################## #  ######################## #
 
+  ## > FIPS deep links ####
+  # county/tract/blockgroup fips get ?fips= links that draw & select the boundary;
+  # state and city/CDP fips are not in the app's boundary services, so they fall
+  # back to a ?wherestr= place-name search
   if ("fips" %in% sitetype) {
-    ##  latlon_from_fips ####
-    sitepoints <- latlon_from_fips(sites$fips) # draft
+    fips <- fips_lead_zero(sites$fips, quiet = TRUE)
+    ftype <- fipstype(fips, quiet = TRUE)
+    linkable <- !is.na(fips) & ftype %in% c("county", "tract", "blockgroup")
+    if (combined) {
+      if (all(linkable) && length(fips) > 0) {
+        return(finish_urls(paste0(baseurl, "?fips=", paste(fips, collapse = ","))))
+      } else {
+        warning("combined = TRUE needs all fips to be county/tract/blockgroup codes - returning one URL per site")
+      }
+    }
+    urlx <- rep(NA_character_, length(fips))
+    urlx[linkable] <- paste0(baseurl, "?fips=", fips[linkable])
+    byname <- !linkable & !is.na(fips)
+    if (any(byname)) {
+      nm <- suppressWarnings(fips2name(fips[byname]))
+      nm[!is.na(nm)] <- utils::URLencode(nm[!is.na(nm)], reserved = TRUE)
+      urlx[byname] <- ifelse(is.na(nm), NA, paste0(baseurl, "?wherestr=", nm))
+    }
+    return(finish_urls(urlx))
   }
+
+  ## > POLYGON deep links ####
+  # pass each polygon's (simplified) outline via ?polygon= so the app draws it;
+  # fall back to old behavior (?wherestr=centroid) if it cannot fit in a URL
   if ("shp" %in% sitetype) {
-    ## latlon_from_shapefile_centroids ####
-    # at least get points that are coordinates of centroids of polygons if cannnot open ejscreen app showing the actual polygon
-    sitepoints = latlon_from_shapefile_centroids(sites$shapefile)
+    polystr <- polygons_as_deeplink_strings(sites$shapefile)
+    if (combined) {
+      if (!anyNA(polystr) && length(polystr) > 0) {
+        urlx <- paste0(baseurl, "?polygon=", paste(polystr, collapse = "&polygon="), radpart)
+        if (nchar(urlx) <= 1900) {return(finish_urls(urlx))} # keep combined URLs a safe length for servers/browsers
+      }
+      warning("combined = TRUE but polygon outlines do not fit in one URL - returning one URL per site")
+    }
+    urlx <- rep(NA_character_, length(polystr))
+    urlx[!is.na(polystr)] <- paste0(baseurl, "?polygon=", polystr[!is.na(polystr)], radpart)
+    if (anyNA(polystr)) {
+      ## latlon_from_shapefile_centroids ####
+      cpts <- latlon_from_shapefile_centroids(sites$shapefile[is.na(polystr), , drop = FALSE])
+      centroidq <- paste(cpts$lat, cpts$lon, sep = ",")
+      centroidq[is.na(cpts$lat) | is.na(cpts$lon)] <- NA
+      urlx[is.na(polystr)] <- ifelse(is.na(centroidq), NA, paste0(baseurl, "?wherestr=", centroidq))
+    }
+    return(finish_urls(urlx))
   }
+
+  ## > POINTS ####
   if ("latlon" %in% sitetype) {
-    ## points ####
     sitepoints <- sites$sitepoints
   }
   lat = sitepoints$lat
   lon = sitepoints$lon
 
   if (is.null(lat) || is.null(lon) || length(lat) == 0 || length(lon) == 0) {
-    ## handle NA or length 0 ####
+    ## wherestr-only, or nothing usable ####
+    if (!is.null(wherestr) && length(wherestr) > 0 && any(!is.na(wherestr) & nzchar(wherestr))) {
+      urlx <- ifelse(is.na(wherestr) | !nzchar(wherestr), NA, paste0(baseurl, "?wherestr=", wherestr))
+      return(finish_urls(urlx))
+    }
     urlx <- ifna
     return(urlx) # length is 0   # or # return(NULL)  ??
   }
-  ######################## #  ######################## #  ######################## #
-  ######################## #  ######################## #  ######################## #
 
-  ## if new API is down, return general links to info page ### #
-  if (TRUE) { # was checking old epa api now obsolete
-    if (isTRUE(global_or_param("ejamapi_is_down"))) {
-      urlx <- rep('https://ejanalysis.org', length(urlx))
-      if (as_html) {
-        urlx <- URLencode(urlx)
-        urlx <- url_linkify(urlx, text = linktext)
+  badpt <- is.na(lat) | is.na(lon)
+  if (combined) {
+    if (all(badpt)) {return(finish_urls(NA_character_))}
+    if (any(badpt)) {warning("dropping site(s) with missing lat/lon from the combined URL")}
+    # Note slight changes can occur in lat,lon values if using paste() instead of format() as per ?as.character()
+    urlx <- paste0(baseurl, "?lat=", paste(lat[!badpt], collapse = ","),
+                   "&lon=", paste(lon[!badpt], collapse = ","), radpart)
+    return(finish_urls(urlx))
+  }
+  if (!is.null(radius)) {
+    # newer form: the app drops a pin AND prefills the report buffer radius
+    urlx <- paste0(baseurl, "?lat=", lat, "&lon=", lon, radpart)
+  } else {
+    # original form, works on all versions of the app: center map & drop a pin
+    urlx <- paste0(baseurl, "?wherestr=", paste(lat, lon, sep = ","))
+  }
+  urlx[badpt] <- NA
+  return(finish_urls(urlx))
+}
+################################################### #################################################### #
+
+#' Encode polygon outlines as EJScreen ?polygon= deep link strings
+#'
+#' One "lat,lon;lat,lon;..." string per row of shp (the exterior ring with the
+#' most vertices, simplified as needed to fit in a URL), or NA for any row whose
+#' outline cannot be simplified enough - see [url_ejscreenmap()].
+#' Holes and secondary parts of multipolygons are not included in the outline.
+#'
+#' @param shp sf object (or sfc) with one row per site
+#' @param digits decimal places for coordinates (4 is about 11 meters)
+#' @param maxchars longest allowed string per polygon, so the URL stays a safe length
+#' @return character vector, one string or NA per row of shp
+#' @keywords internal
+#' @noRd
+#'
+polygons_as_deeplink_strings <- function(shp, digits = 4, maxchars = 1500) {
+  if (is.null(shp) || NROW(shp) == 0) {return(character(0))}
+  out <- rep(NA_character_, NROW(shp))
+  geo <- try(suppressWarnings(sf::st_geometry(shp)), silent = TRUE)
+  if (inherits(geo, "try-error")) {return(out)}
+  for (i in seq_len(NROW(shp))) {
+    stri <- try(suppressWarnings({
+      g3857 <- sf::st_transform(geo[i], 3857)
+      result <- NA_character_
+      for (tol in c(0, 50, 250, 1000, 5000)) { # simplification tolerance in meters
+        gs <- if (tol > 0) {sf::st_simplify(g3857, dTolerance = tol)} else {g3857}
+        if (length(gs) == 0 || any(sf::st_is_empty(gs))) {next}
+        coords <- sf::st_coordinates(sf::st_transform(gs, 4326))
+        if (NROW(coords) < 4) {next} # a closed ring repeats its 1st point, so 3 vertices = 4 rows
+        # use the ring with the most vertices (the main exterior ring)
+        ringid <- apply(coords[, -(1:2), drop = FALSE], 1, paste, collapse = "_")
+        coords <- coords[ringid == names(which.max(table(ringid))), , drop = FALSE]
+        if (NROW(coords) < 4) {next}
+        candidate <- paste(round(coords[, "Y"], digits), round(coords[, "X"], digits), sep = ",", collapse = ";")
+        if (nchar(candidate) <= maxchars) {result <- candidate; break}
       }
-      return(urlx)
-    }
+      result
+    }), silent = TRUE)
+    if (!inherits(stri, "try-error") && length(stri) == 1) {out[i] <- stri}
   }
-  ######################## #  ######################## #  ######################## #
-  ######################## #  ######################## #  ######################## #
-
-  ## > MAKE URL ####
-
-  baseurl_query <- paste0(baseurl, "?wherestr=")
-  whereq <- ""
-  if (!is.null(lat)) {
-    # Note slight changes can occur in lat,lon values if using paste(lat,lon,sep=',) instead of format() as per ?as.character()
-    whereq <- paste( lat,  lon, sep = ',') # points (or centroids of polygons)
-    whereq[is.na(lat) | is.na(lon)] <- NA
-  }
-  if (!is.null(fips) && is.null(wherestr)) {
-    wherestr <- fips2name(fips) # fips-based
-    wherestr[is.na(fips)] <- NA
-  }
-  if (!is.null(wherestr) && is.null(lat)) {
-    whereq <- wherestr # name-based not latlon-based
-  }
-  urlx <- paste0(baseurl_query, whereq)
-
-  ######################## #
-  ### NAs ####
-  ok <- !is.na(whereq)
-  ######################## #
-  urlx[!ok] <- ifna
-  ok <- !is.na(urlx)  # now !ok mean it was a bad input and also  ifna=NA
-  ######################## #
-
-  ### as_html ####
-  if (as_html) {
-    urlx[ok] <- URLencode(urlx[ok]) # consider if we want  reserved = TRUE
-    urlx[ok] <- url_linkify(urlx[ok], text = linktext)
-  }
-  ## use generic URL if site is NA, ifna  again in case linkified an NA
-  urlx[!ok] <- ifna # only use non-linkified ifna for the ones where user set ifna=NA and it had to use ifna
-  return(urlx)
+  return(out)
 }
 ################################################### #################################################### #
 ################################################### #################################################### #

--- a/R/URL_FUNCTIONS_part2.R
+++ b/R/URL_FUNCTIONS_part2.R
@@ -771,7 +771,13 @@ url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
     urlx[!is.na(polystr)] <- paste0(baseurl, "?polygon=", polystr[!is.na(polystr)], radpart)
     if (anyNA(polystr)) {
       ## latlon_from_shapefile_centroids ####
-      cpts <- latlon_from_shapefile_centroids(sites$shapefile[is.na(polystr), , drop = FALSE])
+      # subset by row for sf, by element for a bare geometry column (sfc)
+      shpneedingcentroid <- if (inherits(sites$shapefile, "sfc")) {
+        sites$shapefile[is.na(polystr)]
+      } else {
+        sites$shapefile[is.na(polystr), , drop = FALSE]
+      }
+      cpts <- latlon_from_shapefile_centroids(shpneedingcentroid)
       if (is.null(radius)) {
         centroidq <- paste0("?wherestr=", paste(cpts$lat, cpts$lon, sep = ","))
       } else {

--- a/R/URL_FUNCTIONS_part2.R
+++ b/R/URL_FUNCTIONS_part2.R
@@ -775,7 +775,12 @@ url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
   if (is.null(lat) || is.null(lon) || length(lat) == 0 || length(lon) == 0) {
     ## wherestr-only, or nothing usable ####
     if (!is.null(wherestr) && length(wherestr) > 0 && any(!is.na(wherestr) & nzchar(wherestr))) {
-      urlx <- ifelse(is.na(wherestr) | !nzchar(wherestr), NA, paste0(baseurl, "?wherestr=", wherestr))
+      ok <- !is.na(wherestr) & nzchar(wherestr)
+      whereq <- rep(NA_character_, length(wherestr))
+      # encode the free-text value once here; the app unescape()s it
+      # (idempotent under the as_html re-encode, which uses reserved = FALSE)
+      whereq[ok] <- utils::URLencode(wherestr[ok], reserved = TRUE)
+      urlx <- ifelse(is.na(whereq), NA, paste0(baseurl, "?wherestr=", whereq))
       return(finish_urls(urlx))
     }
     urlx <- ifna

--- a/R/URL_FUNCTIONS_part2.R
+++ b/R/URL_FUNCTIONS_part2.R
@@ -827,9 +827,12 @@ url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
       }
       if (combined) {
         if (any(okzip)) {
-          return(finish_urls(paste0(baseurl, "?zip=", paste(zip[okzip], collapse = ","), radpart)))
+          urlx <- paste0(baseurl, "?zip=", paste(zip[okzip], collapse = ","), radpart)
+          if (nchar(urlx) <= 1900) {return(finish_urls(urlx))} # keep combined URLs a safe length for servers/browsers
+          warning("combined = TRUE but too many zip codes to fit in one URL - returning one URL per site")
+        } else {
+          return(finish_urls(NA_character_))
         }
-        return(finish_urls(NA_character_))
       }
       urlx <- rep(NA_character_, length(zip))
       urlx[okzip] <- paste0(baseurl, "?zip=", zip[okzip], radpart)

--- a/R/URL_FUNCTIONS_part2.R
+++ b/R/URL_FUNCTIONS_part2.R
@@ -591,9 +591,10 @@ url_efpoints <- function(sitecategory = c("npl", "tri", "water", "air", "tsdf", 
 #'
 #'   For County FIPS code 10001, use url_ejscreenmap(fips = "10001") - unambiguous.
 #'
-#'   For zipcode 10001, include more context, like url_ejscreenmap(wherestr = "10001, NY") -
-#'   a bare wherestr = "10001" would open Kent County, DE, since 10001 happens
-#'   to be a county fips as well as a zip code.
+#'   For zipcode 10001, use url_ejscreenmap(zip = "10001") - unambiguous - since
+#'   a bare wherestr = "10001" would open Kent County, DE (10001 happens
+#'   to be a county fips as well as a zip code). Adding context also works,
+#'   like url_ejscreenmap(wherestr = "10001, NY").
 #'
 #'   (The interactive search box inside the EJScreen app is different from
 #'   these launch-URL deep links: it still reads a bare 5-digit number as a zip.)
@@ -613,6 +614,14 @@ url_efpoints <- function(sitecategory = c("npl", "tri", "water", "air", "tsdf", 
 #'   `?wherestr=lat,lon`, or `?lat=&lon=&radius=` when radius is provided so
 #'   the report buffer is still prefilled.
 #' @param shape,shp aliases (synonyms) for shapefile
+#' @param zip 5-digit zip code(s) - the unambiguous way to open EJScreen at zip
+#'   code(s), via the app's `?zip=` parameter: always geocoded as zips, never
+#'   read as county fips (unlike a bare 5-digit wherestr). Each zip gets a pin
+#'   with the report popup; one zip centers the map, several fit the view to
+#'   all of them (or use combined = FALSE, the default, for one URL per zip).
+#'   Used only if sitepoints (or lat,lon), shapefile, and fips are not provided;
+#'   takes precedence over wherestr. A zip passed as a number gets its leading
+#'   zeroes restored.
 #' @param radius optional buffer distance in miles for the EJScreen report around
 #'   each point (or polygon). When provided, point links use the app's
 #'   `?lat=&lon=&radius=` parameters (instead of `?wherestr=lat,lon`) so the
@@ -634,7 +643,8 @@ url_efpoints <- function(sitecategory = c("npl", "tri", "water", "air", "tsdf", 
 #' @seealso [url_ejamapp] [url_ejamapi()]  [url_ejscreenmap()]
 #'   [url_echo_facility()] [url_frs_facility()]  [url_enviromapper()]
 #' @examples
-#' url_ejscreenmap(fips = "10001")
+#' url_ejscreenmap(fips = "10001") # county FIPS 10001 = Kent County, DE
+#' url_ejscreenmap(zip = "10001")  # zip code 10001 = Manhattan, NY
 #' url_ejscreenmap(fips = c("10001", "10003"))
 #' url_ejscreenmap(fips = c("10001", "10003"), combined = TRUE)
 #' url_ejscreenmap(lat = c(39, 39.7), lon = c(-75.5, -75.6), radius = 3, combined = TRUE)
@@ -650,6 +660,7 @@ url_efpoints <- function(sitecategory = c("npl", "tri", "water", "air", "tsdf", 
 url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
                             shapefile = NULL,
                             fips = NULL, wherestr = NULL,
+                            zip = NULL,
                             radius = NULL,
                             combined = FALSE,
                             as_html = FALSE,
@@ -691,7 +702,7 @@ url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
 
   ## if new API is down, return general links to info page ### #
   if (isTRUE(global_or_param("ejamapi_is_down"))) {
-    n <- max(1, NROW(sitepoints), length(lat), length(lon), length(fips), NROW(shapefile), length(wherestr))
+    n <- max(1, NROW(sitepoints), length(lat), length(lon), length(fips), NROW(shapefile), length(wherestr), length(zip))
     if (combined) {n <- 1}
     urlx <- rep('https://ejanalysis.org', n)
     if (as_html) {
@@ -798,6 +809,28 @@ url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
   lon = sitepoints$lon
 
   if (is.null(lat) || is.null(lon) || length(lat) == 0 || length(lon) == 0) {
+    ## > ZIP CODES ####
+    # ?zip= is the app's explicit way to take zip code(s): always geocoded as
+    # zips, never read as county fips (used when no points/fips/shapefile given)
+    if (!is.null(zip) && length(zip) > 0 && any(!is.na(zip))) {
+      zip <- as.character(zip)
+      needpad <- !is.na(zip) & grepl("^[0-9]{3,4}$", zip) # a zip passed as a number can lose leading zeroes
+      zip[needpad] <- sprintf("%05d", as.integer(zip[needpad]))
+      okzip <- !is.na(zip) & grepl("^[0-9]{5}$", zip)
+      if (any(!okzip & !is.na(zip))) {
+        warning("zip should be 5-digit zip code(s); using the generic URL for: ",
+                paste(zip[!okzip & !is.na(zip)], collapse = ", "))
+      }
+      if (combined) {
+        if (any(okzip)) {
+          return(finish_urls(paste0(baseurl, "?zip=", paste(zip[okzip], collapse = ","), radpart)))
+        }
+        return(finish_urls(NA_character_))
+      }
+      urlx <- rep(NA_character_, length(zip))
+      urlx[okzip] <- paste0(baseurl, "?zip=", zip[okzip], radpart)
+      return(finish_urls(urlx))
+    }
     ## wherestr-only, or nothing usable ####
     if (!is.null(wherestr) && length(wherestr) > 0 && any(!is.na(wherestr) & nzchar(wherestr))) {
       wherestr <- as.character(wherestr) # e.g., a zip code passed as a number

--- a/R/URL_FUNCTIONS_part2.R
+++ b/R/URL_FUNCTIONS_part2.R
@@ -583,11 +583,20 @@ url_efpoints <- function(sitecategory = c("npl", "tri", "water", "air", "tsdf", 
 #'   wherestr should be the street address, zip code, or place name (not FIPS code!).
 #'
 #'   Note that nearly half of all county fips codes are impossible to distinguish from
-#'   5-digit zipcodes because the same numbers are used for both purposes.
+#'   5-digit zipcodes because the same numbers are used for both purposes, so a
+#'   bare 5-digit wherestr is ambiguous. The EJScreen app's deep links resolve
+#'   the ambiguity the way EJAM does: a bare 5-digit wherestr is tried as a
+#'   county FIPS first (drawing that county's boundary), and only geocoded as a
+#'   zip code if no county has that code. So:
 #'
-#'   For zipcode 10001, use url_ejscreenmap(wherestr =  '10001')
+#'   For County FIPS code 10001, use url_ejscreenmap(fips = "10001") - unambiguous.
 #'
-#'   For County FIPS code 10001, use url_ejscreenmap(fips = "10001")
+#'   For zipcode 10001, include more context, like url_ejscreenmap(wherestr = "10001, NY") -
+#'   a bare wherestr = "10001" would open Kent County, DE, since 10001 happens
+#'   to be a county fips as well as a zip code.
+#'
+#'   (The interactive search box inside the EJScreen app is different from
+#'   these launch-URL deep links: it still reads a bare 5-digit number as a zip.)
 #'
 #'   This parameter is passed to the app as wherestr= , if point and fips are not specified.
 #'

--- a/R/URL_FUNCTIONS_part2.R
+++ b/R/URL_FUNCTIONS_part2.R
@@ -691,7 +691,7 @@ url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
 
   ## if new API is down, return general links to info page ### #
   if (isTRUE(global_or_param("ejamapi_is_down"))) {
-    n <- max(1, NROW(sitepoints), length(lat), length(fips), NROW(shapefile), length(wherestr))
+    n <- max(1, NROW(sitepoints), length(lat), length(lon), length(fips), NROW(shapefile), length(wherestr))
     if (combined) {n <- 1}
     urlx <- rep('https://ejanalysis.org', n)
     if (as_html) {
@@ -870,6 +870,10 @@ polygons_as_deeplink_strings <- function(shp, digits = 4, maxchars = 1500) {
         ringid <- apply(coords[, -(1:2), drop = FALSE], 1, paste, collapse = "_")
         coords <- coords[ringid == names(which.max(table(ringid))), , drop = FALSE]
         if (NROW(coords) < 4) {next}
+        if (all(coords[1, c("X", "Y")] == coords[NROW(coords), c("X", "Y")])) {
+          coords <- coords[-NROW(coords), , drop = FALSE]
+        }
+        if (NROW(coords) < 3) {next}
         candidate <- paste(round(coords[, "Y"], digits), round(coords[, "X"], digits), sep = ",", collapse = ";")
         if (nchar(candidate) <= maxchars) {result <- candidate; break}
       }

--- a/R/URL_FUNCTIONS_part2.R
+++ b/R/URL_FUNCTIONS_part2.R
@@ -863,7 +863,10 @@ polygons_as_deeplink_strings <- function(shp, digits = 4, maxchars = 1500) {
         if (length(gs) == 0 || any(sf::st_is_empty(gs))) {next}
         coords <- sf::st_coordinates(sf::st_transform(gs, 4326))
         if (NROW(coords) < 4) {next} # a closed ring repeats its 1st point, so 3 vertices = 4 rows
-        # use the ring with the most vertices (the main exterior ring)
+        # keep only exterior rings (ring index L1 == 1; higher values are holes),
+        # then use the exterior ring with the most vertices (the main part)
+        if ("L1" %in% colnames(coords)) {coords <- coords[coords[, "L1"] == 1, , drop = FALSE]}
+        if (NROW(coords) < 4) {next}
         ringid <- apply(coords[, -(1:2), drop = FALSE], 1, paste, collapse = "_")
         coords <- coords[ringid == names(which.max(table(ringid))), , drop = FALSE]
         if (NROW(coords) < 4) {next}

--- a/R/URL_FUNCTIONS_part2.R
+++ b/R/URL_FUNCTIONS_part2.R
@@ -630,9 +630,10 @@ url_efpoints <- function(sitecategory = c("npl", "tri", "water", "air", "tsdf", 
 #'   in a single EJScreen session (drawn on the map and accumulated into the
 #'   app's Multisite list, ready for a Multisite Report or Send to EJAM),
 #'   instead of the default of one URL per site. Works when all sites are
-#'   county/tract/blockgroup fips, or all are points, or all are small polygons.
-#'   If the combined URL would be too long to be reliable (over roughly 1900
-#'   characters), it falls back to one URL per site, with a warning.
+#'   county/tract/blockgroup fips, or all are points, or all are zip codes, or
+#'   all are small polygons. If the combined URL would be too long to be
+#'   reliable (over roughly 1900 characters), it falls back to one URL per
+#'   site, with a warning.
 #' @param as_html Whether to return as just the urls or as html hyperlinks to use in a DT::datatable() for example
 #' @param linktext used as text for hyperlinks, if supplied and as_html=TRUE
 #' @param ifna URL shown for missing, NA, NULL, bad input values
@@ -660,14 +661,17 @@ url_efpoints <- function(sitecategory = c("npl", "tri", "water", "air", "tsdf", 
 url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
                             shapefile = NULL,
                             fips = NULL, wherestr = NULL,
-                            zip = NULL,
-                            radius = NULL,
-                            combined = FALSE,
                             as_html = FALSE,
                             linktext = "EJSCREEN",
                             ifna = "https://pedp-ejscreen.azurewebsites.net/index.html",
                             baseurl = "https://pedp-ejscreen.azurewebsites.net/index.html",
                             ...,
+                            # new params are after ... so they must be passed by name -
+                            # this keeps the original positional order (as_html, linktext,
+                            # ifna, baseurl) working for any existing positional callers
+                            zip = NULL,
+                            radius = NULL,
+                            combined = FALSE,
                             shape = NULL, shp = NULL) {
 
   if (is.null(shapefile) && !is.null(shape)) {shapefile <- shape}

--- a/R/URL_FUNCTIONS_part2.R
+++ b/R/URL_FUNCTIONS_part2.R
@@ -695,7 +695,7 @@ url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
     ok <- !is.na(urlx)  # now !ok mean it was a bad input and also  ifna=NA
     if (as_html) {
       urlx[ok] <- URLencode(urlx[ok]) # consider if we want  reserved = TRUE
-      urlx[ok] <- url_linkify(urlx[ok], text = linktext)
+      urlx[ok] <- url_linkify(urlx[ok], text = linktext, encode = FALSE) # already encoded just above
     }
     ## use generic URL if site is NA, ifna  again in case linkified an NA
     urlx[!ok] <- ifna # only use non-linkified ifna for the ones where user set ifna=NA and it had to use ifna
@@ -711,7 +711,7 @@ url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
     urlx <- rep('https://ejanalysis.org', n)
     if (as_html) {
       urlx <- URLencode(urlx)
-      urlx <- url_linkify(urlx, text = linktext)
+      urlx <- url_linkify(urlx, text = linktext, encode = FALSE) # already encoded just above
     }
     return(urlx)
   }

--- a/R/URL_FUNCTIONS_part2.R
+++ b/R/URL_FUNCTIONS_part2.R
@@ -600,8 +600,9 @@ url_efpoints <- function(sitecategory = c("npl", "tri", "water", "air", "tsdf", 
 #'   polygon (exterior ring, simplified as needed to fit in a URL) is passed via
 #'   the app's `?polygon=` parameter so EJScreen draws and selects it. If an
 #'   outline is too complex to fit even after simplification, that site falls
-#'   back to the old behavior: a `?wherestr=lat,lon` link centered on the
-#'   polygon's centroid (no boundary drawn).
+#'   back to a link centered on the polygon's centroid (no boundary drawn):
+#'   `?wherestr=lat,lon`, or `?lat=&lon=&radius=` when radius is provided so
+#'   the report buffer is still prefilled.
 #' @param shape,shp aliases (synonyms) for shapefile
 #' @param radius optional buffer distance in miles for the EJScreen report around
 #'   each point (or polygon). When provided, point links use the app's
@@ -612,6 +613,8 @@ url_efpoints <- function(sitecategory = c("npl", "tri", "water", "air", "tsdf", 
 #'   app's Multisite list, ready for a Multisite Report or Send to EJAM),
 #'   instead of the default of one URL per site. Works when all sites are
 #'   county/tract/blockgroup fips, or all are points, or all are small polygons.
+#'   If the combined URL would be too long to be reliable (over roughly 1900
+#'   characters), it falls back to one URL per site, with a warning.
 #' @param as_html Whether to return as just the urls or as html hyperlinks to use in a DT::datatable() for example
 #' @param linktext used as text for hyperlinks, if supplied and as_html=TRUE
 #' @param ifna URL shown for missing, NA, NULL, bad input values
@@ -725,7 +728,9 @@ url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
     linkable <- !is.na(fips) & ftype %in% c("county", "tract", "blockgroup")
     if (combined) {
       if (all(linkable) && length(fips) > 0) {
-        return(finish_urls(paste0(baseurl, "?fips=", paste(fips, collapse = ","))))
+        urlx <- paste0(baseurl, "?fips=", paste(fips, collapse = ","))
+        if (nchar(urlx) <= 1900) {return(finish_urls(urlx))} # keep combined URLs a safe length for servers/browsers
+        warning("combined = TRUE but too many fips to fit in one URL - returning one URL per site")
       } else {
         warning("combined = TRUE needs all fips to be county/tract/blockgroup codes - returning one URL per site")
       }
@@ -758,9 +763,14 @@ url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
     if (anyNA(polystr)) {
       ## latlon_from_shapefile_centroids ####
       cpts <- latlon_from_shapefile_centroids(sites$shapefile[is.na(polystr), , drop = FALSE])
-      centroidq <- paste(cpts$lat, cpts$lon, sep = ",")
+      if (is.null(radius)) {
+        centroidq <- paste0("?wherestr=", paste(cpts$lat, cpts$lon, sep = ","))
+      } else {
+        # keep the radius prefill even when falling back to the polygon's centroid
+        centroidq <- paste0("?lat=", cpts$lat, "&lon=", cpts$lon, radpart)
+      }
       centroidq[is.na(cpts$lat) | is.na(cpts$lon)] <- NA
-      urlx[is.na(polystr)] <- ifelse(is.na(centroidq), NA, paste0(baseurl, "?wherestr=", centroidq))
+      urlx[is.na(polystr)] <- ifelse(is.na(centroidq), NA, paste0(baseurl, centroidq))
     }
     return(finish_urls(urlx))
   }
@@ -794,7 +804,8 @@ url_ejscreenmap <- function(sitepoints = NULL, lat = NULL, lon = NULL,
     # Note slight changes can occur in lat,lon values if using paste() instead of format() as per ?as.character()
     urlx <- paste0(baseurl, "?lat=", paste(lat[!badpt], collapse = ","),
                    "&lon=", paste(lon[!badpt], collapse = ","), radpart)
-    return(finish_urls(urlx))
+    if (nchar(urlx) <= 1900) {return(finish_urls(urlx))} # keep combined URLs a safe length for servers/browsers
+    warning("combined = TRUE but too many points to fit in one URL - returning one URL per site")
   }
   if (!is.null(radius)) {
     # newer form: the app drops a pin AND prefills the report buffer radius

--- a/R/ejamapp.R
+++ b/R/ejamapp.R
@@ -58,7 +58,9 @@
 #' some (the ones that are inputs in the ui / server)
 #' can be bookmarked (saved in a URL) for later use.
 #'
-#' For more details, see the article on "Defaults and Custom Settings for the Web App"
+#' For more details, see the article on
+#' `r paste0("[Defaults and Custom Settings for the Web App](", url_package('docs'), "/articles/dev-app-settings.html)")`
+#'
 #'
 #' **Examples of custom parameters that you could pass to ejamapp() are shown below.**
 #'
@@ -158,6 +160,9 @@
 #' )
 #'
 #'   ## Specific cities are preselected at launch
+#'
+#'   ejamapp(fips=3673000)
+#'   ejamapp(fips=name2fips(c("akutan,ak", "syracuse city,ny")))
 #'
 #'   ejamapp(
 #'   default_site_method = "dropdown",
@@ -263,6 +268,7 @@
 #' @return An object that represents the app. Printing the object or
 #'   passing it to [runApp()] will run the app, as would just typing
 #'   [ejamapp()] in the console.
+#' @seealso  [url_ejamapp()] [url_ejscreenmap()] [url_ejamapi()] [ejamapi()]
 #'
 #'
 #' @export

--- a/man/app_run_EJAM.Rd
+++ b/man/app_run_EJAM.Rd
@@ -79,7 +79,8 @@ Some of them can also be adjusted in the web app's Advanced tab, and
 some (the ones that are inputs in the ui / server)
 can be bookmarked (saved in a URL) for later use.
 
-For more details, see the article on "Defaults and Custom Settings for the Web App"
+For more details, see the article on
+\href{https://public-environmental-data-partners.github.io/EJAM/articles/dev-app-settings.html}{Defaults and Custom Settings for the Web App}
 
 \strong{Examples of custom parameters that you could pass to ejamapp() are shown below.}
 
@@ -179,6 +180,9 @@ ejamapp(
 )
 
   ## Specific cities are preselected at launch
+
+  ejamapp(fips=3673000)
+  ejamapp(fips=name2fips(c("akutan,ak", "syracuse city,ny")))
 
   ejamapp(
   default_site_method = "dropdown",
@@ -281,5 +285,8 @@ ejamapp(
   # aka  options=list(test.mode=TRUE)
   default_testing=TRUE
 }
+}
+\seealso{
+\code{\link[=url_ejamapp]{url_ejamapp()}} \code{\link[=url_ejscreenmap]{url_ejscreenmap()}} \code{\link[=url_ejamapi]{url_ejamapi()}} \code{\link[=ejamapi]{ejamapi()}}
 }
 \keyword{internal}

--- a/man/ejamapp.Rd
+++ b/man/ejamapp.Rd
@@ -79,7 +79,8 @@ Some of them can also be adjusted in the web app's Advanced tab, and
 some (the ones that are inputs in the ui / server)
 can be bookmarked (saved in a URL) for later use.
 
-For more details, see the article on "Defaults and Custom Settings for the Web App"
+For more details, see the article on
+\href{https://public-environmental-data-partners.github.io/EJAM/articles/dev-app-settings.html}{Defaults and Custom Settings for the Web App}
 
 \strong{Examples of custom parameters that you could pass to ejamapp() are shown below.}
 
@@ -179,6 +180,9 @@ ejamapp(
 )
 
   ## Specific cities are preselected at launch
+
+  ejamapp(fips=3673000)
+  ejamapp(fips=name2fips(c("akutan,ak", "syracuse city,ny")))
 
   ejamapp(
   default_site_method = "dropdown",
@@ -281,4 +285,7 @@ ejamapp(
   # aka  options=list(test.mode=TRUE)
   default_testing=TRUE
 }
+}
+\seealso{
+\code{\link[=url_ejamapp]{url_ejamapp()}} \code{\link[=url_ejscreenmap]{url_ejscreenmap()}} \code{\link[=url_ejamapi]{url_ejamapi()}} \code{\link[=ejamapi]{ejamapi()}}
 }

--- a/man/run_app.Rd
+++ b/man/run_app.Rd
@@ -79,7 +79,8 @@ Some of them can also be adjusted in the web app's Advanced tab, and
 some (the ones that are inputs in the ui / server)
 can be bookmarked (saved in a URL) for later use.
 
-For more details, see the article on "Defaults and Custom Settings for the Web App"
+For more details, see the article on
+\href{https://public-environmental-data-partners.github.io/EJAM/articles/dev-app-settings.html}{Defaults and Custom Settings for the Web App}
 
 \strong{Examples of custom parameters that you could pass to ejamapp() are shown below.}
 
@@ -179,6 +180,9 @@ ejamapp(
 )
 
   ## Specific cities are preselected at launch
+
+  ejamapp(fips=3673000)
+  ejamapp(fips=name2fips(c("akutan,ak", "syracuse city,ny")))
 
   ejamapp(
   default_site_method = "dropdown",
@@ -281,5 +285,8 @@ ejamapp(
   # aka  options=list(test.mode=TRUE)
   default_testing=TRUE
 }
+}
+\seealso{
+\code{\link[=url_ejamapp]{url_ejamapp()}} \code{\link[=url_ejscreenmap]{url_ejscreenmap()}} \code{\link[=url_ejamapi]{url_ejamapi()}} \code{\link[=ejamapi]{ejamapi()}}
 }
 \keyword{internal}

--- a/man/url_ejscreenmap.Rd
+++ b/man/url_ejscreenmap.Rd
@@ -92,7 +92,10 @@ zeroes restored.}
 \item{radius}{optional buffer distance in miles for the EJScreen report around
 each point (or polygon). When provided, point links use the app's
 \verb{?lat=&lon=&radius=} parameters (instead of \verb{?wherestr=lat,lon}) so the
-report buffer is prefilled.}
+report buffer is prefilled. Must be a single number greater than zero:
+zero (or a negative or non-numeric value) means no buffer is prefilled,
+so it is left out of the URL, which EJScreen treats the same way
+(its deep links only apply a \verb{radius=} that is greater than zero).}
 
 \item{combined}{set TRUE to get ONE URL that loads ALL of the sites together
 in a single EJScreen session (drawn on the map and accumulated into the

--- a/man/url_ejscreenmap.Rd
+++ b/man/url_ejscreenmap.Rd
@@ -31,8 +31,9 @@ url_ejscreenmap(
 polygon (exterior ring, simplified as needed to fit in a URL) is passed via
 the app's \verb{?polygon=} parameter so EJScreen draws and selects it. If an
 outline is too complex to fit even after simplification, that site falls
-back to the old behavior: a \verb{?wherestr=lat,lon} link centered on the
-polygon's centroid (no boundary drawn).}
+back to a link centered on the polygon's centroid (no boundary drawn):
+\verb{?wherestr=lat,lon}, or \verb{?lat=&lon=&radius=} when radius is provided so
+the report buffer is still prefilled.}
 
 \item{fips}{FIPS code(s) of place(s) to select on the map.
 County (5-digit), tract (11), and blockgroup (12) codes become \verb{?fips=}
@@ -67,7 +68,9 @@ report buffer is prefilled.}
 in a single EJScreen session (drawn on the map and accumulated into the
 app's Multisite list, ready for a Multisite Report or Send to EJAM),
 instead of the default of one URL per site. Works when all sites are
-county/tract/blockgroup fips, or all are points, or all are small polygons.}
+county/tract/blockgroup fips, or all are points, or all are small polygons.
+If the combined URL would be too long to be reliable (over roughly 1900
+characters), it falls back to one URL per site, with a warning.}
 
 \item{as_html}{Whether to return as just the urls or as html hyperlinks to use in a DT::datatable() for example}
 

--- a/man/url_ejscreenmap.Rd
+++ b/man/url_ejscreenmap.Rd
@@ -46,11 +46,20 @@ boundary services, so those are translated via \code{\link[=fips2name]{fips2name
 wherestr should be the street address, zip code, or place name (not FIPS code!).
 
 Note that nearly half of all county fips codes are impossible to distinguish from
-5-digit zipcodes because the same numbers are used for both purposes.
+5-digit zipcodes because the same numbers are used for both purposes, so a
+bare 5-digit wherestr is ambiguous. The EJScreen app's deep links resolve
+the ambiguity the way EJAM does: a bare 5-digit wherestr is tried as a
+county FIPS first (drawing that county's boundary), and only geocoded as a
+zip code if no county has that code. So:
 
-For zipcode 10001, use url_ejscreenmap(wherestr =  '10001')
+For County FIPS code 10001, use url_ejscreenmap(fips = "10001") - unambiguous.
 
-For County FIPS code 10001, use url_ejscreenmap(fips = "10001")
+For zipcode 10001, include more context, like url_ejscreenmap(wherestr = "10001, NY") -
+a bare wherestr = "10001" would open Kent County, DE, since 10001 happens
+to be a county fips as well as a zip code.
+
+(The interactive search box inside the EJScreen app is different from
+these launch-URL deep links: it still reads a bare 5-digit number as a zip.)
 
 This parameter is passed to the app as wherestr= , if point and fips are not specified.
 

--- a/man/url_ejscreenmap.Rd
+++ b/man/url_ejscreenmap.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/URL_FUNCTIONS_part2.R
 \name{url_ejscreenmap}
 \alias{url_ejscreenmap}
-\title{Get URL(s) for (new) EJSCREEN app with map centered at given point(s)}
+\title{Get URL(s) for (new) EJSCREEN app with the given place(s) selected on the map}
 \usage{
 url_ejscreenmap(
   sitepoints = NULL,
@@ -11,6 +11,8 @@ url_ejscreenmap(
   shapefile = NULL,
   fips = NULL,
   wherestr = NULL,
+  radius = NULL,
+  combined = FALSE,
   as_html = FALSE,
   linktext = "EJSCREEN",
   ifna = "https://pedp-ejscreen.azurewebsites.net/index.html",
@@ -25,11 +27,19 @@ url_ejscreenmap(
 
 \item{lat, lon}{vectors of coordinates, ignored if sitepoints provided, can be used otherwise, if shapefile and fips not used}
 
-\item{shapefile}{shows URL of a EJSCREEN app map centered on the centroid of a given polygon,
-but does not actually show the polygon.}
+\item{shapefile}{polygon(s) as from \code{\link[=shapefile_from_any]{shapefile_from_any()}}. The outline of each
+polygon (exterior ring, simplified as needed to fit in a URL) is passed via
+the app's \verb{?polygon=} parameter so EJScreen draws and selects it. If an
+outline is too complex to fit even after simplification, that site falls
+back to the old behavior: a \verb{?wherestr=lat,lon} link centered on the
+polygon's centroid (no boundary drawn).}
 
-\item{fips}{The FIPS code of a place to center map on (blockgroup, tract, city/cdp, county, state FIPS).
-It gets translated into the right wherestr parameter if fips is provided.}
+\item{fips}{FIPS code(s) of place(s) to select on the map.
+County (5-digit), tract (11), and blockgroup (12) codes become \verb{?fips=}
+deep links that make the EJScreen app draw and select the boundary.
+State (2-digit) and city/CDP (7-digit) codes are not supported by the app's
+boundary services, so those are translated via \code{\link[=fips2name]{fips2name()}} into a
+\verb{?wherestr=} place-name search (map centers there without a boundary).}
 
 \item{wherestr}{If fips and sitepoints (or lat and lon) are not provided,
 wherestr should be the street address, zip code, or place name (not FIPS code!).
@@ -41,12 +51,23 @@ For zipcode 10001, use url_ejscreenmap(wherestr =  '10001')
 
 For County FIPS code 10001, use url_ejscreenmap(fips = "10001")
 
-This parameter is passed to the API as wherestr= , if point and fips are not specified.
+This parameter is passed to the app as wherestr= , if point and fips are not specified.
 
 Can be State abbrev like "NY" or full state name,
 or city like "New Rochelle, NY" as from fips2name() -- using fips2name()
 works for state, county, or city FIPS code converted to name,
 but using the fips parameter is probably a better idea.}
+
+\item{radius}{optional buffer distance in miles for the EJScreen report around
+each point (or polygon). When provided, point links use the app's
+\verb{?lat=&lon=&radius=} parameters (instead of \verb{?wherestr=lat,lon}) so the
+report buffer is prefilled.}
+
+\item{combined}{set TRUE to get ONE URL that loads ALL of the sites together
+in a single EJScreen session (drawn on the map and accumulated into the
+app's Multisite list, ready for a Multisite Report or Send to EJAM),
+instead of the default of one URL per site. Works when all sites are
+county/tract/blockgroup fips, or all are points, or all are small polygons.}
 
 \item{as_html}{Whether to return as just the urls or as html hyperlinks to use in a DT::datatable() for example}
 
@@ -56,17 +77,34 @@ but using the fips parameter is probably a better idea.}
 
 \item{baseurl}{do not change unless endpoint actually changed}
 
-\item{...}{unused}
+\item{...}{regid can be provided (used to look up lat,lon as a last resort if no sites provided); other arguments ignored}
 
 \item{shape, shp}{aliases (synonyms) for shapefile}
 }
 \value{
-URL(s)
+URL(s), or a single URL if combined = TRUE
 }
 \description{
-Get URL(s) for (new) EJSCREEN app with map centered at given point(s)
+Get URL(s) for (new) EJSCREEN app with the given place(s) selected on the map
+}
+\details{
+These are deep links into the EJScreen map app. For county, tract, or
+blockgroup FIPS codes, for points (with a radius), and for small polygons,
+the URL makes EJScreen actually draw and select the place(s) for analysis
+(boundary drawn, report popup or multisite list ready), using the
+\verb{?fips=}, \verb{?lat=&lon=&radius=}, and \verb{?polygon=} parameters of the app.
+
+Note the selection-drawing parameters require the version of the EJScreen app
+that supports deep links (PEDP EJScreen as of mid-2026 or later); older
+deployments ignore them and just open the map. The \verb{wherestr=} style links
+(the default for points when no radius is given, and the fallback for state
+or city/CDP FIPS) work on all versions of the app.
 }
 \examples{
+url_ejscreenmap(fips = "10001")
+url_ejscreenmap(fips = c("10001", "10003"))
+url_ejscreenmap(fips = c("10001", "10003"), combined = TRUE)
+url_ejscreenmap(lat = c(39, 39.7), lon = c(-75.5, -75.6), radius = 3, combined = TRUE)
 # browseURL(url_ejscreenmap(fips = '10001'))
 # browseURL(url_ejscreenmap(sitepoints = testpoints_10[1,]))
 # shp = shapefile_from_any(  testdata("portland.*zip")[1])[1, ]

--- a/man/url_ejscreenmap.Rd
+++ b/man/url_ejscreenmap.Rd
@@ -11,6 +11,7 @@ url_ejscreenmap(
   shapefile = NULL,
   fips = NULL,
   wherestr = NULL,
+  zip = NULL,
   radius = NULL,
   combined = FALSE,
   as_html = FALSE,
@@ -54,9 +55,10 @@ zip code if no county has that code. So:
 
 For County FIPS code 10001, use url_ejscreenmap(fips = "10001") - unambiguous.
 
-For zipcode 10001, include more context, like url_ejscreenmap(wherestr = "10001, NY") -
-a bare wherestr = "10001" would open Kent County, DE, since 10001 happens
-to be a county fips as well as a zip code.
+For zipcode 10001, use url_ejscreenmap(zip = "10001") - unambiguous - since
+a bare wherestr = "10001" would open Kent County, DE (10001 happens
+to be a county fips as well as a zip code). Adding context also works,
+like url_ejscreenmap(wherestr = "10001, NY").
 
 (The interactive search box inside the EJScreen app is different from
 these launch-URL deep links: it still reads a bare 5-digit number as a zip.)
@@ -67,6 +69,15 @@ Can be State abbrev like "NY" or full state name,
 or city like "New Rochelle, NY" as from fips2name() -- using fips2name()
 works for state, county, or city FIPS code converted to name,
 but using the fips parameter is probably a better idea.}
+
+\item{zip}{5-digit zip code(s) - the unambiguous way to open EJScreen at zip
+code(s), via the app's \verb{?zip=} parameter: always geocoded as zips, never
+read as county fips (unlike a bare 5-digit wherestr). Each zip gets a pin
+with the report popup; one zip centers the map, several fit the view to
+all of them (or use combined = FALSE, the default, for one URL per zip).
+Used only if sitepoints (or lat,lon), shapefile, and fips are not provided;
+takes precedence over wherestr. A zip passed as a number gets its leading
+zeroes restored.}
 
 \item{radius}{optional buffer distance in miles for the EJScreen report around
 each point (or polygon). When provided, point links use the app's
@@ -113,7 +124,8 @@ deployments ignore them and just open the map. The \verb{wherestr=} style links
 or city/CDP FIPS) work on all versions of the app.
 }
 \examples{
-url_ejscreenmap(fips = "10001")
+url_ejscreenmap(fips = "10001") # county FIPS 10001 = Kent County, DE
+url_ejscreenmap(zip = "10001")  # zip code 10001 = Manhattan, NY
 url_ejscreenmap(fips = c("10001", "10003"))
 url_ejscreenmap(fips = c("10001", "10003"), combined = TRUE)
 url_ejscreenmap(lat = c(39, 39.7), lon = c(-75.5, -75.6), radius = 3, combined = TRUE)

--- a/man/url_ejscreenmap.Rd
+++ b/man/url_ejscreenmap.Rd
@@ -11,14 +11,14 @@ url_ejscreenmap(
   shapefile = NULL,
   fips = NULL,
   wherestr = NULL,
-  zip = NULL,
-  radius = NULL,
-  combined = FALSE,
   as_html = FALSE,
   linktext = "EJSCREEN",
   ifna = "https://pedp-ejscreen.azurewebsites.net/index.html",
   baseurl = "https://pedp-ejscreen.azurewebsites.net/index.html",
   ...,
+  zip = NULL,
+  radius = NULL,
+  combined = FALSE,
   shape = NULL,
   shp = NULL
 )
@@ -70,6 +70,16 @@ or city like "New Rochelle, NY" as from fips2name() -- using fips2name()
 works for state, county, or city FIPS code converted to name,
 but using the fips parameter is probably a better idea.}
 
+\item{as_html}{Whether to return as just the urls or as html hyperlinks to use in a DT::datatable() for example}
+
+\item{linktext}{used as text for hyperlinks, if supplied and as_html=TRUE}
+
+\item{ifna}{URL shown for missing, NA, NULL, bad input values}
+
+\item{baseurl}{do not change unless endpoint actually changed}
+
+\item{...}{regid can be provided (used to look up lat,lon as a last resort if no sites provided); other arguments ignored}
+
 \item{zip}{5-digit zip code(s) - the unambiguous way to open EJScreen at zip
 code(s), via the app's \verb{?zip=} parameter: always geocoded as zips, never
 read as county fips (unlike a bare 5-digit wherestr). Each zip gets a pin
@@ -88,19 +98,10 @@ report buffer is prefilled.}
 in a single EJScreen session (drawn on the map and accumulated into the
 app's Multisite list, ready for a Multisite Report or Send to EJAM),
 instead of the default of one URL per site. Works when all sites are
-county/tract/blockgroup fips, or all are points, or all are small polygons.
-If the combined URL would be too long to be reliable (over roughly 1900
-characters), it falls back to one URL per site, with a warning.}
-
-\item{as_html}{Whether to return as just the urls or as html hyperlinks to use in a DT::datatable() for example}
-
-\item{linktext}{used as text for hyperlinks, if supplied and as_html=TRUE}
-
-\item{ifna}{URL shown for missing, NA, NULL, bad input values}
-
-\item{baseurl}{do not change unless endpoint actually changed}
-
-\item{...}{regid can be provided (used to look up lat,lon as a last resort if no sites provided); other arguments ignored}
+county/tract/blockgroup fips, or all are points, or all are zip codes, or
+all are small polygons. If the combined URL would be too long to be
+reliable (over roughly 1900 characters), it falls back to one URL per
+site, with a warning.}
 
 \item{shape, shp}{aliases (synonyms) for shapefile}
 }

--- a/tests/testthat/test-URL_FUNCTIONS_part2.R
+++ b/tests/testthat/test-URL_FUNCTIONS_part2.R
@@ -186,6 +186,8 @@ test_that("url_ejscreenmap points: legacy wherestr by default, lat/lon/radius wh
 test_that("url_ejscreenmap wherestr-only calls now produce a wherestr link", {
   base <- "https://pedp-ejscreen.azurewebsites.net/index.html"
   expect_equal(url_ejscreenmap(wherestr = "10001"), paste0(base, "?wherestr=10001"))
+  # a zip code passed as a number works too
+  expect_equal(url_ejscreenmap(wherestr = 10001), paste0(base, "?wherestr=10001"))
   # free text is percent-encoded once (the app unescape()s it), and
   # as_html's re-encode (reserved = FALSE) must not double-encode it
   expect_equal(url_ejscreenmap(wherestr = "Dover, DE"), paste0(base, "?wherestr=Dover%2C%20DE"))

--- a/tests/testthat/test-URL_FUNCTIONS_part2.R
+++ b/tests/testthat/test-URL_FUNCTIONS_part2.R
@@ -186,6 +186,12 @@ test_that("url_ejscreenmap points: legacy wherestr by default, lat/lon/radius wh
 test_that("url_ejscreenmap wherestr-only calls now produce a wherestr link", {
   base <- "https://pedp-ejscreen.azurewebsites.net/index.html"
   expect_equal(url_ejscreenmap(wherestr = "10001"), paste0(base, "?wherestr=10001"))
+  # free text is percent-encoded once (the app unescape()s it), and
+  # as_html's re-encode (reserved = FALSE) must not double-encode it
+  expect_equal(url_ejscreenmap(wherestr = "Dover, DE"), paste0(base, "?wherestr=Dover%2C%20DE"))
+  xh <- url_ejscreenmap(wherestr = "Dover, DE", as_html = TRUE)
+  expect_true(grepl("wherestr=Dover%2C%20DE", xh, fixed = TRUE))
+  expect_false(grepl("%25", xh, fixed = TRUE))
 })
 
 test_that("url_ejscreenmap shapefile makes ?polygon= deep links, drawing the outline", {

--- a/tests/testthat/test-URL_FUNCTIONS_part2.R
+++ b/tests/testthat/test-URL_FUNCTIONS_part2.R
@@ -241,6 +241,11 @@ test_that("url_ejscreenmap combined=TRUE falls back to one URL per site when too
                  "one URL per site")
   expect_equal(length(p), 150)
   expect_true(all(grepl("radius=1", p, fixed = TRUE)))
+  # same guard for combined zip codes
+  manyzip <- sprintf("%05d", 10001:10400)
+  expect_warning({z <- url_ejscreenmap(zip = manyzip, combined = TRUE)}, "one URL per site")
+  expect_equal(length(z), length(manyzip))
+  expect_true(all(startsWith(z, paste0(base, "?zip="))))
 })
 
 test_that("url_ejscreenmap combined=TRUE for shapefile returns one URL with repeated polygon=", {

--- a/tests/testthat/test-URL_FUNCTIONS_part2.R
+++ b/tests/testthat/test-URL_FUNCTIONS_part2.R
@@ -260,6 +260,42 @@ test_that("url_ejscreenmap polygon centroid fallback keeps the radius", {
   expect_true(grepl("&radius=2", u3, fixed = TRUE))
 })
 
+test_that("url_ejscreenmap API-down fallback counts lon-only inputs", {
+  orig_global_or_param <- EJAM:::global_or_param
+  local_mocked_bindings(
+    global_or_param = function(vname) {
+      if (identical(vname, "ejamapi_is_down")) {return(TRUE)}
+      orig_global_or_param(vname)
+    },
+    .package = "EJAM"
+  )
+
+  x <- url_ejscreenmap(lon = c(-75.5, -75.6, -75.7))
+  expect_equal(length(x), 3)
+  expect_equal(x, rep("https://ejanalysis.org", 3))
+})
+
+test_that("polygons_as_deeplink_strings uses exterior rings without repeated closing point", {
+  outer <- matrix(
+    c(0, 0,
+      0, 10,
+      10, 10,
+      10, 0,
+      0, 0),
+    ncol = 2, byrow = TRUE
+  )
+  theta <- seq(0, 2 * pi, length.out = 25)
+  hole <- cbind(5 + cos(theta), 5 + sin(theta))
+  poly <- sf::st_sf(geometry = sf::st_sfc(sf::st_polygon(list(outer, hole)), crs = 4326))
+
+  polystr <- EJAM:::polygons_as_deeplink_strings(poly, digits = 1)
+  pairs <- strsplit(polystr, ";", fixed = TRUE)[[1]]
+
+  expect_equal(length(pairs), 4)
+  expect_false(identical(pairs[1], pairs[length(pairs)]))
+  expect_true(all(pairs %in% c("0,0", "10,0", "10,10", "0,10")))
+})
+
 test_that("url_ejscreenmap as_html returns hyperlinks for fips deep links", {
   x <- url_ejscreenmap(fips = "10001", as_html = TRUE)
   expect_true(grepl("^<a ", x))

--- a/tests/testthat/test-URL_FUNCTIONS_part2.R
+++ b/tests/testthat/test-URL_FUNCTIONS_part2.R
@@ -196,6 +196,23 @@ test_that("url_ejscreenmap wherestr-only calls now produce a wherestr link", {
   expect_false(grepl("%25", xh, fixed = TRUE))
 })
 
+test_that("url_ejscreenmap zip= is the explicit way to link zip codes", {
+  base <- "https://pedp-ejscreen.azurewebsites.net/index.html"
+  expect_equal(url_ejscreenmap(zip = "10001"), paste0(base, "?zip=10001"))
+  # a zip passed as a number gets its leading zeroes restored
+  expect_equal(url_ejscreenmap(zip = 1001), paste0(base, "?zip=01001"))
+  # one URL per zip by default; combined = one URL for all; radius passes through
+  expect_equal(url_ejscreenmap(zip = c("10001", "99501")),
+               paste0(base, "?zip=", c("10001", "99501")))
+  expect_equal(url_ejscreenmap(zip = c("10001", "99501"), combined = TRUE, radius = 2),
+               paste0(base, "?zip=10001,99501&radius=2"))
+  # zip takes precedence over wherestr
+  expect_equal(url_ejscreenmap(zip = "10001", wherestr = "Dover, DE"), paste0(base, "?zip=10001"))
+  # non-5-digit values get the generic URL, with a warning
+  expect_warning({x <- url_ejscreenmap(zip = c("10001", "123456"))}, "5-digit")
+  expect_equal(x, c(paste0(base, "?zip=10001"), base))
+})
+
 test_that("url_ejscreenmap shapefile makes ?polygon= deep links, drawing the outline", {
   base <- "https://pedp-ejscreen.azurewebsites.net/index.html"
   u <- url_ejscreenmap(shapefile = testinput_shapes_2[1, ])

--- a/tests/testthat/test-URL_FUNCTIONS_part2.R
+++ b/tests/testthat/test-URL_FUNCTIONS_part2.R
@@ -294,6 +294,19 @@ test_that("polygons_as_deeplink_strings uses exterior rings without repeated clo
   expect_equal(length(pairs), 4)
   expect_false(identical(pairs[1], pairs[length(pairs)]))
   expect_true(all(pairs %in% c("0,0", "10,0", "10,10", "0,10")))
+
+  outer2 <- matrix(
+    c(20, 20,
+      20, 25,
+      25, 25,
+      25, 20,
+      20, 20),
+    ncol = 2, byrow = TRUE
+  )
+  mpoly <- sf::st_sf(geometry = sf::st_sfc(sf::st_multipolygon(list(list(outer, hole), list(outer2))), crs = 4326))
+  mpairs <- strsplit(EJAM:::polygons_as_deeplink_strings(mpoly, digits = 1), ";", fixed = TRUE)[[1]]
+  expect_equal(length(mpairs), 4)
+  expect_false(any(grepl("^5", mpairs)))
 })
 
 test_that("url_ejscreenmap as_html returns hyperlinks for fips deep links", {

--- a/tests/testthat/test-URL_FUNCTIONS_part2.R
+++ b/tests/testthat/test-URL_FUNCTIONS_part2.R
@@ -139,6 +139,75 @@ for (func in funcnames) {
 
 # url_github_preview()
 
+############## TESTS FOR url_ejscreenmap() DEEP LINKS ############## #
+
+test_that("url_ejscreenmap makes ?fips= deep links for county/tract/blockgroup", {
+  base <- "https://pedp-ejscreen.azurewebsites.net/index.html"
+  expect_equal(url_ejscreenmap(fips = "10001"), paste0(base, "?fips=10001"))
+  expect_equal(url_ejscreenmap(fips = c("10001", "10003")),
+               paste0(base, "?fips=", c("10001", "10003")))
+  expect_equal(url_ejscreenmap(fips = "10001040100"), paste0(base, "?fips=10001040100"))   # tract
+  expect_equal(url_ejscreenmap(fips = "100010401001"), paste0(base, "?fips=100010401001")) # blockgroup
+  # numeric fips gets its leading zero restored
+  expect_equal(url_ejscreenmap(fips = 6037), paste0(base, "?fips=06037"))
+})
+
+test_that("url_ejscreenmap combined=TRUE returns one multisite URL", {
+  base <- "https://pedp-ejscreen.azurewebsites.net/index.html"
+  expect_equal(url_ejscreenmap(fips = c("10001", "10003"), combined = TRUE),
+               paste0(base, "?fips=10001,10003"))
+  expect_equal(url_ejscreenmap(lat = c(39, 39.7), lon = c(-75.5, -75.6), combined = TRUE, radius = 2),
+               paste0(base, "?lat=39,39.7&lon=-75.5,-75.6&radius=2"))
+  # combined with a non-deep-linkable fips type falls back to one URL per site, with a warning
+  expect_warning({x <- url_ejscreenmap(fips = c("10001", "10"), combined = TRUE)})
+  expect_equal(length(x), 2)
+})
+
+test_that("url_ejscreenmap state/city fips fall back to ?wherestr= place name", {
+  base <- "https://pedp-ejscreen.azurewebsites.net/index.html"
+  u <- url_ejscreenmap(fips = "10") # Delaware
+  expect_true(startsWith(u, paste0(base, "?wherestr=")))
+  expect_false(grepl("fips=", u, fixed = TRUE))
+  u2 <- url_ejscreenmap(fips = "4748000") # Memphis city/CDP
+  expect_true(startsWith(u2, paste0(base, "?wherestr=")))
+})
+
+test_that("url_ejscreenmap points: legacy wherestr by default, lat/lon/radius when radius given", {
+  base <- "https://pedp-ejscreen.azurewebsites.net/index.html"
+  expect_equal(url_ejscreenmap(lat = 39, lon = -75.5),
+               paste0(base, "?wherestr=39,-75.5"))
+  expect_equal(url_ejscreenmap(lat = 39, lon = -75.5, radius = 3),
+               paste0(base, "?lat=39&lon=-75.5&radius=3"))
+  # NA points use the ifna URL
+  expect_equal(url_ejscreenmap(lat = c(39, NA), lon = c(-75.5, -75.6)),
+               c(paste0(base, "?wherestr=39,-75.5"), base))
+})
+
+test_that("url_ejscreenmap wherestr-only calls now produce a wherestr link", {
+  base <- "https://pedp-ejscreen.azurewebsites.net/index.html"
+  expect_equal(url_ejscreenmap(wherestr = "10001"), paste0(base, "?wherestr=10001"))
+})
+
+test_that("url_ejscreenmap shapefile makes ?polygon= deep links, drawing the outline", {
+  base <- "https://pedp-ejscreen.azurewebsites.net/index.html"
+  u <- url_ejscreenmap(shapefile = testinput_shapes_2[1, ])
+  expect_true(startsWith(u, paste0(base, "?polygon=")))
+  # the polygon= value is lat,lon pairs separated by ;
+  val <- sub(".*polygon=", "", u)
+  pairs <- strsplit(val, ";")[[1]]
+  expect_true(length(pairs) >= 3)
+  expect_true(all(grepl("^-?[0-9.]+,-?[0-9.]+$", pairs)))
+  # one URL per polygon by default
+  u2 <- url_ejscreenmap(shapefile = testinput_shapes_2)
+  expect_equal(length(u2), NROW(testinput_shapes_2))
+})
+
+test_that("url_ejscreenmap as_html returns hyperlinks for fips deep links", {
+  x <- url_ejscreenmap(fips = "10001", as_html = TRUE)
+  expect_true(grepl("^<a ", x))
+  expect_true(grepl("fips=10001", x))
+})
+
 ############## TESTS FOR FACILITY-NEARBY URL FUNCTIONS ############## #
 
 test_that("url_efpoints builds correct base URL for each sitecategory layer number", {

--- a/tests/testthat/test-URL_FUNCTIONS_part2.R
+++ b/tests/testthat/test-URL_FUNCTIONS_part2.R
@@ -208,6 +208,40 @@ test_that("url_ejscreenmap shapefile makes ?polygon= deep links, drawing the out
   expect_equal(length(u2), NROW(testinput_shapes_2))
 })
 
+test_that("url_ejscreenmap combined=TRUE falls back to one URL per site when too long", {
+  base <- "https://pedp-ejscreen.azurewebsites.net/index.html"
+  # ~400 five-digit codes is far over the ~1900-character combined-URL cap
+  manyfips <- sprintf("%05d", 10001:10400)
+  expect_warning({x <- url_ejscreenmap(fips = manyfips, combined = TRUE)}, "one URL per site")
+  expect_equal(length(x), length(manyfips))
+  expect_true(all(startsWith(x, paste0(base, "?fips="))))
+  # same guard for combined points
+  manylat <- rep(39.123456, 150)
+  manylon <- rep(-75.123456, 150)
+  expect_warning({p <- url_ejscreenmap(lat = manylat, lon = manylon, combined = TRUE, radius = 1)},
+                 "one URL per site")
+  expect_equal(length(p), 150)
+  expect_true(all(grepl("radius=1", p, fixed = TRUE)))
+})
+
+test_that("url_ejscreenmap polygon centroid fallback keeps the radius", {
+  base <- "https://pedp-ejscreen.azurewebsites.net/index.html"
+  # a star polygon with many deep teeth survives simplification with too many
+  # vertices to fit in a URL, forcing the centroid fallback
+  n <- 400
+  ang <- seq(0, 2 * pi, length.out = n + 1)[-(n + 1)]
+  r <- rep(c(0.6, 0.3), length.out = n)
+  ring <- cbind(-75 + r * cos(ang), 39.5 + r * sin(ang))
+  ring <- rbind(ring, ring[1, ])
+  star <- sf::st_sf(geometry = sf::st_sfc(sf::st_polygon(list(ring)), crs = 4326))
+  u <- url_ejscreenmap(shapefile = star, radius = 2)
+  expect_true(startsWith(u, paste0(base, "?lat=")))
+  expect_true(grepl("&radius=2", u, fixed = TRUE))
+  # without a radius, the fallback stays the legacy centroid wherestr link
+  u2 <- url_ejscreenmap(shapefile = star)
+  expect_true(startsWith(u2, paste0(base, "?wherestr=")))
+})
+
 test_that("url_ejscreenmap as_html returns hyperlinks for fips deep links", {
   x <- url_ejscreenmap(fips = "10001", as_html = TRUE)
   expect_true(grepl("^<a ", x))

--- a/tests/testthat/test-URL_FUNCTIONS_part2.R
+++ b/tests/testthat/test-URL_FUNCTIONS_part2.R
@@ -224,6 +224,18 @@ test_that("url_ejscreenmap combined=TRUE falls back to one URL per site when too
   expect_true(all(grepl("radius=1", p, fixed = TRUE)))
 })
 
+test_that("url_ejscreenmap combined=TRUE for shapefile returns one URL with repeated polygon=", {
+  base <- "https://pedp-ejscreen.azurewebsites.net/index.html"
+  u <- url_ejscreenmap(shapefile = testinput_shapes_2, combined = TRUE, radius = 1)
+  expect_equal(length(u), 1)
+  expect_true(startsWith(u, paste0(base, "?polygon=")))
+  # one polygon= value per row of the shapefile, plus the shared radius
+  expect_equal(lengths(regmatches(u, gregexpr("polygon=", u, fixed = TRUE))),
+               NROW(testinput_shapes_2))
+  expect_true(grepl("&radius=1", u, fixed = TRUE))
+  expect_true(nchar(u) <= 1900)
+})
+
 test_that("url_ejscreenmap polygon centroid fallback keeps the radius", {
   base <- "https://pedp-ejscreen.azurewebsites.net/index.html"
   # a star polygon with many deep teeth survives simplification with too many

--- a/tests/testthat/test-URL_FUNCTIONS_part2.R
+++ b/tests/testthat/test-URL_FUNCTIONS_part2.R
@@ -252,6 +252,10 @@ test_that("url_ejscreenmap polygon centroid fallback keeps the radius", {
   # without a radius, the fallback stays the legacy centroid wherestr link
   u2 <- url_ejscreenmap(shapefile = star)
   expect_true(startsWith(u2, paste0(base, "?wherestr=")))
+  # the same fallback works for a bare geometry column (sfc) input
+  u3 <- url_ejscreenmap(shapefile = sf::st_geometry(star), radius = 2)
+  expect_true(startsWith(u3, paste0(base, "?lat=")))
+  expect_true(grepl("&radius=2", u3, fixed = TRUE))
 })
 
 test_that("url_ejscreenmap as_html returns hyperlinks for fips deep links", {

--- a/tests/testthat/test-ejamit.R
+++ b/tests/testthat/test-ejamit.R
@@ -394,14 +394,22 @@ test_that("ejamit() still returns results_bysite identical to numbers it used to
     suppressMessages({
       # if (!exists("ejamitoutnow")) {stop("ejamitoutnow is missing but should have been created by EJAM/tests/testthat/setup.R")}
       # ejamitoutnow <- ejamit(testpoints_10, radius = 1, quiet = T, silentinteractive = TRUE) # see setup.R - takes roughly 5-10 seconds
+      ## Compare all columns except the two hyperlink columns ("EJAM Report" =
+      ## column 1, and "EJSCREEN Map"): link formats legitimately change (e.g.,
+      ## EJSCREEN links now use lat/lon/radius deep-link parameters instead of
+      ## wherestr=), the stored reference is deliberately NOT regenerated for
+      ## URL-format-only changes, and link formats are covered by the dedicated
+      ## URL tests (test-URL_FUNCTIONS_part2.R etc.). This check is about the
+      ## data values.
+      linkcols <- c("EJAM Report", "EJSCREEN Map")
+      keptcols <- setdiff(names(testoutput_ejamit_10pts_1miles$results_bysite), linkcols)
       expect_equal(
-        ## Compare all columns expect column 1, the url of the EJAM Report
-        ejamitoutnow$results_bysite[,-1],
-        testoutput_ejamit_10pts_1miles$results_bysite[,-1]
-        ,
-        ignore_attr = ".internal.selfref" # intended to ignore attribute
-        # but does not ignore attributes that are metadata like date saved to package, ACS version, etc. that are part of testoutput_ejamit_10pts_1miles, etc.
+        as.data.frame(ejamitoutnow$results_bysite)[, keptcols],
+        as.data.frame(testoutput_ejamit_10pts_1miles$results_bysite)[, keptcols]
       )
+      ## sanity check the links column still holds links (format details are
+      ## checked by the URL function tests, not against the stored copy)
+      expect_true(all(grepl('^<a href="https://', ejamitoutnow$results_bysite[["EJSCREEN Map"]])))
       # all.equal(    ejamitoutnow$results_bysite,
       #               testoutput_ejamit_10pts_1miles$results_bysite)
     } )
@@ -418,10 +426,20 @@ test_that("ejamit() still returns results_bysite with same EJAM Report column", 
       ## version (version=X.Y.Z), which legitimately changes every release, so
       ## normalize it before comparing -- otherwise this structural check breaks on
       ## each version bump (the saved reference was built at an earlier version).
-      norm_report_version <- function(x) gsub("version=[0-9]+\\.[0-9]+\\.[0-9]+", "version=VER", x)
+      ## Likewise normalize the API base URL and the fileextension= parameter,
+      ## which legitimately changed (branded api.ejanalysis.com base URL, explicit
+      ## fileextension=pdf) without regenerating the stored reference: this check
+      ## is about the per-site query values (lat/lon/buffer/sitetype), while the
+      ## URL base and format are covered by the URL function tests.
+      norm_report_url <- function(x) {
+        x <- gsub("version=[0-9]+\\.[0-9]+\\.[0-9]+", "version=VER", x)
+        x <- gsub("https://[^/\"]+/report\\?", "https://HOST/report?", x)
+        x <- gsub("&fileextension=[[:alnum:]]+", "", x)
+        x
+      }
       expect_equal(
-        norm_report_version(as.vector(unlist(ejamitoutnow$results_bysite[,1]))),
-        norm_report_version(as.vector(unlist(testoutput_ejamit_10pts_1miles$results_bysite[,1])))
+        norm_report_url(as.vector(unlist(ejamitoutnow$results_bysite[,1]))),
+        norm_report_url(as.vector(unlist(testoutput_ejamit_10pts_1miles$results_bysite[,1])))
       )
       # all.equal(    ejamitoutnow$results_bysite,
       #               testoutput_ejamit_10pts_1miles$results_bysite)

--- a/vignettes/dev-api.Rmd
+++ b/vignettes/dev-api.Rmd
@@ -20,7 +20,7 @@ knitr::opts_chunk$set(eval = FALSE, comment = "#>")
 This is a short overview. For the authoritative and most current details, see:
 
 - the **[EJAM-API repository](https://github.com/Public-Environmental-Data-Partners/EJAM-API)**
-  and its README -- it documents every endpoint, parameter, and example;
+  and its [README](https://github.com/Public-Environmental-Data-Partners/EJAM-API?tab=readme-ov-file#ejam-api) -- it documents every endpoint, parameter, and example;
 - the help for **`?ejamapi`** and **`?url_ejamapi`**; and
 - the [Defaults and Custom Settings for the Web App](dev-app-settings.html) article, for the
   *deep links* (launch-URL parameters + token handoff) that pre-load the EJAM web app.
@@ -33,6 +33,14 @@ points, a polygon, or US Census areas (FIPS). It runs the same engine as the pac
 API report matches what `ejamit()` / `ejam2report()` would produce locally.
 
 ## Reaching it from R
+
+```{r api, eval=FALSE}
+## API - multisite report fails until redeploy API to use v3.2022.1
+urlx = url_ejamapi(fips=c(3650617,'0973000'), sitenumber = 0)
+urlx
+# "https://api.ejanalysis.com/report?fips=3650617,0973000&buffer=0&sitenumber=0&version=3.2022.1&fileextension=html"
+# browseURL(urlx)
+```
 
 Two functions wrap the API:
 

--- a/vignettes/dev-api.Rmd
+++ b/vignettes/dev-api.Rmd
@@ -35,7 +35,7 @@ API report matches what `ejamit()` / `ejam2report()` would produce locally.
 ## Reaching it from R
 
 ```{r api, eval=FALSE}
-## API - multisite report fails until redeploy API to use v3.2022.1
+## API example: build a multisite report URL
 urlx = url_ejamapi(fips=c(3650617,'0973000'), sitenumber = 0)
 urlx
 # "https://api.ejanalysis.com/report?fips=3650617,0973000&buffer=0&sitenumber=0&version=3.2022.1&fileextension=html"

--- a/vignettes/dev-app-settings.Rmd
+++ b/vignettes/dev-app-settings.Rmd
@@ -83,23 +83,28 @@ anyone can construct:
   vertices (at least 3); repeat the parameter for more than one polygon. `shape=`, `shp=`,
   and `shapefile=` are aliases (synonyms) for `polygon=`, matching the parameter aliases
   EJAM functions like `ejamit()` accept.
+- `?zip=10001` or `?zip=10001,99501` -- the explicit way to pass zip code(s),
+  comma-separated: each is geocoded as a zip (never read as a county FIPS) and pinned
+  with the report popup; one zip centers the map, several fit the view to all of them.
 - `?wherestr=Dover%2C%20DE` or `?wherestr=39.157,-75.52` -- the original EJScreen
   parameter: geocodes a place name / address / zipcode (or centers on a `lat,lon`) and
   drops a pin, without selecting a boundary -- except a bare 5-digit value, see below.
 
 One kind of place is used per link, in the order above (`fips` beats `lat`/`lon`, which
-beat polygons, which beat `wherestr`). A single place opens the site report popup on it;
-several places are all drawn and added to EJScreen's Multisite list, ready for a Multisite
-Report or the "Send to EJAM" handoff back into EJAM.
+beat polygons, which beat `zip`, which beats `wherestr`). A single place opens the site
+report popup on it; several places are all drawn and (other than zips) added to
+EJScreen's Multisite list, ready for a Multisite Report or the "Send to EJAM" handoff
+back into EJAM.
 
 **ZIP code vs county FIPS:** a bare 5-digit number is ambiguous -- 10001 is both a
-Manhattan zip code and Kent County, DE's county FIPS. EJAM treats a 5-digit place code as
-a county FIPS, and EJScreen's deep links now follow the same convention:
-`?wherestr=10001` is tried as a county FIPS first (drawing and selecting that county),
-and only geocoded as a zip code if no county has that code. To be unambiguous, pass FIPS
-codes with `fips=` (what `url_ejscreenmap()` does), and force a zip by adding context,
-e.g. `?wherestr=10001,NY`. The interactive search box inside the EJScreen app is
-unchanged: typing a bare 5-digit number there still searches it as a zip code.
+Manhattan zip code and Kent County, DE's county FIPS. The deep links resolve it
+explicitly: `fips=` is always county/tract/blockgroup FIPS, and `zip=` is always a zip
+code. A bare 5-digit `wherestr=` follows EJAM's convention: it is tried as a county FIPS
+first (drawing and selecting that county), and only geocoded as a zip code if no county
+has that code. So prefer `fips=` and `zip=` (i.e., `url_ejscreenmap(fips = )` and
+`url_ejscreenmap(zip = )`); adding context like `?wherestr=10001,NY` also still forces
+the zip reading. The interactive search box inside the EJScreen app is unchanged:
+typing a bare 5-digit number there still searches it as a zip code.
 
 URL-encoding: percent-encode free-text values (a space becomes `%20`, a comma can be
 `%2C`); the digits, commas, and semicolons in the numeric parameters can be left as is.
@@ -109,8 +114,13 @@ back to a centroid `wherestr=` link if an outline cannot fit):
 
 ```{r url_ejscreenmap_examples}
 # One county: boundary drawn & selected, site report popup open
+# (10001 as a FIPS is Kent County, DE; as a zip code it is in Manhattan, NY)
 url_ejscreenmap(fips = "10001")
 #> "https://pedp-ejscreen.azurewebsites.net/index.html?fips=10001"
+
+# The same 5 digits as a zip code: pinned in Manhattan, never read as a FIPS
+url_ejscreenmap(zip = "10001")
+#> "https://pedp-ejscreen.azurewebsites.net/index.html?zip=10001"
 
 # One URL per site (the default; used for per-site link columns in EJAM result tables)
 url_ejscreenmap(fips = c("10001", "10003"))

--- a/vignettes/dev-app-settings.Rmd
+++ b/vignettes/dev-app-settings.Rmd
@@ -90,8 +90,11 @@ anyone can construct:
   parameter: geocodes a place name / address / zipcode (or centers on a `lat,lon`) and
   drops a pin, without selecting a boundary -- except a bare 5-digit value, see below.
 
-One kind of place is used per link, in the order above (`fips` beats `lat`/`lon`, which
-beat polygons, which beat `zip`, which beats `wherestr`). A single place opens the site
+One kind of place is used per link: the EJScreen app reads these URL parameters in the
+order above, so a link's `fips=` beats its `lat=`/`lon=`, which beat polygons, which
+beat `zip=`, which beats `wherestr=`. (That describes how the app reads a URL -- the
+`url_ejscreenmap()` R helper arbitrates its *arguments* in its own order when several
+are passed, so give it only one input type per call.) A single place opens the site
 report popup on it; several places are all drawn and (other than zips) added to
 EJScreen's Multisite list, ready for a Multisite Report or the "Send to EJAM" handoff
 back into EJAM.
@@ -101,8 +104,8 @@ Manhattan zip code and Kent County, DE's county FIPS. The deep links resolve it
 explicitly: `fips=` is always county/tract/blockgroup FIPS, and `zip=` is always a zip
 code. A bare 5-digit `wherestr=` follows EJAM's convention: it is tried as a county FIPS
 first (drawing and selecting that county), and only geocoded as a zip code if no county
-has that code. So prefer `fips=` and `zip=` (i.e., `url_ejscreenmap(fips = )` and
-`url_ejscreenmap(zip = )`); adding context like `?wherestr=10001,NY` also still forces
+has that code. So prefer `fips=` and `zip=` -- the `fips` and `zip` arguments of
+`url_ejscreenmap()` -- while adding context like `?wherestr=10001,NY` also still forces
 the zip reading. The interactive search box inside the EJScreen app is unchanged:
 typing a bare 5-digit number there still searches it as a zip code.
 

--- a/vignettes/dev-app-settings.Rmd
+++ b/vignettes/dev-app-settings.Rmd
@@ -86,14 +86,13 @@ Deep links based on FIPS code of Census unit like county:
 - http://ejamdev.ejanalysis.com/?fips=24029,24031
 
 ```{r url_ejamapp, eval=FALSE}
-## EJAM app on production server - fails until deployed to production 
-urlx = url_ejamapp(fips=c(3650617,'0973000') )
+## EJAM app deep link (default base URL)
+urlx <- url_ejamapp(fips = c(3650617, "0973000"))
 urlx
-#           "https://ejamapp.ejanalysis.com/?fips=3650617,0973000"
-# browseURL("https://ejamapp.ejanalysis.com/?fips=3650617,0973000")
+# browseURL(urlx)
 
-## EJAM app dev - ok
-browseURL("https://ejamdev.ejanalysis.com/?fips=3650617,0973000")
+## For a non-default deployment, override the base URL:
+# browseURL(url_ejamapp(fips = c(3650617, "0973000"), baseurl = "<staging-app-baseurl>"))
 ```
 
 Build such a link with `url_ejamapp()`; its query vocabulary matches `url_ejamapi()` (which

--- a/vignettes/dev-app-settings.Rmd
+++ b/vignettes/dev-app-settings.Rmd
@@ -38,12 +38,18 @@ if (!exists("blockgroupstats")) {library(EJAM)} # use installed version only if 
 ```
 
 
-# Deep links: launch the app pre-loaded via URL parameters
+# Deep links: launch the EJAM app pre-loaded via URL parameters
 
 Besides the deploy-time settings described below, an already-running EJAM app can be
 **launched pre-loaded with a set of places** by opening it with launch query parameters in
 the URL. This is how the EJScreen Report tool's "Send to EJAM" button opens EJAM ready to
 run, and what `url_ejamapp()` builds as shareable deep links.
+
+Deep linking, in other words, lets you send selected sites from the EJScreen app
+to the EJAM app (multisite tool) via a "handoff"
+that lets you continue in EJAM for further analysis.
+
+EJAM app v3.x handles a few deeplink parameters.
 
 The app reads these at startup (one place-type per launch -- points, else FIPS, else
 polygons):
@@ -55,6 +61,41 @@ polygons):
 - `?handoff=<token>` -- a token minted by the EJAM API `POST /handoff` and fetched back at
   startup, for large polygon sets that exceed URL-length limits
 
+Some examples of URLs:
+
+The URL https://ejam.ejanalysis.com/  is an alias for
+the production server hosting the live EJAM shiny app 
+at https://ejam.publicenvirodata.org,
+and it provides a way to pass through URL-encoded parameters.
+
+The URL http://ejamdev.ejanalysis.com is an alias for
+the development / staging server hosting a live EJAM shiny app 
+at http://ejam-dev-alb-971929002.us-east-1.elb.amazonaws.com 
+and it also provides a way to pass through URL-encoded parameters.
+
+Deep links based on lat and lon and radius
+for one or more points:
+
+- http://ejam-dev-alb-971929002.us-east-1.elb.amazonaws.com/?lat=33&lon=-112&radius=2
+- http://ejamdev.ejanalysis.com/?lat=33&lon=-112&radius=2
+- http://ejamdev.ejanalysis.com/?lat=33,33.1&lon=-112,-112.2&radius=2
+
+Deep links based on FIPS code of Census unit like county:
+  
+- http://ejamdev.ejanalysis.com/?fips=24029&buffer=0
+- http://ejamdev.ejanalysis.com/?fips=24029,24031
+
+```{r url_ejamapp, eval=FALSE}
+## EJAM app on production server - fails until deployed to production 
+urlx = url_ejamapp(fips=c(3650617,'0973000') )
+urlx
+#           "https://ejamapp.ejanalysis.com/?fips=3650617,0973000"
+# browseURL("https://ejamapp.ejanalysis.com/?fips=3650617,0973000")
+
+## EJAM app dev - ok
+browseURL("https://ejamdev.ejanalysis.com/?fips=3650617,0973000")
+```
+
 Build such a link with `url_ejamapp()`; its query vocabulary matches `url_ejamapi()` (which
 builds *API* request URLs rather than *app* links). The default app base is
 `https://ejamapp.ejanalysis.com/`, a Cloudflare-fronted shortcut on the `ejanalysis.com`
@@ -62,6 +103,20 @@ domain that forwards the query string to the live app (a plain redirect that dro
 query would open the app empty). For the API side -- including the friendlier
 `https://api.ejanalysis.com/` base and parameter details -- see the `dev-api` article, the
 help for `ejamapi()`/`url_ejamapi()`, and the EJAM-API repository's README.
+
+----
+
+**Limited deep link capability for linking into the EJScreen app via URLs:**
+
+  See `url_ejscreenmap()`
+
+Show EJScreen map at given lat,lon point selected
+https://pedp-ejscreen.azurewebsites.net/index.html?wherestr=33,-100
+
+Show EJScreen map at given FIPS code (county), but it is not selected/shown as bounds
+https://pedp-ejscreen.azurewebsites.net/index.html?fips=10001
+
+----
 
 # NOTES ON GLOBAL DEFAULTS, SHINY INPUTS, BOOKMARKS, AND FUNCTION PARAMETERS
 
@@ -138,10 +193,10 @@ Many defaults/ settings used by the web app are defined in the global_defaults_ 
 (global_defaults_package.R, global_defaults_shiny.R, global_defaults_shiny_public.R).
 Some settings are needed even if the shiny app is never launched, so they are stored for the package 
 as soon as the package is attached, in a list object called `global_defaults_package` in the global environment, e.g., `global_defaults_package$report_title`. (When the app is launched, those and many other global_defaults from the files `global_defaults_*.R`, including radius_default, will be stored in the shiny app).
-Note the parameter isPublic is special because it is checked by the global_defaults_shiny_public.R file
-and some settings depend on isPublic being T or F.
+Note the parameter `isPublic` is special because it is checked by the global_defaults_shiny_public.R file
+and some settings depend on `isPublic` being T or F.
 
-### any ejamapp() parameters will override global_defaults_*.R settings
+### any `ejamapp()` parameters will override global_defaults_*.R settings
 
 Just before launching the app, `ejamapp()` calls `get_global_defaults_or_user_options()` which
 gets the global defaults and then overrides/replaces them with

--- a/vignettes/dev-app-settings.Rmd
+++ b/vignettes/dev-app-settings.Rmd
@@ -84,13 +84,22 @@ anyone can construct:
   and `shapefile=` are aliases (synonyms) for `polygon=`, matching the parameter aliases
   EJAM functions like `ejamit()` accept.
 - `?wherestr=Dover%2C%20DE` or `?wherestr=39.157,-75.52` -- the original EJScreen
-  parameter, unchanged: geocodes a place name / address / zipcode (or centers on a
-  `lat,lon`) and drops a pin, without selecting a boundary.
+  parameter: geocodes a place name / address / zipcode (or centers on a `lat,lon`) and
+  drops a pin, without selecting a boundary -- except a bare 5-digit value, see below.
 
 One kind of place is used per link, in the order above (`fips` beats `lat`/`lon`, which
 beat polygons, which beat `wherestr`). A single place opens the site report popup on it;
 several places are all drawn and added to EJScreen's Multisite list, ready for a Multisite
 Report or the "Send to EJAM" handoff back into EJAM.
+
+**ZIP code vs county FIPS:** a bare 5-digit number is ambiguous -- 10001 is both a
+Manhattan zip code and Kent County, DE's county FIPS. EJAM treats a 5-digit place code as
+a county FIPS, and EJScreen's deep links now follow the same convention:
+`?wherestr=10001` is tried as a county FIPS first (drawing and selecting that county),
+and only geocoded as a zip code if no county has that code. To be unambiguous, pass FIPS
+codes with `fips=` (what `url_ejscreenmap()` does), and force a zip by adding context,
+e.g. `?wherestr=10001,NY`. The interactive search box inside the EJScreen app is
+unchanged: typing a bare 5-digit number there still searches it as a zip code.
 
 URL-encoding: percent-encode free-text values (a space becomes `%20`, a comma can be
 `%2C`); the digits, commas, and semicolons in the numeric parameters can be left as is.

--- a/vignettes/dev-app-settings.Rmd
+++ b/vignettes/dev-app-settings.Rmd
@@ -63,6 +63,74 @@ query would open the app empty). For the API side -- including the friendlier
 `https://api.ejanalysis.com/` base and parameter details -- see the `dev-api` article, the
 help for `ejamapi()`/`url_ejamapi()`, and the EJAM-API repository's README.
 
+## Deep links into EJScreen (the mapping tool)
+
+The PEDP EJScreen map app (`https://pedp-ejscreen.azurewebsites.net/index.html`) accepts a
+symmetric set of launch-URL parameters, so a link can open EJScreen with place(s) already
+drawn and **selected for analysis** -- the reverse direction of the "Send to EJAM" handoff
+described above. `url_ejscreenmap()` builds these links for you, but they are plain URLs
+anyone can construct:
+
+- `?fips=10001` or `?fips=10001,10003,10001040100` -- one or more FIPS codes,
+  comma-separated: 5-digit county, 11-digit tract, or 12-digit block group (mixes allowed).
+  EJScreen queries its boundary services, draws each area, and selects it. State (2-digit)
+  and city/CDP (7-digit) codes have no boundary service in the app, so use `wherestr=` with
+  a place name for those -- `url_ejscreenmap()` does that fallback automatically via
+  `fips2name()`.
+- `?lat=39,39.7&lon=-75.5,-75.6&radius=3` -- one or more points (comma-separated, equal
+  lengths); the optional `radius=` (miles) prefills the site report's buffer distance.
+- `?polygon=39.1,-75.5;39.2,-75.4;39.0,-75.3` -- a polygon as semicolon-separated `lat,lon`
+  vertices (at least 3); repeat the parameter for more than one polygon. `shape=`, `shp=`,
+  and `shapefile=` are aliases (synonyms) for `polygon=`, matching the parameter aliases
+  EJAM functions like `ejamit()` accept.
+- `?wherestr=Dover%2C%20DE` or `?wherestr=39.157,-75.52` -- the original EJScreen
+  parameter, unchanged: geocodes a place name / address / zipcode (or centers on a
+  `lat,lon`) and drops a pin, without selecting a boundary.
+
+One kind of place is used per link, in the order above (`fips` beats `lat`/`lon`, which
+beat polygons, which beat `wherestr`). A single place opens the site report popup on it;
+several places are all drawn and added to EJScreen's Multisite list, ready for a Multisite
+Report or the "Send to EJAM" handoff back into EJAM.
+
+URL-encoding: percent-encode free-text values (a space becomes `%20`, a comma can be
+`%2C`); the digits, commas, and semicolons in the numeric parameters can be left as is.
+EJScreen decodes the values on arrival. `url_ejscreenmap()` takes care of the encoding,
+and for polygons it also simplifies each outline enough to fit URL length limits (falling
+back to a centroid `wherestr=` link if an outline cannot fit):
+
+```{r url_ejscreenmap_examples}
+# One county: boundary drawn & selected, site report popup open
+url_ejscreenmap(fips = "10001")
+#> "https://pedp-ejscreen.azurewebsites.net/index.html?fips=10001"
+
+# One URL per site (the default; used for per-site link columns in EJAM result tables)
+url_ejscreenmap(fips = c("10001", "10003"))
+
+# ONE link that loads ALL the sites into EJScreen's Multisite list
+url_ejscreenmap(fips = c("10001", "10003"), combined = TRUE)
+#> "https://pedp-ejscreen.azurewebsites.net/index.html?fips=10001,10003"
+
+# Points, with the site report buffer prefilled to 3 miles
+url_ejscreenmap(lat = c(39, 39.7), lon = c(-75.5, -75.6), radius = 3, combined = TRUE)
+#> "https://pedp-ejscreen.azurewebsites.net/index.html?lat=39,39.7&lon=-75.5,-75.6&radius=3"
+
+# A polygon (outline simplified as needed to fit in a URL)
+url_ejscreenmap(shapefile = testinput_shapes_2[1, ])
+#> "https://pedp-ejscreen.azurewebsites.net/index.html?polygon=39.0375,-75.5519;39.0392,..."
+
+# A place name via the legacy parameter (free text gets percent-encoded)
+url_ejscreenmap(wherestr = "Dover, DE")
+#> "https://pedp-ejscreen.azurewebsites.net/index.html?wherestr=Dover%2C%20DE"
+
+# browseURL(url_ejscreenmap(fips = "10001"))  # open one in the browser
+```
+
+The selection-drawing parameters need the EJScreen release that added deep links (see
+[Public-Environmental-Data-Partners/EJScreen#70](https://github.com/Public-Environmental-Data-Partners/EJScreen/pull/70));
+older EJScreen deployments ignore them and just open the map, while the `wherestr=` links
+work on all versions. The same parameter vocabulary is documented in the EJScreen
+repository's README.
+
 # NOTES ON GLOBAL DEFAULTS, SHINY INPUTS, BOOKMARKS, AND FUNCTION PARAMETERS
 
 This document provides technical notes on how defaults and custom settings are defined for the EJAM web app.

--- a/vignettes/dev-app-settings.Rmd
+++ b/vignettes/dev-app-settings.Rmd
@@ -68,22 +68,23 @@ the production server hosting the live EJAM shiny app
 at https://ejam.publicenvirodata.org,
 and it provides a way to pass through URL-encoded parameters.
 
-The URL http://ejamdev.ejanalysis.com is an alias for
-the development / staging server hosting a live EJAM shiny app 
-at http://ejam-dev-alb-971929002.us-east-1.elb.amazonaws.com 
-and it also provides a way to pass through URL-encoded parameters.
+The URL https://ejamdev.ejanalysis.com is an alias for
+the development / staging server hosting a live EJAM shiny app.
+(It redirects to an AWS load balancer whose literal hostname can change when the
+infrastructure is rebuilt -- one reason the stable alias is the address to share --
+and it also provides a way to pass through URL-encoded parameters.)
 
 Deep links based on lat and lon and radius
-for one or more points:
+for one or more points (staging examples; links for the production app are the
+same but with the production base, which is `url_ejamapp()`'s default):
 
-- http://ejam-dev-alb-971929002.us-east-1.elb.amazonaws.com/?lat=33&lon=-112&radius=2
-- http://ejamdev.ejanalysis.com/?lat=33&lon=-112&radius=2
-- http://ejamdev.ejanalysis.com/?lat=33,33.1&lon=-112,-112.2&radius=2
+- https://ejamdev.ejanalysis.com/?lat=33&lon=-112&radius=2
+- https://ejamdev.ejanalysis.com/?lat=33,33.1&lon=-112,-112.2&radius=2
 
 Deep links based on FIPS code of Census unit like county:
-  
-- http://ejamdev.ejanalysis.com/?fips=24029&buffer=0
-- http://ejamdev.ejanalysis.com/?fips=24029,24031
+
+- https://ejamdev.ejanalysis.com/?fips=24029&buffer=0
+- https://ejamdev.ejanalysis.com/?fips=24029,24031
 
 ```{r url_ejamapp, eval=FALSE}
 ## EJAM app deep link (default base URL)
@@ -105,11 +106,12 @@ help for `ejamapi()`/`url_ejamapi()`, and the EJAM-API repository's README.
 
 ## Deep links into EJScreen (the mapping tool)
 
-The PEDP EJScreen map app (`https://pedp-ejscreen.azurewebsites.net/index.html`) accepts a
-symmetric set of launch-URL parameters, so a link can open EJScreen with place(s) already
-drawn and **selected for analysis** -- the reverse direction of the "Send to EJAM" handoff
-described above. `url_ejscreenmap()` builds these links for you, but they are plain URLs
-anyone can construct:
+The PEDP EJScreen map app accepts a symmetric set of launch-URL parameters, so a link can
+open EJScreen with place(s) already drawn and **selected for analysis** -- the reverse
+direction of the "Send to EJAM" handoff described above. Build these links with
+`url_ejscreenmap()`, whose default `baseurl=` points at the current live EJScreen
+deployment (override `baseurl=` for a different one); they are plain URLs anyone can
+construct:
 
 - `?fips=10001` or `?fips=10001,10003,10001040100` -- one or more FIPS codes,
   comma-separated: 5-digit county, 11-digit tract, or 12-digit block group (mixes allowed).

--- a/vignettes/zipcodes.Rmd
+++ b/vignettes/zipcodes.Rmd
@@ -53,7 +53,9 @@ The original (pre-2025) EJSCREEN API did not handle zip codes. It can show where
 
 ```{r, eval=FALSE, include=TRUE}
 # Just see where the zipcode is, not its boundaries
-browseURL(url_ejscreenmap(wherestr =  '10001'))
+# (use zip= , not wherestr= : a bare 5-digit wherestr is now read as a county FIPS first,
+#  so wherestr = '10001' would open Kent County, DE instead of this Manhattan zip code)
+browseURL(url_ejscreenmap(zip = '10001'))
 ```
 
 **To map and analyze zip codes you can download shapefiles for them and analyze or map them in EJAM as shown below.**

--- a/vignettes/zipcodes.Rmd
+++ b/vignettes/zipcodes.Rmd
@@ -100,7 +100,34 @@ mapview::mapview(shp1)
 
 ## see EJSCREEN map at a zip code
 
-browseURL(url_ejscreenmap(wherestr =  '20019'))
+The EJScreen map app can be opened at zip code(s) via a deep link, using its `?zip=`
+launch-URL parameter -- the explicit way to pass a zip code. That matters because a bare
+5-digit number is ambiguous: 10001 is both a Manhattan zip code and Kent County, DE's
+county FIPS, and EJScreen deep links read a bare 5-digit `wherestr=` as a county FIPS
+first (EJAM's convention). `url_ejscreenmap(zip = )` builds the unambiguous zip links:
+
+```{r url_ejscreenmap_zip, eval=FALSE, include=TRUE}
+# one zip code: EJScreen opens centered there, with a pin and the site report popup
+browseURL(url_ejscreenmap(zip = "20019"))
+#> opens https://pedp-ejscreen.azurewebsites.net/index.html?zip=20019
+
+# note the zip parameter, unlike wherestr, is never confused with a county FIPS:
+url_ejscreenmap(zip = "10001")  # zip 10001, in Manhattan, NY
+url_ejscreenmap(fips = "10001") # county FIPS 10001 = Kent County, DE (boundary drawn)
+
+# several zips in one link (the map zooms to fit all of them),
+# and radius= prefills the report buffer distance in miles:
+url_ejscreenmap(zip = c("20019", "20020"), combined = TRUE, radius = 1)
+#> "https://pedp-ejscreen.azurewebsites.net/index.html?zip=20019,20020&radius=1"
+
+# a zip passed as a number gets its leading zeroes restored:
+url_ejscreenmap(zip = 1001) # zip 01001, Agawam, MA
+```
+
+These links need the EJScreen release that added deep links (see
+[Public-Environmental-Data-Partners/EJScreen#70](https://github.com/Public-Environmental-Data-Partners/EJScreen/pull/70));
+the map pins the zip's location -- for analyzing the zip code's actual boundaries, use
+the zcta polygons approach above.
 
 ## analyzing zip codes in EJAM
 

--- a/vignettes/zipcodes.Rmd
+++ b/vignettes/zipcodes.Rmd
@@ -104,7 +104,8 @@ The EJScreen map app can be opened at zip code(s) via a deep link, using its `?z
 launch-URL parameter -- the explicit way to pass a zip code. That matters because a bare
 5-digit number is ambiguous: 10001 is both a Manhattan zip code and Kent County, DE's
 county FIPS, and EJScreen deep links read a bare 5-digit `wherestr=` as a county FIPS
-first (EJAM's convention). `url_ejscreenmap(zip = )` builds the unambiguous zip links:
+first (EJAM's convention). The `zip` argument of `url_ejscreenmap()` builds the
+unambiguous zip links:
 
 ```{r url_ejscreenmap_zip, eval=FALSE, include=TRUE}
 # one zip code: EJScreen opens centered there, with a pin and the site report popup


### PR DESCRIPTION
v3.2022.1 amendment 4 — the production cut. Brings development's latest into main:

- **`url_ejscreenmap()` rewrite** (Public-Environmental-Data-Partners/EJAM#460): generates deep links INTO EJScreen that draw + select the analyzed place(s) (`?fips=`/`?lat=&lon=`/`?polygon=`), matching the inbound vocabulary EJScreen gained in Public-Environmental-Data-Partners/EJScreen#70 (merged by ericnost and verified live on the Azure site). Stored testoutputs deliberately NOT regenerated for URL-column changes (maintainer decision).
- **Documentation edits** for ejamapp() + vignettes (Public-Environmental-Data-Partners/EJAM#459, already on development).
- NEWS.md updated.

Full test_ejam suite run on the exact post-merge tree (result posted before merge). After merge: v3.2022.1 tag re-move (same-tag amendment, no new release), main→dev-deploy deploy + verify, then dev-deploy→prod-deploy (Public-Environmental-Data-Partners/EJAM#453) for the production app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)