### PR TITLE
Fix reports for zero-population sites

### DIFF
--- a/R/ejam2report.R
+++ b/R/ejam2report.R
@@ -84,10 +84,7 @@ ejam2report_site_is_reportable <- function(site_result) {
   } else {
     ""
   }
-  isTRUE(grepl(
-    "^(no block centroids \\(|blocks found but zero residents$|blocks with residents found but unable to aggregate$)",
-    invalid_msg
-  ))
+  isTRUE(invalid_msg %in% unname(ejamit_reportable_invalid_messages()))
 }
 ################################################## #
 

--- a/R/ejam2report.R
+++ b/R/ejam2report.R
@@ -67,6 +67,30 @@ assert_pdf_report_available <- function() {
 }
 ################################################## #
 
+# helper
+
+ejam2report_site_is_reportable <- function(site_result) {
+  if (!("valid" %in% names(site_result)) || isTRUE(site_result$valid[1])) {
+    return(TRUE)
+  }
+
+  if (!("pop" %in% names(site_result)) ||
+      !isTRUE(!is.na(site_result$pop[1]) && site_result$pop[1] == 0)) {
+    return(FALSE)
+  }
+
+  invalid_msg <- if ("invalid_msg" %in% names(site_result)) {
+    as.character(site_result$invalid_msg[1])
+  } else {
+    ""
+  }
+  isTRUE(grepl(
+    "^(no block centroids \\(|blocks found but zero residents$|blocks with residents found but unable to aggregate$)",
+    invalid_msg
+  ))
+}
+################################################## #
+
 
 #' View HTML Report on EJAM Results (Overall or at 1 Site)
 #'
@@ -271,11 +295,12 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
     sitenumber <- 0  # in case sitenumber was invalid
   }
   # How many sites were actually analyzed, in the (valid) results provided?
-  nsites <- NROW(ejamitout$results_bysite[ejamitout$results_bysite$valid %in% TRUE, ]) # might differ from ejamout1$sitecount_unique
+  valid_site_rows <- which(ejamitout$results_bysite$valid %in% TRUE)
+  nsites <- length(valid_site_rows) # might differ from ejamout1$sitecount_unique
   # Treat it like a 1-site report if only 1 valid site was analyzed.
   #   And then if sitenumber omitted, or sitenumber=1, or sitenumber provided was invalid, just use that 1 site.
   if (sitenumber %in% 0 && nsites == 1) {
-    sitenumber <- 1
+    sitenumber <- valid_site_rows[1]
   }
 
   # Multi-site  (results_overall) ###################################################
@@ -348,7 +373,7 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
   include_ejindexes <- any(names_ej_pctile %in% colnames(ejamout1))
 
   if (!("valid" %in% names(ejamout1))) {ejamout1$valid <- TRUE}
