### PR TITLE
Fix EJAM app crash on EJScreen token handoff (FIPS/polygon/bufferless selections)

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -548,6 +548,16 @@ app_server <- function(input, output, session) {
         error = function(e) NULL
       )
       if (!is.null(payload) && is.null(payload$error)) {
+        # The API serializes absent payload fields (an R NULL for sites/fips/shape/
+        # radius) as JSON {}, which jsonlite::fromJSON() parses back as a zero-length
+        # list, NOT NULL. Treat any zero-length field as absent so the checks below
+        # see a clean NULL. Without this, a radius-less handoff (every FIPS/polygon
+        # basket, and any point basket with no buffer) returns radius:{} -> an empty
+        # list that reaches as.numeric() in the radius block and evaluates the if()
+        # on a zero-length value, an unhandled error in this init observer that
+        # crashes the whole session. length() of a real sites data.frame is its
+        # column count (>0), so genuine payloads are preserved.
+        payload <- lapply(payload, function(x) if (length(x) == 0) NULL else x)
         if (!is.null(payload$sites) && is.data.frame(payload$sites)) {
           spec$lat <- payload$sites$lat
           spec$lon <- payload$sites$lon
@@ -616,14 +626,15 @@ app_server <- function(input, output, session) {
     ## clobbered when the slider re-renders (e.g. after set_site_method() above changes
     ## the upload method). Reading url_radius() inside the renderUI makes setting it here
     ## re-render the slider with the launch value, which is reliable in both orderings.
-    if (!is.null(spec$radius)) {
-      radval <- suppressWarnings(as.numeric(spec$radius))
-      # 0 is a valid buffer for polygon/FIPS methods (minradius_shapefile is 0,
-      # meaning analyze inside the boundary with no buffer); the slider renderUI
-      # clamps the value into the current method's [min, max], so e.g. 0 becomes
-      # the point-method minimum when points were supplied. Negatives are ignored.
-      if (!is.na(radval) && radval >= 0) url_radius(radval)
-    }
+    # 0 is a valid buffer for polygon/FIPS methods (minradius_shapefile is 0,
+    # meaning analyze inside the boundary with no buffer); the slider renderUI
+    # clamps the value into the current method's [min, max], so e.g. 0 becomes
+    # the point-method minimum when points were supplied. Negatives are ignored.
+    # length(radval) == 1 guard: any absent/empty/multi-value radius (as.numeric()
+    # of NULL or an empty list is numeric(0)) is skipped rather than evaluated by
+    # the if(), which would error on a zero-length condition and crash session init.
+    radval <- suppressWarnings(as.numeric(spec$radius))
+    if (length(radval) == 1 && !is.na(radval) && radval >= 0) url_radius(radval)
   }, priority = 1000)
 
   data_up_shp <- reactive({

--- a/tests/testthat/test-webapp-ui_and_server.R
+++ b/tests/testthat/test-webapp-ui_and_server.R
@@ -336,6 +336,205 @@ test_that("app_server override latch: an advanced-tab Site Selection Method pick
 })
 ################################################# #
 
+## Launch-URL / EJScreen "Send to EJAM" handoff regressions (PR #466, issue #465).
+##
+## The EJAM API serializes absent handoff-payload fields (sites/fips/shape/radius are
+## R NULLs) as JSON {}, which jsonlite::fromJSON() parses back as a ZERO-LENGTH LIST,
+## not NULL. Before the #466 fix, a radius-less handoff (every FIPS/polygon basket,
+## and any point basket with no buffer) carried radius:{} into the launch observer's
+## radius block, where as.numeric() of the empty list yielded numeric(0) and the if()
+## evaluated a zero-length condition -- an unhandled error in the priority-1000 init
+## observer that killed the whole Shiny session ("This app has stopped because of an
+## error or a timeout"). These tests run the REAL launch observer via testServer()
+## against the exact JSON text the API returns (served through a mocked httr2 fetch),
+## so reintroducing the bug crashes the observer and fails the test. Verified: the
+## three radius-less cases below fail on the pre-fix app_server with the production
+## error signature; the with-radius / error-payload / direct-deep-link cases pass on
+## both, locking in unchanged behavior for the already-working paths.
+##
+## Mock plumbing (all mocks must be in place BEFORE testServer() -- the launch
+## observer reads session$clientData once at init and MockShinySession's clientData
+## is static and non-reactive, always "?mocksearch=1"):
+##  - shiny::parseQueryString  maps the mock search string to the launch query we want
+##    (any other string passes through to the real parser);
+##  - EJAM:::global_or_param   returns a fake ejamapi_baseurl so the ?handoff= fetch
+##    has a resolvable API base, plus the usual hide-tab flags workaround the other
+##    testServer tests above use;
+##  - httr2::req_perform / resp_body_string  serve the canned handoff JSON for that
+##    fake base's /handoff/ URL only (anything else passes through to real httr2).
+
+testserver_with_launch_query <- function(query, handoff_json = NULL, expr) {
+  orig_global_or_param <- EJAM:::global_or_param
+  orig_parseQueryString <- shiny::parseQueryString
+  orig_req_perform <- httr2::req_perform
+  orig_resp_body_string <- httr2::resp_body_string
+  testthat::with_mocked_bindings(
+    global_or_param = function(vname) {
+      if (vname %in% c("default_hide_about_tab", "default_hide_written_report",
+                       "default_hide_plot_barplot_tab", "default_hide_plot_histo_tab")) {
+        return(FALSE)
+      }
+      if (identical(vname, "ejamapi_baseurl")) return("http://ejam-api.invalid")
+      orig_global_or_param(vname)
+    },
+    .package = "EJAM",
+    testthat::with_mocked_bindings(
+      parseQueryString = function(str, nested = FALSE) {
+        if (identical(str, "?mocksearch=1")) return(query)
+        orig_parseQueryString(str, nested = nested)
+      },
+      .package = "shiny",
+      testthat::with_mocked_bindings(
+        req_perform = function(req, ...) {
+          if (grepl("^http://ejam-api\\.invalid/handoff/", req$url)) {
+            return(structure(list(url = req$url), class = "ejam_test_handoff_response"))
+          }
+          orig_req_perform(req, ...)
+        },
+        resp_body_string = function(resp, ...) {
+          if (inherits(resp, "ejam_test_handoff_response")) return(handoff_json)
+          orig_resp_body_string(resp, ...)
+        },
+        .package = "httr2",
+        expr
+      )
+    )
+  )
+}
+################################################# #
+
+test_that("handoff: FIPS basket (radius {}) loads FIPS and does not crash the session", {
+  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
+  ## THE #465 crash case: a County/Tract selection sent via EJScreen "Send to EJAM".
+  ## Payload is verbatim what the API returns for a FIPS basket (radius/sites/shape = {}).
+  testserver_with_launch_query(
+    query = list(handoff = "TESTTOKEN"),
+    handoff_json = '{"method":["FIPS"],"sites":{},"fips":["10001","10003"],"shape":{},"radius":{}}',
+    expr = testServer(app = app_server, expr = {
+      session$setInputs(testing = FALSE)
+      expect_identical(url_fips(), c("10001", "10003"))
+      expect_null(url_radius())      # radius:{} means absent, not 0 and not an error
+      expect_null(url_sitepoints())  # one place-type per launch
+      expect_null(url_shapefile())
+      expect_identical(site_method_last_set(), "upload")  # method was switched for the handoff
+    })
+  )
+})
+################################################# #
+
+test_that("handoff: point basket with no buffer (radius {}) loads points and does not crash", {
+  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
+  ## Same #465 crash for lat/lon selections made without a buffer: EJScreen's
+  ## multisite.js only includes radius when a buffer is set, so the API returns radius:{}.
+  testserver_with_launch_query(
+    query = list(handoff = "TESTTOKEN"),
+    handoff_json = '{"method":["latlon"],"sites":[{"lat":38.9072,"lon":-77.0369},{"lat":39.29,"lon":-76.61}],"fips":{},"shape":{},"radius":{}}',
+    expr = testServer(app = app_server, expr = {
+      session$setInputs(testing = FALSE)
+      expect_identical(url_sitepoints(), data.frame(lat = c(38.9072, 39.29), lon = c(-77.0369, -76.61)))
+      expect_null(url_radius())
+      expect_null(url_fips())
+      expect_identical(site_method_last_set(), "upload")
+    })
+  )
+})
+################################################# #
+
+test_that("handoff: polygon basket (GeoJSON, radius {}) loads the shape and does not crash", {
+  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
+  skip_if_not_installed("sf")
+  ## Third #465 crash case: a drawn-polygon selection. shape arrives as GeoJSON text
+  ## (a JSON string field), radius is absent ({}).
+  geojson_txt <- '{"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-77.05,38.90],[-77.00,38.90],[-77.00,38.95],[-77.05,38.95],[-77.05,38.90]]]}}]}'
+  testserver_with_launch_query(
+    query = list(handoff = "TESTTOKEN"),
+    handoff_json = sprintf('{"method":["shape"],"sites":{},"fips":{},"shape":%s,"radius":{}}',
+                           jsonlite::toJSON(geojson_txt, auto_unbox = TRUE)),
+    expr = testServer(app = app_server, expr = {
+      session$setInputs(testing = FALSE)
+      expect_s3_class(url_shapefile(), "sf")  # stored parsed, so data_up_shp() reuses it
+      expect_null(url_radius())
+      expect_null(url_fips())
+      expect_identical(site_method_last_set(), "upload")
+    })
+  )
+})
+################################################# #
+
+test_that("handoff: point basket WITH a buffer still applies the radius (working path preserved)", {
+  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
+  testserver_with_launch_query(
+    query = list(handoff = "TESTTOKEN"),
+    handoff_json = '{"method":["latlon"],"sites":[{"lat":38.9072,"lon":-77.0369}],"fips":{},"shape":{},"radius":[3]}',
+    expr = testServer(app = app_server, expr = {
+      session$setInputs(testing = FALSE)
+      expect_identical(url_sitepoints(), data.frame(lat = 38.9072, lon = -77.0369))
+      expect_identical(url_radius(), 3)
+    })
+  )
+})
+################################################# #
+
+test_that("handoff: explicit radius 0 is accepted (valid no-buffer value for FIPS/polygon)", {
+  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
+  ## EJScreen#73 / EJAM-API#49 make FIPS/shape handoffs carry an explicit radius 0;
+  ## 0 must pass the >= 0 guard (minradius_shapefile is 0 = analyze inside the boundary).
+  testserver_with_launch_query(
+    query = list(handoff = "TESTTOKEN"),
+    handoff_json = '{"method":["FIPS"],"sites":{},"fips":["10001"],"shape":{},"radius":[0]}',
+    expr = testServer(app = app_server, expr = {
+      session$setInputs(testing = FALSE)
+      expect_identical(url_fips(), "10001")
+      expect_identical(url_radius(), 0)
+    })
+  )
+})
+################################################# #
+
+test_that("handoff: API error payload loads nothing and does not crash", {
+  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
+  testserver_with_launch_query(
+    query = list(handoff = "TESTTOKEN"),
+    handoff_json = '{"error":["handoff token not found or expired"]}',
+    expr = testServer(app = app_server, expr = {
+      session$setInputs(testing = FALSE)
+      expect_null(url_sitepoints())
+      expect_null(url_fips())
+      expect_null(url_shapefile())
+      expect_null(url_radius())
+      expect_null(site_method_last_set())  # method untouched when nothing loads
+    })
+  )
+})
+################################################# #
+
+test_that("direct deep-link ?fips=&radius= still loads both (radius-guard refactor unchanged)", {
+  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
+  testserver_with_launch_query(
+    query = list(fips = "10001,10003", radius = "5"),
+    expr = testServer(app = app_server, expr = {
+      session$setInputs(testing = FALSE)
+      expect_identical(url_fips(), c("10001", "10003"))
+      expect_identical(url_radius(), 5)
+    })
+  )
+})
+################################################# #
+
+test_that("direct deep-link ?fips= with no radius leaves url_radius NULL and does not crash", {
+  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
+  ## as.numeric(NULL) is numeric(0); the length()==1 guard must skip it silently.
+  testserver_with_launch_query(
+    query = list(fips = "10001"),
+    expr = testServer(app = app_server, expr = {
+      session$setInputs(testing = FALSE)
+      expect_identical(url_fips(), "10001")
+      expect_null(url_radius())
+    })
+  )
+})
+################################################# #
+
 test_that("shinytest category selection waits for input values and saves failure logs", {
   setup_file <- testthat::test_path("setup-shinytest2.R")
   setup_lines <- readLines(setup_file, warn = FALSE)

--- a/tests/testthat/test-webapp-ui_and_server.R
+++ b/tests/testthat/test-webapp-ui_and_server.R
@@ -363,6 +363,14 @@ test_that("app_server override latch: an advanced-tab Site Selection Method pick
 ##  - httr2::req_perform / resp_body_string  serve the canned handoff JSON for that
 ##    fake base's /handoff/ URL only (anything else passes through to real httr2).
 
+## Bind the unexported app_server from the namespace so the handoff regression tests
+## below run in BOTH contexts: devtools::test()/load_all() (where app_server is already
+## a visible symbol) AND installed-package testing via test_check()/R CMD check (where
+## it is not, and an exists()-based skip would silently drop this regression coverage --
+## flagged by Copilot/Codex review on PR #466). Under load_all(), EJAM:::app_server is
+## the same dev-source object, so binding unconditionally is safe in either context.
+app_server <- EJAM:::app_server
+
 testserver_with_launch_query <- function(query, handoff_json = NULL, expr) {
   orig_global_or_param <- EJAM:::global_or_param
   orig_parseQueryString <- shiny::parseQueryString
@@ -404,7 +412,6 @@ testserver_with_launch_query <- function(query, handoff_json = NULL, expr) {
 ################################################# #
 
 test_that("handoff: FIPS basket (radius {}) loads FIPS and does not crash the session", {
-  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
   ## THE #465 crash case: a County/Tract selection sent via EJScreen "Send to EJAM".
   ## Payload is verbatim what the API returns for a FIPS basket (radius/sites/shape = {}).
   testserver_with_launch_query(
@@ -423,7 +430,6 @@ test_that("handoff: FIPS basket (radius {}) loads FIPS and does not crash the se
 ################################################# #
 
 test_that("handoff: point basket with no buffer (radius {}) loads points and does not crash", {
-  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
   ## Same #465 crash for lat/lon selections made without a buffer: EJScreen's
   ## multisite.js only includes radius when a buffer is set, so the API returns radius:{}.
   testserver_with_launch_query(
@@ -441,7 +447,6 @@ test_that("handoff: point basket with no buffer (radius {}) loads points and doe
 ################################################# #
 
 test_that("handoff: polygon basket (GeoJSON, radius {}) loads the shape and does not crash", {
-  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
   skip_if_not_installed("sf")
   ## Third #465 crash case: a drawn-polygon selection. shape arrives as GeoJSON text
   ## (a JSON string field), radius is absent ({}).
@@ -462,7 +467,6 @@ test_that("handoff: polygon basket (GeoJSON, radius {}) loads the shape and does
 ################################################# #
 
 test_that("handoff: point basket WITH a buffer still applies the radius (working path preserved)", {
-  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
   testserver_with_launch_query(
     query = list(handoff = "TESTTOKEN"),
     handoff_json = '{"method":["latlon"],"sites":[{"lat":38.9072,"lon":-77.0369}],"fips":{},"shape":{},"radius":[3]}',
@@ -476,8 +480,8 @@ test_that("handoff: point basket WITH a buffer still applies the radius (working
 ################################################# #
 
 test_that("handoff: explicit radius 0 is accepted (valid no-buffer value for FIPS/polygon)", {
-  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
-  ## EJScreen#73 / EJAM-API#49 make FIPS/shape handoffs carry an explicit radius 0;
+  ## Public-Environmental-Data-Partners/EJScreen#73 and
+  ## Public-Environmental-Data-Partners/EJAM-API#49 make FIPS/shape handoffs carry an explicit radius 0;
   ## 0 must pass the >= 0 guard (minradius_shapefile is 0 = analyze inside the boundary).
   testserver_with_launch_query(
     query = list(handoff = "TESTTOKEN"),
@@ -492,7 +496,6 @@ test_that("handoff: explicit radius 0 is accepted (valid no-buffer value for FIP
 ################################################# #
 
 test_that("handoff: API error payload loads nothing and does not crash", {
-  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
   testserver_with_launch_query(
     query = list(handoff = "TESTTOKEN"),
     handoff_json = '{"error":["handoff token not found or expired"]}',
@@ -509,7 +512,6 @@ test_that("handoff: API error payload loads nothing and does not crash", {
 ################################################# #
 
 test_that("direct deep-link ?fips=&radius= still loads both (radius-guard refactor unchanged)", {
-  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
   testserver_with_launch_query(
     query = list(fips = "10001,10003", radius = "5"),
     expr = testServer(app = app_server, expr = {
@@ -522,7 +524,6 @@ test_that("direct deep-link ?fips=&radius= still loads both (radius-guard refact
 ################################################# #
 
 test_that("direct deep-link ?fips= with no radius leaves url_radius NULL and does not crash", {
-  skip_if_not(exists("app_server"), message = "unexported function app_server() not found, skipping test")
   ## as.numeric(NULL) is numeric(0); the length()==1 guard must skip it silently.
   testserver_with_launch_query(
     query = list(fips = "10001"),


### PR DESCRIPTION
## What & why

Fixes #465 — the EJAM app crashes (Shiny session dies → "This app has stopped because of an error or a timeout") when EJScreen's Report tool hands off a selection via **"Send to EJAM"** (the token-based `?handoff=<token>` path) for any **County/Tract (FIPS)** or **drawn-polygon** selection, or a lat/lon selection made without a buffer. The **"Multisite Report"** button is unaffected because it calls the EJAM API directly and never launches the app.

**Verified live** against production EJAM **v3.2022.1**: minting a FIPS handoff token against `https://api.ejanalysis.com/handoff` and opening `https://ejam.publicenvirodata.org/?handoff=<token>` reproduces the crash overlay before this change.

## Root cause

The EJAM API returns the handoff payload with absent fields serialized as JSON `{}` (plumber renders an R `NULL` as `{}`). A FIPS handoff comes back as:

```json
{"method":["FIPS"],"sites":{},"fips":["10001"],"shape":{},"radius":{}}
```

`jsonlite::fromJSON()` parses each `{}` as a **zero-length list**, not `NULL`, so the launch observer's radius block runs `as.numeric(list())` → `numeric(0)` and evaluates `if (!is.na(radval) && radval >= 0)` on a zero-length value → **"missing value where TRUE/FALSE needed"**. That's an unhandled error in a `priority=1000` init observer, which terminates the session.

lat/lon handoffs "worked" only because EJScreen's `multisite.js` includes `radius` in the payload just when a buffer is set; FIPS/polygon baskets never carry one. Direct `?fips=`/`?lat=` deep-links are unaffected — that branch already yields a clean `NULL` radius.

## The change (`R/app_server.R`, launch-URL handoff observer)

1. **Normalize the parsed payload** so zero-length (`{}`) fields become `NULL`, matching the direct-query-param branch's semantics. A genuine `sites` data.frame has `length()` = column count (> 0), so real payloads are preserved.
2. **Length-safe radius guard** (`length(radval) == 1 && …`) as defense-in-depth, so a non-scalar radius can never reach `if()`.

Chose the app side (not the API/EJScreen) because it is the component that crashes, it needs no API/EJScreen redeploy, and it hardens the app against any malformed handoff payload.

## Testing

- Simulated the observer against every handoff payload shape (FIPS single/multi, lat/lon with & without radius, polygon, and an error payload): all load correctly with no crash; the pre-fix code crashed on the radius-less cases.
- Live end-to-end reproduction of the crash on production before the fix.
- `R/app_server.R` parses clean.

No behavior change for working paths (lat/lon-with-buffer handoff still applies the buffer; direct deep-links unchanged).
