### PR TITLE
acs_bybg(): gate requested year on Census-published ACS, not tidycensus default year

### DIFF
--- a/R/acs_bybg.R
+++ b/R/acs_bybg.R
@@ -184,23 +184,10 @@ acs_bybg <- function(
   if (missing(year) || is.null(year)) {
     year <- acs_endyear(guess_as_of = Sys.Date(), guess_always = TRUE, # to get the latest published by census bureau which may be newer than what is in latest release of EJSCREEN/EJAM
                        guess_census_has_published = TRUE)
-    yr_was_inferred = TRUE
-  } else {
-    yr_was_inferred = FALSE
   }
-  year <- as.numeric(year)
-  default_available = formals(tidycensus::get_acs)$year
-  if (year > default_available) {
-    yr_source = ifelse(yr_was_inferred, "assumed/guessed to be available", "requested")
-    msg = paste0("Data for the year ", year, " does not seem to be supported yet by tidycensus package, since the default year in tidycensus::get_acs() is only ", default_available, " which is not as recent as the ", year, " data that was ", yr_source, ".")
-    if (!yr_was_inferred) {
-      stop(msg)
-    } else {
-      warning(msg)
-      message("Using data for the year ", default_available, " instead of the guessed year of ", year, ".")
-      year <- default_available
-    }
-  }
+  # Block only years the Census Bureau has not published yet -- a year newer than
+  # tidycensus's own default year works fine when passed to get_acs() explicitly.
+  year <- acs_check_year_available(year)
 
   # NEED API KEY POSSIBLY, FOR LARGE QUERIES AT LEAST
 

--- a/R/utils_acs_endyear.R
+++ b/R/utils_acs_endyear.R
@@ -229,3 +229,26 @@ acs_endyear <- function(guess_as_of = Sys.Date(), guess_always = FALSE, guess_ce
     }
   }
 }
+##################### #
+# stop if a requested ACS 5-year end year has not yet been published by Census Bureau.
+# The cutoff must be what api.census.gov actually serves, NOT formals(tidycensus::get_acs)$year:
+# tidycensus's default year can lag a year or more behind the Census Bureau release
+# (e.g., its default was still 2023 after the 2020-2024 ACS was released 1/29/2026),
+# and tidycensus serves newer years fine when year= is passed explicitly.
+# Returns the year as numeric, invisibly.
+
+acs_check_year_available <- function(year, guess_as_of = Sys.Date()) {
+
+  year <- as.numeric(year)
+  latest_published <- suppressMessages({
+    as.numeric(acs_endyear(guess_as_of = guess_as_of, guess_always = TRUE,
+                           guess_census_has_published = TRUE))
+  })
+  if (year > latest_published) {
+    stop(paste0("ACS 5-year data ending in ", year, " ", acs_yr_range(year, parens = TRUE),
+                " does not seem to have been published yet by the Census Bureau -- the latest available appears to be ",
+                acs_yr_range(latest_published, parens = TRUE),
+                ". Omit the year parameter to use the latest available year."))
+  }
+  return(invisible(year))
+}