-  if (isTRUE(ejamout1$valid)) {
+  if (ejam2report_site_is_reportable(ejamout1)) {
 
     #############################################################################  #
 

--- a/R/ejamit.R
+++ b/R/ejamit.R
@@ -16,6 +16,30 @@ ejamit_no_block_centroids_message <- function(sitetype) {
   "no block centroids (radius too small for low pop density)"
 }
 
+#' Normalize population for invalid sites in final `ejamit()` output
+#'
+#' `doaggregate()` omits sites it cannot aggregate. When [ejamit()] merges those
+#' original input rows back into `results_bysite`, their result columns are
+#' unavailable, but their contribution to analyzed population is zero. Preserve
+#' `NA` for the unavailable indicators while using zero for population.
+#' @param results_bysite final site-level results table from [ejamit()]
+#' @return `results_bysite` with `pop = 0` where `valid = FALSE`
+#' @noRd
+#'
+ejamit_invalid_site_pop_zero <- function(results_bysite) {
+  if (!is.data.frame(results_bysite) ||
+      !all(c("valid", "pop") %in% names(results_bysite))) {
+    return(results_bysite)
+  }
+
+  if (data.table::is.data.table(results_bysite)) {
+    results_bysite[valid %in% FALSE, pop := 0]
+  } else {
+    results_bysite$pop[results_bysite$valid %in% FALSE] <- 0
+  }
+  results_bysite
+}
+
 #' Get an EJ analysis (residential population and environmental indicators) in or near a list of locations
 #'
 #' @description This is the main function in EJAM that runs the analysis.
@@ -944,6 +968,13 @@ ejamit <- function(sitepoints = NULL,
   ## * table_tall_from_overall() ####
 
   out$formatted <- table_tall_from_overall(out$results_overall, fixcolnames(names(out$results_overall), 'r', 'long')) # out$longnames)
+
+  ## * invalid site population ####
+
+  # Keep the historical batch-summary treatment of unavailable rows above, then
+  # expose their population as zero in final site-level output. `valid` and the
+  # other NA result columns still distinguish sites that were not analyzed.
+  out$results_bysite <- ejamit_invalid_site_pop_zero(out$results_bysite)
 
   ###################################### #
   ## * sitetype ####

--- a/R/ejamit.R
+++ b/R/ejamit.R
@@ -1,4 +1,27 @@
 
+#' Messages for analysis-invalid sites that can still have reports
+#'
+#' These messages describe usable analysis requests that returned no population
+#' results. Keeping the emitter and reportability check on one canonical list
+#' prevents message wording changes from silently disabling reports.
+#' @return a named character vector of reportable analysis-invalid messages
+#' @noRd
+#'
+ejamit_reportable_invalid_messages <- function() {
+  c(
+    no_block_centroids_fips =
+      "no block centroids (fips boundaries not obtained)",
+    no_block_centroids_shp =
+      "no block centroids (polygon too small for low pop density)",
+    no_block_centroids_latlon =
+      "no block centroids (radius too small for low pop density)",
+    unable_to_aggregate =
+      "blocks with residents found but unable to aggregate",
+    zero_residents =
+      "blocks found but zero residents"
+  )
+}
+
 #' Message describing why no block centroids were found near a site
 #'
 #' Internal helper used by [ejamit()] to explain empty results by site type.
@@ -7,13 +30,14 @@
 #' @noRd
 #'
 ejamit_no_block_centroids_message <- function(sitetype) {
+  messages <- ejamit_reportable_invalid_messages()
   if (sitetype %in% "fips") {
-    return("no block centroids (fips boundaries not obtained)")
+    return(unname(messages[["no_block_centroids_fips"]]))
   }
   if (sitetype %in% "shp") {
-    return("no block centroids (polygon too small for low pop density)")
+    return(unname(messages[["no_block_centroids_shp"]]))
   }
-  "no block centroids (radius too small for low pop density)"
+  unname(messages[["no_block_centroids_latlon"]])
 }
 
 #' Normalize population for invalid sites in final `ejamit()` output
@@ -844,12 +868,13 @@ ejamit <- function(sitepoints = NULL,
 
   data_uploaded$valid[site_in_results_pop0 | !site_in_results] <- FALSE  # NOTE this also says invalid if zero population
 
+  reportable_invalid_messages <- ejamit_reportable_invalid_messages()
   data_uploaded$invalid_msg[!dropped_before_getblocks & !site_in_blocksfound] <-
     ejamit_no_block_centroids_message(sitetype)
   data_uploaded$invalid_msg[site_in_blocksfound & !site_in_results] <-
-    "blocks with residents found but unable to aggregate" # why?
+    unname(reportable_invalid_messages[["unable_to_aggregate"]]) # why?
   data_uploaded$invalid_msg[site_in_results_pop0]   <-
-    "blocks found but zero residents" # msg differed from server version?
+    unname(reportable_invalid_messages[["zero_residents"]]) # msg differed from server version?
 
   # Merge invalid and valid sites and msg, so results_bysite has ALL sites originally provided for analysis.
   setDT(data_uploaded)

--- a/tests/testthat/test-ejam2report.R
+++ b/tests/testthat/test-ejam2report.R
@@ -116,20 +116,27 @@ test_that("ejam2report() returns an absolute path when filename has no directory
   expect_true(startsWith(result_dotslash, "/") || grepl("^[A-Za-z]:", result_dotslash))
 })
 
-fips_report_test_output <- function(radius) {
+fips_report_test_output <- function(radius,
+                                    valid = c(TRUE, TRUE),
+                                    pop = c(10, 20),
+                                    invalid_msg = rep("", length(valid))) {
+  stopifnot(length(valid) == length(pop), length(valid) == length(invalid_msg))
+  fips <- c("10001", "10003")[seq_along(valid)]
   list(
     sitetype = "fips",
     results_bysite = data.table::data.table(
-      ejam_uniq_id = c("10001", "10003"),
-      valid = c(TRUE, TRUE),
-      pop = c(10, 20),
+      ejam_uniq_id = fips,
+      valid = valid,
+      invalid_msg = invalid_msg,
+      pop = pop,
       radius.miles = radius,
-      statename = c("Delaware", "Delaware")
+      statename = rep("Delaware", length(valid))
     ),
     results_overall = data.table::data.table(
       ejam_uniq_id = "overall",
       valid = TRUE,
-      pop = 30,
+      invalid_msg = "",
+      pop = sum(pop[valid %in% TRUE], na.rm = TRUE),
       radius.miles = radius,
       statename = "Delaware"
     )
@@ -139,6 +146,7 @@ fips_report_test_output <- function(radius) {
 local_ejam2report_fips_mocks <- function(buffer_state, .env = parent.frame()) {
   local_mocked_bindings(
     shapes_from_fips = function(fips) {
+      buffer_state$selected_fips <- c(buffer_state$selected_fips, fips)
       data.frame(fips = fips)
     },
     shape_buffered_from_shapefile = function(shapefile, radius.miles, ...) {
@@ -149,7 +157,15 @@ local_ejam2report_fips_mocks <- function(buffer_state, .env = parent.frame()) {
     report_residents_within_xyz_from_ejamit = function(...) "residents",
     report_setup_temp_files = function(...) "template.Rmd",
     create_filename = function(...) "report.html",
-    build_community_report = function(...) "<section>report</section>",
+    build_community_report = function(...) {
+      args <- list(...)
+      buffer_state$reported_fips <- c(
+        buffer_state$reported_fips,
+        as.character(args$output_df$ejam_uniq_id)
+      )
+      buffer_state$reported_pop <- c(buffer_state$reported_pop, args$output_df$pop)
+      "<section>report</section>"
+    },
     plot_barplot_ratios_ez = function(...) ggplot2::ggplot(),
     ejam2map = function(...) "map",
     ensure_pandoc_available_for_ejam = function(...) invisible(TRUE),
@@ -192,6 +208,80 @@ test_that("ejam2report buffers FIPS shapes for positive radius in production pat
     )
   )
   expect_equal(buffer_state$radii, c(1, 1))
+})
+
+test_that("ejam2report creates a report for an analysis-invalid zero-population site", {
+  buffer_state <- new.env(parent = emptyenv())
+  buffer_state$radii <- numeric()
+  buffer_state$selected_fips <- character()
+  buffer_state$reported_fips <- character()
+  buffer_state$reported_pop <- numeric()
+  local_ejam2report_fips_mocks(buffer_state)
+
+  out <- fips_report_test_output(
+    radius = 1,
+    valid = FALSE,
+    pop = 0,
+    invalid_msg = "blocks found but zero residents"
+  )
+
+  expect_no_error(
+    result <- ejam2report(
+      out,
+      sitenumber = 1,
+      report_title = "Report",
+      analysis_title = "Analysis",
+      return_html = TRUE,
+      launch_browser = FALSE
+    )
+  )
+  expect_match(result, "<html>report</html>", fixed = TRUE)
+  expect_equal(buffer_state$reported_pop, 0)
+})
+
+test_that("ejam2report selects the actual valid row when only one site is valid", {
+  buffer_state <- new.env(parent = emptyenv())
+  buffer_state$radii <- numeric()
+  buffer_state$selected_fips <- character()
+  buffer_state$reported_fips <- character()
+  buffer_state$reported_pop <- numeric()
+  local_ejam2report_fips_mocks(buffer_state)
+
+  out <- fips_report_test_output(
+    radius = 1,
+    valid = c(FALSE, TRUE),
+    pop = c(0, 20),
+    invalid_msg = c("blocks with residents found but unable to aggregate", "")
+  )
+
+  expect_no_error(
+    ejam2report(
+      out,
+      report_title = "Report",
+      analysis_title = "Analysis",
+      return_html = TRUE,
+      launch_browser = FALSE
+    )
+  )
+  expect_equal(buffer_state$selected_fips, "10003")
+  expect_equal(buffer_state$reported_fips, "10003")
+  expect_equal(buffer_state$reported_pop, 20)
+})
+
+test_that("ejam2report only treats known no-results messages as reportable", {
+  no_centroids <- data.frame(
+    valid = FALSE,
+    pop = 0,
+    invalid_msg = "no block centroids (radius too small for low pop density)"
+  )
+  invalid_input <- data.frame(
+    valid = FALSE,
+    pop = 0,
+    invalid_msg = "invalid FIPS"
+  )
+
+  expect_true(EJAM:::ejam2report_site_is_reportable(no_centroids))
+  expect_false(EJAM:::ejam2report_site_is_reportable(invalid_input))
 })
 
 test_that("ejam2report does not buffer FIPS shapes for legacy radius 999", {

--- a/tests/testthat/test-ejam2report.R
+++ b/tests/testthat/test-ejam2report.R
@@ -269,18 +269,21 @@ test_that("ejam2report selects the actual valid row when only one site is valid"
 })
 
 test_that("ejam2report only treats known no-results messages as reportable", {
-  no_centroids <- data.frame(
-    valid = FALSE,
-    pop = 0,
-    invalid_msg = "no block centroids (radius too small for low pop density)"
-  )
+  recognized_messages <- unname(EJAM:::ejamit_reportable_invalid_messages())
+  recognized_results <- lapply(recognized_messages, function(message) {
+    data.frame(valid = FALSE, pop = 0, invalid_msg = message)
+  })
   invalid_input <- data.frame(
     valid = FALSE,
     pop = 0,
     invalid_msg = "invalid FIPS"
   )
 
-  expect_true(EJAM:::ejam2report_site_is_reportable(no_centroids))
+  expect_true(all(vapply(
+    recognized_results,
+    EJAM:::ejam2report_site_is_reportable,
+    logical(1)
+  )))
   expect_false(EJAM:::ejam2report_site_is_reportable(invalid_input))
 })
 

--- a/tests/testthat/test-ejamit.R
+++ b/tests/testthat/test-ejamit.R
@@ -142,6 +142,16 @@ test_that("local Arrow release marker reader treats blank markers as missing", {
 ########################################################## #
 
 test_that("ejamit no-block-centroid invalid messages distinguish site types", {
+  expect_setequal(
+    unname(EJAM:::ejamit_reportable_invalid_messages()),
+    c(
+      "no block centroids (fips boundaries not obtained)",
+      "no block centroids (polygon too small for low pop density)",
+      "no block centroids (radius too small for low pop density)",
+      "blocks with residents found but unable to aggregate",
+      "blocks found but zero residents"
+    )
+  )
   expect_equal(
     EJAM:::ejamit_no_block_centroids_message("fips"),
     "no block centroids (fips boundaries not obtained)"

--- a/tests/testthat/test-ejamit.R
+++ b/tests/testthat/test-ejamit.R
@@ -157,6 +157,21 @@ test_that("ejamit no-block-centroid invalid messages distinguish site types", {
 })
 ########################################################## #
 
+test_that("ejamit final output uses zero population for invalid sites", {
+  bysite <- data.table::data.table(
+    valid = c(TRUE, FALSE, FALSE),
+    pop = c(NA_real_, NA_real_, 12),
+    pctlowinc = c(NA_real_, NA_real_, NA_real_)
+  )
+
+  result <- EJAM:::ejamit_invalid_site_pop_zero(bysite)
+
+  expect_equal(result$pop, c(NA_real_, 0, 0))
+  expect_true(all(is.na(result$pctlowinc)))
+  expect_equal(result$valid, c(TRUE, FALSE, FALSE))
+})
+########################################################## #
+
 test_that("ejamit() returns no result rather than crashing when Island Area sites have no block helpers", {
   guam_point <- data.table::data.table(lat = 13.45, lon = 144.75)
   out <- NULL


### PR DESCRIPTION
## Summary

- normalize final `ejamit()$results_bysite$pop` to `0` for `valid = FALSE` rows while preserving `valid = FALSE` and the other unavailable values as `NA`
- keep historical batch-summary handling unchanged by applying that normalization only to final site-level output
- make `ejam2report()` select the actual valid row when only one of several rows is valid
- allow normal reports for known analysis-no-results cases with population zero, while retaining the not-reportable path for malformed inputs
- centralize the reportable analysis-invalid messages so emitter wording and reportability checks cannot drift apart

## Root cause

`doaggregate()` intentionally omits sites it cannot aggregate. `ejamit()` merges the original input rows back afterward, which previously left population missing. Separately, `ejam2report()` assumed that a sole valid site was row 1 and rejected every explicitly selected `valid = FALSE` row with a bare `NA`.

The same report selection and validity-gate behavior is present in `v2.32.8.001`, so this is a long-standing latent bug rather than a newly introduced report regression. Dataset and API usage changes expose it more readily.

The fix does not recompute `results_overall$pop` from site rows; that aggregate remains the union-aware result from `doaggregate()`, avoiding double-counting across overlapping sites.

## Impact

Direct R calls can now create ordinary HTML/PDF reports for usable locations with zero population or no analysis results. Population displays as zero, unavailable indicators remain `NA`, and malformed locations are still rejected.

EJAM-API will be able to serve these reports after it updates to an EJAM release containing this fix and relaxes the pre-report zero-population guard in Public-Environmental-Data-Partners/EJAM-API#48. Its post-render `NULL`/`NA` guard should remain.

Related API review: https://github.com/Public-Environmental-Data-Partners/EJAM-API/pull/48#pullrequestreview-4710426796

## Validation

- `devtools::test(filter = "ejam2report")`: PASS 37, FAIL 0, WARN 0, SKIP 1 (Pandoc unavailable for one pre-existing path test)
- exact one-site and mixed-site examples: both generated normal 2.8 MB HTML reports; invalid site population was `0`; the mixed case selected row 2
- real zero-population PDF: six pages, 605,120 bytes
- review follow-up: all 63 `ejamit` tests passed; focused shared-message checks passed; the combined affected-file run's only failure was an environment-only headless-Chrome failure in a pre-existing PDF fallback test
- `git diff --check origin/development...HEAD`
- staged-content scan found no local user paths

Closes #467

— Codex