--- a/R/utils_acs_endyear.R
+++ b/R/utils_acs_endyear.R
@@ -239,16 +239,27 @@ acs_endyear <- function(guess_as_of = Sys.Date(), guess_always = FALSE, guess_ce
 
 acs_check_year_available <- function(year, guess_as_of = Sys.Date()) {
 
-  year <- as.numeric(year)
+  year_num <- suppressWarnings(as.numeric(year))
+  if (length(year_num) != 1 || is.na(year_num) || !is.finite(year_num)) {
+    stop("year must be a single numeric ACS 5-year end year (e.g., 2024).")
+  }
+
   latest_published <- suppressMessages({
-    as.numeric(acs_endyear(guess_as_of = guess_as_of, guess_always = TRUE,
-                           guess_census_has_published = TRUE))
+    suppressWarnings(as.numeric(acs_endyear(
+      guess_as_of = guess_as_of,
+      guess_always = TRUE,
+      guess_census_has_published = TRUE
+    )))
   })
-  if (year > latest_published) {
-    stop(paste0("ACS 5-year data ending in ", year, " ", acs_yr_range(year, parens = TRUE),
+  if (length(latest_published) != 1 || is.na(latest_published) || !is.finite(latest_published)) {
+    stop("Cannot determine the latest ACS 5-year end year published by the Census Bureau.")
+  }
+
+  if (year_num > latest_published) {
+    stop(paste0("ACS 5-year data ending in ", year_num, " ", acs_yr_range(year_num, parens = TRUE),
                 " does not seem to have been published yet by the Census Bureau -- the latest available appears to be ",
                 acs_yr_range(latest_published, parens = TRUE),
                 ". Omit the year parameter to use the latest available year."))
   }
-  return(invisible(year))
+  return(invisible(year_num))
 }

--- a/tests/testthat/test-acs_bybg.R
+++ b/tests/testthat/test-acs_bybg.R
@@ -41,3 +41,13 @@ test_that("acs_bybg() ok, 1 state", {
     fips_state_from_state_abbrev(TEST_ST)
   )
 })
+
+test_that("acs_bybg() blocks only years Census has not published, before any API call", {
+
+  # the year gate fires before tidycensus::get_acs() is reached,
+  # so this needs no census api key and no network access
+  expect_error(
+    acs_bybg(c(pop = "B01001_001"), state = "DC", year = 2099),
+    "published"
+  )
+})

--- a/tests/testthat/test-acs_endyear.R
+++ b/tests/testthat/test-acs_endyear.R
@@ -53,6 +53,38 @@ testthat::test_that("acs_endyear ok", {
 })
 ############################################################################################ #
 
+testthat::test_that("acs_check_year_available() gates on Census-published years, not tidycensus default year", {
+
+  # 2020-2024 ACS was released by Census Bureau 1/29/2026, so year 2024 must pass the gate
+  # as of mid-2026, even though tidycensus's own default year still lagged at 2023 then
+  testthat::expect_no_error({
+    y = acs_check_year_available(2024, guess_as_of = "2026-07-01")
+  })
+  testthat::expect_equal(y, 2024)
+
+  # but 2024 had not been published yet as of mid-2025
+  testthat::expect_error(
+    acs_check_year_available(2024, guess_as_of = "2025-07-01"),
+    "published"
+  )
+  testthat::expect_no_error(
+    acs_check_year_available(2023, guess_as_of = "2025-07-01")
+  )
+
+  # a far-future year always errors
+  testthat::expect_error(
+    acs_check_year_available(2099),
+    "published"
+  )
+
+  # year given as text works like numeric
+  testthat::expect_equal(
+    acs_check_year_available("2022", guess_as_of = "2026-07-01"),
+    2022
+  )
+})
+############################################################################################ #
+
 testthat::test_that("acs_clean_date good dates ok", {
 
   testthat::expect_no_error({


### PR DESCRIPTION
## Summary

`acs_bybg(year = 2024)` no longer errors, and the no-`year` path no longer silently downgrades 2024 to 2023: the year gate now blocks only ACS 5-year end years the **Census Bureau has not actually published**, instead of gating on tidycensus's own default year.

This is the last remaining EJAM-code item of Public-Environmental-Data-Partners/EJAM#391 (the main key-requirement fix landed in Public-Environmental-Data-Partners/EJAM#392, with follow-ups in #402/#406).

Closes Public-Environmental-Data-Partners/EJAM#391

## Problem

The gate used `formals(tidycensus::get_acs)$year` as an availability cutoff. That default can lag more than a year behind what `api.census.gov` serves — tidycensus 1.7–1.8 still defaulted to 2023 after the 2020–2024 ACS was released 1/29/2026 — and tidycensus serves newer years fine when `year=` is passed explicitly. Net effect before this PR:

- `acs_bybg(year = 2024, ...)` → hard `stop()`, even though the data exists and works
- `acs_bybg()` with no year → correctly guessed 2024 via `acs_endyear(guess_census_has_published = TRUE)`, then the gate warned and silently downgraded it back to 2023

## Change

- New internal helper `acs_check_year_available(year, guess_as_of = Sys.Date())` in `R/utils_acs_endyear.R`: stops (before any API call, with an actionable message) only when the requested end year exceeds the latest ACS the Census Bureau has published, per `acs_endyear(guess_always = TRUE, guess_census_has_published = TRUE)`.
- `acs_bybg()` uses it in place of the tidycensus-default gate. The old warn-and-downgrade branch for inferred years is gone because it is unreachable: the inferred year comes from the same latest-published guess the gate checks against.
- No exported API changes, no roxygen/man changes.

## Testing

- New deterministic unit tests for the helper in `tests/testthat/test-acs_endyear.R` (fixed `guess_as_of` dates: 2024 passes as of mid-2026, errors as of mid-2025; 2099 always errors; text year works) — file now passes 38/38.
- New no-network regression test in `tests/testthat/test-acs_bybg.R`: `acs_bybg(year = 2099)` errors at the gate before any API call — file passes 6/6 with 0 skips locally.
- Live verification with a real `CENSUS_API_KEY`: `acs_bybg(c(pop = "B01001_001"), state = "DC", year = 2024)` now returns actual 2020–2024 ACS blockgroup data (this exact call hard-errored before), and the no-`year` path logs "Getting data from the 2020-2024 5-year ACS" instead of downgrading to 2023.
- Existing test files only were edited (no new files), so `R/test_ejam.R` group lists need no update.

## Notes

- NEWS.md deliberately untouched — this repo writes NEWS in dedicated release-time passes, so this can ride the v3.2022.2 NEWS pass.
- Remaining issue-#391 checklist items live outside this repo's code: the keyless-metadata audit is tracked in ejanalysis/ACSdownload#27, and the deferred v3.2023.1/v3.2024.1 vintage patch releases are release-campaign work (the vintage branches already carry the key-fix backports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
