### PR TITLE
Fix API per-site report links mislabeling every report as Site 1

### DIFF
--- a/R/MAP_FUNCTIONS.R
+++ b/R/MAP_FUNCTIONS.R
@@ -17,12 +17,18 @@
 #' @param radius_buffer optional but can be obtained from out
 #' @param circle_color optional
 #' @param launch_browser set TRUE to have it launch browser to show map.
+#' @param sitenumber_label optional, display-only override (a number or short text) of the
+#'   site number shown in map popups, passed to [popup_from_ejscreen()].
+#'   Only relevant when mapping a single site -- see [ejam2report()], whose
+#'   sitenumber_label parameter this supports.
 #'
 #' @return map html widget
 #'
 #' @keywords internal
 #'
-map_ejam_plus_shp <- function(shp, out, radius_buffer = NULL, circle_color = '#000080', launch_browser = FALSE) {
+map_ejam_plus_shp <- function(shp, out, radius_buffer = NULL, circle_color = '#000080', launch_browser = FALSE,
+                              sitenumber_label = NULL # name-only, at end to avoid arg shift
+                              ) {
 
   ## to use it in shiny app:
   # shp <- data_uploaded()  # reactive in shiny app already has ejam_uniq_id but outside shiny shp might lack that
@@ -111,7 +117,8 @@ map_ejam_plus_shp <- function(shp, out, radius_buffer = NULL, circle_color = '#0
   } else {
     # linkcolnames = sapply(global_or_param("default_reports"), function(x) x$header)
     pops <- popup_from_ejscreen(
-      shpout %>% sf::st_drop_geometry()
+      shpout %>% sf::st_drop_geometry(),
+      sitenumber_label = sitenumber_label
     )
     if (is.null(radius_buffer)) {
       radius_buffer <- out$results_bysite$radius.miles[1]

--- a/R/community_report_helper_funs.R
+++ b/R/community_report_helper_funs.R
@@ -1243,13 +1243,22 @@ report_xmilesof <- function(radius = NA, unitsingular = 'mile') {
 #'   For example, if it is a 1-site report as via sitenumber=2,
 #'    and you set ejam_uniq_id = "Jones Mill Site" it will use that in the header
 #'   instead of using "ejam_uniq_id 2" (but ejam_uniq_id is ignored for a multisite summary report).
+#' @param sitenumber_label optional, display-only override (a number or short text) of the
+#'   site identifier shown in a 1-site report header, in place of the `sitenumber` row index.
+#'   Useful when one site from a larger analysis has been re-analyzed alone -- e.g., the
+#'   EJAM API per-site report links made by [url_ejamapi()] re-analyze a single site that
+#'   was row N of the original multisite results, so its row index here (1) is not the
+#'   site number the user expects to see. A number N is shown as "Site N"; text is shown
+#'   as-is. Ignored for a multisite/overall summary report.
 #'
 #' @return text string such as "Residents within 1 mile of any of the 99 specified points<br>Area in Square Miles: 311.02"
 #'
 #' @export
 #' @keywords internal
 #'
-report_residents_within_xyz_from_ejamit = function(ejamitout, sitenumber = NULL, site_method = NULL, ...) {
+report_residents_within_xyz_from_ejamit = function(ejamitout, sitenumber = NULL, site_method = NULL, ...,
+                                                   sitenumber_label = NULL # name-only (after ... so positional args are unchanged)
+                                                   ) {
 
   out <- ejamitout
   if (!missing(...)) {params = list(...)} else {params = NULL}
@@ -1258,6 +1267,7 @@ report_residents_within_xyz_from_ejamit = function(ejamitout, sitenumber = NULL,
   if (!is.null(sitenumber) && sitenumber %in% 0) {sitenumber <- NULL} # because ejam2report() allows 0 to mean summary report
   stopifnot(!is.na(sitenumber), (is.null(sitenumber) | is.atomic(sitenumber)), length(sitenumber) < 2)
   stopifnot(is.numeric(sitenumber) | is.null(sitenumber))
+  stopifnot(is.null(sitenumber_label) || (is.atomic(sitenumber_label) && length(sitenumber_label) == 1 && !is.na(sitenumber_label)))
   if (!is.null(sitenumber)) {
     if (sitenumber < 1 || sitenumber > NROW(out$results_bysite)) {
       message("sitenumber was < 1 or > number of rows in results_bysite, so ignoring sitenumber parameter")
@@ -1373,6 +1383,22 @@ report_residents_within_xyz_from_ejamit = function(ejamitout, sitenumber = NULL,
     census_unit_type <- ft
   } else {
     census_unit_type <- NULL
+  }
+
+  # sitenumber_label: display-only override of the site number/label shown in the header.
+  # A per-site report regenerated from a larger analysis (e.g., the EJAM API per-site links
+  # from url_ejamapi()) analyzes 1 site whose row index here is 1, but it was row N of the
+  # original analysis, so showing "Site 1" would mislabel it
+  # (Public-Environmental-Data-Partners/EJAM#348). All row lookups above still use the
+  # numeric sitenumber row index; only what is displayed changes here.
+  if (!is.null(sitenumber) && !is.null(sitenumber_label)) {
+    ejam_uniq_id_explicit <- !is.null(params) && ("ejam_uniq_id" %in% names(params))
+    if (!ejam_uniq_id_explicit && is.numeric(ejam_uniq_id) && !(sitetype %in% "fips")) {
+      # drop the auto-assigned row-number id of this results table -- it is just the row
+      # index of the (possibly regenerated, 1-site) run and would contradict the label
+      ejam_uniq_id <- NULL
+    }
+    sitenumber <- sitenumber_label
   }
 
   report_residents_within_xyz(

--- a/R/community_report_helper_funs.R
+++ b/R/community_report_helper_funs.R
@@ -1267,7 +1267,7 @@ report_residents_within_xyz_from_ejamit = function(ejamitout, sitenumber = NULL,
   if (!is.null(sitenumber) && sitenumber %in% 0) {sitenumber <- NULL} # because ejam2report() allows 0 to mean summary report
   stopifnot(!is.na(sitenumber), (is.null(sitenumber) | is.atomic(sitenumber)), length(sitenumber) < 2)
   stopifnot(is.numeric(sitenumber) | is.null(sitenumber))
-  stopifnot(is.null(sitenumber_label) || (is.atomic(sitenumber_label) && length(sitenumber_label) == 1 && !is.na(sitenumber_label)))
+  stopifnot(is.null(sitenumber_label) || ((is.numeric(sitenumber_label) || is.character(sitenumber_label)) && length(sitenumber_label) == 1 && !is.na(sitenumber_label)))
   if (!is.null(sitenumber)) {
     if (sitenumber < 1 || sitenumber > NROW(out$results_bysite)) {
       message("sitenumber was < 1 or > number of rows in results_bysite, so ignoring sitenumber parameter")
@@ -1393,9 +1393,12 @@ report_residents_within_xyz_from_ejamit = function(ejamitout, sitenumber = NULL,
   # numeric sitenumber row index; only what is displayed changes here.
   if (!is.null(sitenumber) && !is.null(sitenumber_label)) {
     ejam_uniq_id_explicit <- !is.null(params) && ("ejam_uniq_id" %in% names(params))
-    if (!ejam_uniq_id_explicit && is.numeric(ejam_uniq_id) && !(sitetype %in% "fips")) {
+    if (!ejam_uniq_id_explicit && is.numeric(ejam_uniq_id) && !(sitetype %in% "fips") &&
+        isTRUE(ejam_uniq_id == sitenumber)) {
       # drop the auto-assigned row-number id of this results table -- it is just the row
-      # index of the (possibly regenerated, 1-site) run and would contradict the label
+      # index of the (possibly regenerated, 1-site) run and would contradict the label.
+      # A numeric id that does NOT equal the row index is not the auto row-number,
+      # so it may be meaningful and is kept alongside the label.
       ejam_uniq_id <- NULL
     }
     sitenumber <- sitenumber_label

--- a/R/ejam2map.R
+++ b/R/ejam2map.R
@@ -18,6 +18,10 @@
 #' @param buffer alias (synonym) for radius
 #'
 #' @param sitenumber as used in [ejam2report()]
+#' @param sitenumber_label optional, display-only override (a number or short text) of the
+#'   site number shown in map popups, in place of the auto-assigned row number/ejam_uniq_id.
+#'   Only relevant when mapping a single site -- see [ejam2report()], whose
+#'   sitenumber_label parameter this supports.
 #'
 #' @return like what [mapfastej()] returns
 #' @examples
@@ -50,7 +54,9 @@ ejam2map <- function(ejamitout, column_names = "ej", launch_browser = TRUE, shp 
                      sitenumber = NULL,
                      shape = NULL,     # alias (synonym) for shp
                      shapefile = NULL, # alias (synonym) for shp
-                     buffer = NULL) {  # alias (synonym) for radius
+                     buffer = NULL,    # alias (synonym) for radius
+                     sitenumber_label = NULL # name-only, at end to avoid arg shift
+                     ) {
 
   # Aliases (synonyms) for naming consistency with ejamit()/ejamapp() etc.
   if (is.null(shp) && !is.null(shape))     {shp <- shape}
@@ -133,7 +139,8 @@ ejam2map <- function(ejamitout, column_names = "ej", launch_browser = TRUE, shp 
     map_ejam_plus_shp(shp = shp,
                       out = ejamitout,
                       radius_buffer = radius,
-                      launch_browser = launch_browser)
+                      launch_browser = launch_browser,
+                      sitenumber_label = sitenumber_label)
   } else {
     if (is.null(shp) && (sitetype %in% "shp")) {
       stop("cannot map results of shapefile analysis if no polygons provided in shp parameter")
@@ -142,7 +149,8 @@ ejam2map <- function(ejamitout, column_names = "ej", launch_browser = TRUE, shp 
     mapfast(mydf = ejamitout$results_bysite,
             radius = radius,
             column_names = column_names,
-            launch_browser = launch_browser
+            launch_browser = launch_browser,
+            sitenumber_label = sitenumber_label
     )
   }
 }

--- a/R/ejam2report.R
+++ b/R/ejam2report.R
@@ -81,7 +81,8 @@ assert_pdf_report_available <- function() {
 #'   one site was analyzed (or only one had valid results).
 #'
 #' @param sitenumber_label optional, display-only override (a number or short text) of the site
-#'   identifier shown in the 1-site report header, in place of the `sitenumber` row index.
+#'   identifier shown in the 1-site report header and in the report map's marker popup,
+#'   in place of the `sitenumber` row index.
 #'   `sitenumber` still selects which row of `ejamitout$results_bysite` to report on; this
 #'   only changes the label displayed. Useful when one site from a larger analysis has been
 #'   re-analyzed alone -- e.g., the EJAM API per-site report links made by [url_ejamapi()]
@@ -510,11 +511,13 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
       }
     } else {
       # just 1 site specified by sitenumber so map should show just that 1 site! shp and ejamout1 both 1 row already in this case
+      # sitenumber_label (display-only) also flows into the map marker popup, so a regenerated
+      # 1-site run's popup says "Site N" like the report header does, not the auto "Site 1"
       if (sitetype %in% c("fips", "shp") && !is.null(shp)) {
         # radius gets found, and used just in popups since shapefile given
-        map <- ejam2map(ejamitout = ejamout1, shp = shp, launch_browser = FALSE)
+        map <- ejam2map(ejamitout = ejamout1, shp = shp, launch_browser = FALSE, sitenumber_label = sitenumber_label)
       } else {
-        map <- mapfastej(ejamout1, radius = rad)
+        map <- mapfastej(ejamout1, radius = rad, sitenumber_label = sitenumber_label)
       }
     }
     ## FOOTER/DATE/VERSION ####

--- a/R/ejam2report.R
+++ b/R/ejam2report.R
@@ -80,6 +80,15 @@ assert_pdf_report_available <- function() {
 #'   But note that it is treated / titled like a 1-site report if only
 #'   one site was analyzed (or only one had valid results).
 #'
+#' @param sitenumber_label optional, display-only override (a number or short text) of the site
+#'   identifier shown in the 1-site report header, in place of the `sitenumber` row index.
+#'   `sitenumber` still selects which row of `ejamitout$results_bysite` to report on; this
+#'   only changes the label displayed. Useful when one site from a larger analysis has been
+#'   re-analyzed alone -- e.g., the EJAM API per-site report links made by [url_ejamapi()]
+#'   re-analyze a single site that was row N of the original multisite results, so its row
+#'   index in the regenerated results (1) is not the site number the user expects to see.
+#'   A number N is shown as "Site N"; text is shown as-is. Ignored for a multisite report.
+#'
 #' @param analysis_title optional title of analysis, default is global_or_param("default_standard_analysis_title")
 #'
 #' @param report_title optional generic name of this type of report, to be shown at top,
@@ -207,6 +216,7 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
                         filename = NULL,
                         return_html = FALSE,
                         launch_browser = TRUE,
+                        sitenumber_label = NULL, # (name-only, at end to avoid arg shift)
                         shape = NULL,     # alias (synonym) for shp (name-only, at end to avoid arg shift)
                         shapefile = NULL  # alias (synonym) for shp
 ) {
@@ -374,7 +384,8 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
     residents_within_xyz <- report_residents_within_xyz_from_ejamit(
       ejamitout = ejamitout,
       sitenumber = sitenumber,
-      site_method = site_method
+      site_method = site_method,
+      sitenumber_label = sitenumber_label
     )
     ####################################################### #
 

--- a/R/ejam2report.R
+++ b/R/ejam2report.R
@@ -238,9 +238,9 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
                         filename = NULL,
                         return_html = FALSE,
                         launch_browser = TRUE,
-                        sitenumber_label = NULL, # (name-only, at end to avoid arg shift)
                         shape = NULL,     # alias (synonym) for shp (name-only, at end to avoid arg shift)
-                        shapefile = NULL  # alias (synonym) for shp
+                        shapefile = NULL, # alias (synonym) for shp
+                        sitenumber_label = NULL # display-only (placed after shape/shapefile to avoid positional arg shift)
 ) {
   # Aliases (synonyms) for shp, for naming consistency with ejamit()/ejamapp() etc.
   if (is.null(shp) && !is.null(shape))     {shp <- shape}

--- a/R/mapfast.R
+++ b/R/mapfast.R
@@ -9,7 +9,9 @@
 #' @return like what [mapfast()] returns
 #' @export
 #'
-mapfastej <- function(mydf, radius = 3, column_names = 'ej', labels = column_names, launch_browser = FALSE, color = "#03F") {
+mapfastej <- function(mydf, radius = 3, column_names = 'ej', labels = column_names, launch_browser = FALSE, color = "#03F",
+                      sitenumber_label = NULL # name-only, at end to avoid arg shift
+                      ) {
 
   if (missing(radius)) {if ("radius.miles" %in% names(mydf)) {radius = mydf$radius.miles[1]} else {
     if ("results_bysite" %in% names(mydf) && ("radius.miles" %in% names(mydf$results_bysite))) {
@@ -18,7 +20,8 @@ mapfastej <- function(mydf, radius = 3, column_names = 'ej', labels = column_nam
   }
   }
 
-  mapfast(mydf = mydf, radius = radius, column_names = column_names, labels = labels, launch_browser = launch_browser, color = color)
+  mapfast(mydf = mydf, radius = radius, column_names = column_names, labels = labels, launch_browser = launch_browser, color = color,
+          sitenumber_label = sitenumber_label)
 }
 ############################################################################ #
 
@@ -50,6 +53,11 @@ mapfastej <- function(mydf, radius = 3, column_names = 'ej', labels = column_nam
 #'   and print the temp filepath and filename in the console.
 #'   Normally the map would be shown in the default RStudio viewer pane.
 #' @param color color of circles or polygons
+#' @param sitenumber_label optional, display-only override (a number or short text) of the
+#'   site number shown in map popups, in place of the auto-assigned row number/ejam_uniq_id.
+#'   Passed to [popup_from_ejscreen()] (so used only if column_names is "ej"), and only
+#'   relevant when mydf is a single-site (1-row) table -- see [ejam2report()], whose
+#'   sitenumber_label parameter this supports.
 #' @seealso [ejam2map()] [popup_from_any()] [mapfastej()]
 #' @return plots a map via the leaflet package, with popups with all the columns from mydf,
 #'   and returns html widget
@@ -57,7 +65,9 @@ mapfastej <- function(mydf, radius = 3, column_names = 'ej', labels = column_nam
 #'
 #' @export
 #'
-mapfast <- function(mydf, radius = 3, column_names='all', labels = column_names, launch_browser = FALSE, color = "#03F") {
+mapfast <- function(mydf, radius = 3, column_names='all', labels = column_names, launch_browser = FALSE, color = "#03F",
+                    sitenumber_label = NULL # name-only, at end to avoid arg shift
+                    ) {
 
   if (missing(radius)) {if ("radius.miles" %in% names(mydf)) {radius = mydf$radius.miles[1]} else {
     if ("results_bysite" %in% names(mydf) && ("radius.miles" %in% names(mydf$results_bysite))) {
@@ -107,7 +117,7 @@ mapfast <- function(mydf, radius = 3, column_names='all', labels = column_names,
       mydf <- cbind(mydf, ejna)
     }
 
-    mypop <- popup_from_ejscreen(sf::st_drop_geometry(mydf)) # linkcolnames = sapply(global_or_param("default_reports"), function(x) x$header)
+    mypop <- popup_from_ejscreen(sf::st_drop_geometry(mydf), sitenumber_label = sitenumber_label) # linkcolnames = sapply(global_or_param("default_reports"), function(x) x$header)
 
   } else if (column_names[1] == 'all') {
     mypop <- popup_from_df(sf::st_drop_geometry(mydf))

--- a/R/popup_from_ejscreen.R
+++ b/R/popup_from_ejscreen.R
@@ -38,6 +38,13 @@
 #'   The shiny app server provides `site_method` from the reactive called submitted_upload_method()
 #'   which is much like the one called current_upload_method().
 #'
+#' @param sitenumber_label optional, display-only override (a number or short text) of the
+#'   site number shown in the popup, in place of the auto-assigned row number/ejam_uniq_id.
+#'   Only used when `out` is a single-site (1-row) table, as when [ejam2report()] re-analyzes
+#'   one site that was row N of a larger analysis (e.g., the EJAM API per-site report links
+#'   made by [url_ejamapi()]) -- the regenerated run's row index (1) is not the site number
+#'   the user expects to see. A number N is shown as "Site N"; text is shown as-is.
+#'
 #' @return HTML ready to be used for map popups
 #'
 #' @keywords internal
@@ -46,7 +53,9 @@
 popup_from_ejscreen <- function(out,
                                 linkcolnames = sapply(global_or_param("default_reports"), function(x) x$header),
                                 verbose = FALSE,
-                                site_method = NULL) {
+                                site_method = NULL,
+                                sitenumber_label = NULL # name-only, at end to avoid arg shift
+                                ) {
   # ornull = function(n) {
   #   x <- try(global_or_param("default_reports")[[n]]$header)
   #   if (inherits(x, "try-error")) {return(NULL)} else {return(x)}
@@ -71,6 +80,16 @@ popup_from_ejscreen <- function(out,
   if (data.table::is.data.table(out)) {out <- data.table::copy(out); data.table::setDF(out)}
   if (NROW(out) == 0) {
     return(character(0))
+  }
+
+  # sitenumber_label: display-only override of the site number shown in popups, only
+  # meaningful for a single-site table (see ejam2report() and
+  # Public-Environmental-Data-Partners/EJAM#348) -- ignore it otherwise.
+  if (!is.null(sitenumber_label)) {
+    if (NROW(out) != 1 ||
+        !(is.atomic(sitenumber_label) && length(sitenumber_label) == 1 && !is.na(sitenumber_label))) {
+      sitenumber_label <- NULL
+    }
   }
 
   ############################################ #
@@ -422,7 +441,20 @@ popup_from_ejscreen <- function(out,
   ############################################################################# #
   ## > ID/GEO INFO ON EACH SITE  ####
 
-  if ('ejam_uniq_id' %in% names(out)) {pops_ejam_uniq_id <- paste0('Site ID (ejam_uniq_id): ', out$ejam_uniq_id, '<br>')} else {pops_ejam_uniq_id <- ''}
+  # Does sitenumber_label contradict (and so replace) the auto-assigned row-number id?
+  # For fips, ejam_uniq_id is the FIPS code (real info), so keep showing it alongside the label.
+  label_replaces_id <- !is.null(sitenumber_label) && !(sitetype %in% "fips") &&
+    ('ejam_uniq_id' %in% names(out)) && is.numeric(out$ejam_uniq_id)
+
+  if ('ejam_uniq_id' %in% names(out)) {
+    if (label_replaces_id) {
+      # display-only override (see sitenumber_label param): the auto row-number id of a
+      # regenerated 1-site run would contradict the label, so show the label instead
+      pops_ejam_uniq_id <- paste0('Site ID: ', sitenumber_label, '<br>')
+    } else {
+      pops_ejam_uniq_id <- paste0('Site ID (ejam_uniq_id): ', out$ejam_uniq_id, '<br>')
+    }
+  } else {pops_ejam_uniq_id <- ''}
   if ('id'           %in% names(out)) {pops_id           <- paste0('id: ',           out$id,           '<br>')} else {pops_id           <- ''}
   if ('regid'        %in% names(out)) {regid             <- paste0('regid: ',        out$regid,        '<br>')} else {regid             <- ''}
   if ('REGISTRY_ID'  %in% names(out)) {REGISTRY_ID       <- paste0('REGISTRY_ID: ',  out$REGISTRY_ID,  '<br>')} else {REGISTRY_ID       <- ''}
@@ -456,8 +488,11 @@ popup_from_ejscreen <- function(out,
         ## unitsingular = 'mile',
         area_in_square_miles = 0, # to suppress it here since added separately below. # out$area_sqmi[n],
         nsites = 1,
-        sitenumber = n,
-        ejam_uniq_id = out$ejam_uniq_id[n],
+        # display-only override (see sitenumber_label param): show the site number the user
+        # expects, and drop the auto row-number id when it would contradict that label,
+        # like report_residents_within_xyz_from_ejamit() does for the report header
+        sitenumber = if (is.null(sitenumber_label)) n else sitenumber_label,
+        ejam_uniq_id = if (label_replaces_id) NULL else out$ejam_uniq_id[n],
         sitetype = sitetype,
         site_method = site_method, # detailed sitetype like MACT/NAICS/etc. if relevant as from server
         census_unit_type = census_unit_type[n], # # ?? detailed sitetype if fips

--- a/R/popup_from_ejscreen.R
+++ b/R/popup_from_ejscreen.R
@@ -87,7 +87,8 @@ popup_from_ejscreen <- function(out,
   # Public-Environmental-Data-Partners/EJAM#348) -- ignore it otherwise.
   if (!is.null(sitenumber_label)) {
     if (NROW(out) != 1 ||
-        !(is.atomic(sitenumber_label) && length(sitenumber_label) == 1 && !is.na(sitenumber_label))) {
+        !((is.numeric(sitenumber_label) || is.character(sitenumber_label)) &&
+          length(sitenumber_label) == 1 && !is.na(sitenumber_label))) {
       sitenumber_label <- NULL
     }
   }
@@ -442,9 +443,13 @@ popup_from_ejscreen <- function(out,
   ## > ID/GEO INFO ON EACH SITE  ####
 
   # Does sitenumber_label contradict (and so replace) the auto-assigned row-number id?
+  # Only when ejam_uniq_id equals the row index (1, since the label is only kept for a
+  # 1-row table) is it the auto row-number of a regenerated run; a numeric id with any
+  # other value may be meaningful, so keep it alongside the label.
   # For fips, ejam_uniq_id is the FIPS code (real info), so keep showing it alongside the label.
   label_replaces_id <- !is.null(sitenumber_label) && !(sitetype %in% "fips") &&
-    ('ejam_uniq_id' %in% names(out)) && is.numeric(out$ejam_uniq_id)
+    ('ejam_uniq_id' %in% names(out)) && is.numeric(out$ejam_uniq_id) &&
+    isTRUE(out$ejam_uniq_id[1] == 1)
 
   if ('ejam_uniq_id' %in% names(out)) {
     if (label_replaces_id) {

--- a/R/url_ejamapi.R
+++ b/R/url_ejamapi.R
@@ -20,7 +20,12 @@
 #'   `sitenumber = 1` requests a single-site report (the API's per-request default when
 #'   none is supplied), and `sitenumber = 0` (or "overall") produces an aggregate
 #'   *multisite* report. (Note `url_ejamapi()`'s own default is `sitenumber = "each"` --
-#'   see the parameter docs below.) The API leaves the
+#'   see the parameter docs below.) When a URL sends only ONE site to the API but says
+#'   `sitenumber=N`, N identifies which row that site was in the original multisite
+#'   analysis, so the API can label the report header "Site N" instead of mislabeling
+#'   every per-site report as Site 1
+#'   (Public-Environmental-Data-Partners/EJAM#348) -- the per-site URLs this
+#'   function returns carry that. The API leaves the
 #'   report title to [ejam2report()], which uses "EJSCREEN Community Report" for a
 #'   single site and "EJSCREEN Multisite Summary" for the aggregate. Many or large
 #'   polygons can exceed URL length for this GET-based path; the API also provides
@@ -57,18 +62,23 @@
 #'  - `"each"` (or `-1`) -- **the default** -- returns a vector of URLs, one per site
 #'    (one single-site report per site). Unlike [ejam2report()]/[ejam2map()], which never
 #'    return a vector, the `url_*` helpers can; that vector-per-site output is the main
-#'    reason this parameter exists.
+#'    reason this parameter exists. Each URL sends only its own site to the API but also
+#'    carries `sitenumber=N` (that site's row number in the inputs) so the API labels the
+#'    report header "Site N" instead of calling every per-site report Site 1
+#'    (Public-Environmental-Data-Partners/EJAM#348).
 #'
 #'  - `"overall"` (or `0`, `NULL`, or `""`) -- returns a single URL requesting one
 #'    aggregate *multisite* report combining all sites (sent to the API as `sitenumber=0`;
 #'    assumes >1 site was provided).
 #'
 #'  - `N` (a number `> 0`) -- returns a single URL for just the Nth site found in the
-#'    inputs (e.g. the 3rd point, fips, or polygon).
+#'    inputs (e.g. the 3rd point, fips, or polygon). The URL carries `sitenumber=N` when
+#'    `N > 1` (as for "each" above; omitted when N is 1 since Site 1 is the API's default label).
 #'
 #'  Single-site auto-override: when the inputs resolve to exactly one site (one row of
 #'  sitepoints, one fips code, or one polygon), sitenumber is coerced to `1` regardless of what
-#'  was requested, so a lone place yields a single-site report URL.
+#'  was requested, so a lone place yields a single-site report URL (with no `sitenumber`
+#'  parameter in it).
 #'
 #' @param ... a named list of other query parameters passed to the API,
 #'   to allow for expansion of allowed parameters
@@ -286,9 +296,12 @@ url_ejamapi = function(
 
   # sitenumber (overall vs 1-site) ####
 
-  # N  means Nth site report
-  # -1 means "overall" report
-  # 0  means "each" site report, in a vector of URLs
+  # After normalization here:
+  #  0 means "overall" report (all sites in one URL, sent to the API as sitenumber=0)
+  # -1 means "each" site report, in a vector of URLs (each URL sends 1 site to the API,
+  #      plus sitenumber=N saying which row that site was in the inputs, so the report
+  #      header can be labeled Site N -- Public-Environmental-Data-Partners/EJAM#348)
+  #  N  means Nth site report (1 URL sending just site N, plus sitenumber=N when N > 1)
 
   if (length(sitenumber) > 1) {stop("invalid value for sitenumber")}
   if (is.null(sitenumber) || all(is.na(sitenumber)) || length(sitenumber) == 0 || all(sitenumber %in% "") || sitenumber %in% c(0, "0", "overall")) {
@@ -297,10 +310,8 @@ url_ejamapi = function(
 
   } else {
     if (sitenumber %in% c("each", -1)) {
-      # provide vector of urls, 1 site in each, and do not pass any sitenumber parameter to the API (since saying sitenumber=1 for each would be confusing)
       sitenumber <- -1  # each site (vector of URLs)
     } else {
-      # return only 1 URL, 1 of the sites, and do not pass any sitenumber parameter to the API (since we only send site N to the API so it would be confusing to pass site 3 and have to tell the API it is site 1 of what was passed)
       sitenumber <- as.numeric(sitenumber)  # Nth site
     }
   }
@@ -347,10 +358,11 @@ url_ejamapi = function(
         sitenumber <- "" # now omit this from the URL used in API
       }
       if (!is.null(sitenumber) && -1 %in% sitenumber) {
-        # "each" site's URL: provide vector of urls, 1 site in each,
-        # and either do not pass any sitenumber parameter to the API (since saying sitenumber=1 for each would be confusing)
-        # or use sitenumber 1:n for a vector of URLs? that would be useful in the table of API links for map popups, if it could tell the API what to say about the site# in the report header without trying to pick that row from a table of results...
-        # e.g., but problematic when API passes it to ejam2report() which tries to use sitenumber to pick 1 site from a table of multisite results
+        # "each" site's URL: these are app-fallback links (not API /report URLs) until
+        # per-polygon API report links are implemented, so no sitenumber is added here.
+        # Once implemented, they should carry sitenumber=1..N like the latlon and fips
+        # branches do, so the API labels each report with the site's original row number
+        # (see Public-Environmental-Data-Partners/EJAM#348).
         url_of_report <- rep(shp_one_site_fallback_url, NROW(shapefile))
         if (any(bad)) {
         url_of_report[bad] <- NA_character_
@@ -381,15 +393,19 @@ url_ejamapi = function(
           fips <- paste0(fips, collapse = ",") ## *** check this is the expected format in the API
         }
         if (sitenumber > 0) {
-          # 1 site's URL:  return only 1 URL, 1 of the sites, and do not pass any sitenumber parameter to the API (since we only send site N to the API so it would be confusing to pass site 3 and have to tell the API it is site 1 of what was passed)
+          # 1 site's URL: return only 1 URL, sending only site N to the API, plus (when N > 1)
+          # sitenumber=N so the API can label the report header "Site N" -- the row this site
+          # had in the original set of inputs -- instead of "Site 1"
+          # (Public-Environmental-Data-Partners/EJAM#348).
           fips <- fips[sitenumber]  # 1-site report
-          sitenumber <- "" # now omit this from the URL used in API
+          if (sitenumber == 1) {sitenumber <- ""} # omit from URL; Site 1 is the API's default label anyway
         }
         if (-1 %in% sitenumber) {
-          # "each" site's URL: provide vector of urls, 1 site in each,
-          # and maybe do not pass any sitenumber parameter to the API (since saying sitenumber=1 for each would be confusing)
-          # 1-site reports as a vector
-          sitenumber <- "" # now omit this from the URL used in API
+          # "each" site's URL: provide vector of urls, 1 site in each, each carrying
+          # sitenumber=1..N so the API labels each report with that site's original row
+          # number instead of calling every one "Site 1"
+          # (Public-Environmental-Data-Partners/EJAM#348)
+          sitenumber <- seq_along(fips)
         }
 
         url_of_report <- paste0(
@@ -429,17 +445,22 @@ url_ejamapi = function(
           lon <- paste0(lon, collapse = ",")
         }
         if (sitenumber > 0) {
-          # 1 site's URL:  return only 1 URL, 1 of the sites, and do not pass any sitenumber parameter to the API (since we only send site N to the API so it would be confusing to pass site 3 and have to tell the API it is site 1 of what was passed)
+          # 1 site's URL: return only 1 URL, sending only site N to the API, plus (when N > 1)
+          # sitenumber=N so the API can label the report header "Site N" -- the row this site
+          # had in the original set of inputs -- instead of "Site 1"
+          # (Public-Environmental-Data-Partners/EJAM#348).
           x <- sitepoints[sitenumber, , drop = FALSE]  # 1-site report
-          sitenumber <- "" # now omit this from the URL used in API
+          if (sitenumber == 1) {sitenumber <- ""} # omit from URL; Site 1 is the API's default label anyway
           lat <- x$lat
           lon <- x$lon
         }
-        if (sitenumber == -1) {
-          # "each" site's URL: provide vector of urls, 1 site in each, and do not pass any sitenumber parameter to the API (since saying sitenumber=1 for each would be confusing)
-          # 1-site reports as a vector
+        if (length(sitenumber) == 1 && sitenumber == -1) {
+          # "each" site's URL: provide vector of urls, 1 site in each, each carrying
+          # sitenumber=1..N so the API labels each report with that site's original row
+          # number instead of calling every one "Site 1"
+          # (Public-Environmental-Data-Partners/EJAM#348)
           x <- sitepoints
-          sitenumber <- "" # now omit this from the URL used in API
+          sitenumber <- seq_len(NROW(x))
           lat <- x$lat
           lon <- x$lon
         }
@@ -473,8 +494,8 @@ url_ejamapi = function(
   # fileextension (report format) ####
   # Appended here, after the branches above, because "auto" depends on the kind
   # of report each URL requests: at this point sitenumber is 0 only for an
-  # aggregate MULTISITE report over >1 site (single-site and "each" links have
-  # cleared it), so auto = html for the multisite summary (renders several
+  # aggregate MULTISITE report over >1 site (single-site links carry N or omit
+  # it, and "each" links carry 1..N), so auto = html for the multisite summary (renders several
   # times faster; the link opens in a browser tab) and pdf for single-site
   # reports (the traditional printable community report). Applied only to
   # actual API /report URLs -- never to the app-fallback links used for

--- a/inst/plumber/plumber.R
+++ b/inst/plumber/plumber.R
@@ -297,9 +297,15 @@ if (FALSE) {
 #* @param shape A GeoJSON string representing the area of interest
 #* @param fips A FIPS code for a specific US Census geography
 #* @param buffer The buffer radius in miles
+#* @param sitenumber Which site to report on: 0 (or "overall") for an aggregate multisite
+#*   report, or N to report on the Nth submitted site. When only one site is submitted
+#*   (as in the per-site report links that url_ejamapi() builds from multisite results),
+#*   N is used to label the report header "Site N" -- the row that site had in the
+#*   original analysis -- instead of mislabeling every per-site report as Site 1.
+#*   Default (omitted) is a single-site report labeled by row.
 #* @get /report
 #* @serializer html
-function(lat = "", lon = "", shape = "", fips = "", buffer = 3, res) {
+function(lat = "", lon = "", shape = "", fips = "", buffer = 3, sitenumber = "", res) {
   # Determine the input method and prepare the area.
   method <- if (!("" %in% lat) && !("" %in% lon)) "latlon" else if (!("" %in% shape)) "SHP" else if (!("" %in% fips)) "FIPS" else NULL
   area <- if (method == "latlon") data.frame(lat = as.numeric(lat), lon = as.numeric(lon)) else shape %||% fips
@@ -307,6 +313,18 @@ function(lat = "", lon = "", shape = "", fips = "", buffer = 3, res) {
   if (is.null(method) || is.null(area)) {
     res$status <- 400
     return(handle_error("You must provide valid coordinates, a shape, or a FIPS code.", "html"))
+  }
+
+  # Normalize sitenumber: "" (omitted) -> 1; 0 or "overall" -> 0 = aggregate multisite report.
+  sitenumber <- api2rnulltf(sitenumber)
+  if (length(sitenumber) > 1) {sitenumber <- sitenumber[1]} # e.g., a repeated query param
+  if (is.null(sitenumber)) {
+    sitenum <- 1
+  } else if (tolower(as.character(sitenumber)) %in% c("0", "overall")) {
+    sitenum <- 0
+  } else {
+    sitenum <- suppressWarnings(as.numeric(sitenumber))
+    if (length(sitenum) != 1 || is.na(sitenum) || sitenum < 1) {sitenum <- 1}
   }
 
   # Perform the EJAM analysis.
@@ -324,7 +342,16 @@ function(lat = "", lon = "", shape = "", fips = "", buffer = 3, res) {
   }
 
   # Generate and return the HTML report.
-  ejam2report(out, sitenumber = 1, return_html = TRUE, launch_browser = FALSE, site_method = method)
+  # When one site was submitted but it was row N (>1) of a larger original analysis --
+  # as in the per-site report links from url_ejamapi() -- report on that one row but
+  # label the header "Site N" instead of "Site 1"
+  # (Public-Environmental-Data-Partners/EJAM#348).
+  if (sitenum > 1 && NROW(out$results_bysite) == 1) {
+    ejam2report(out, sitenumber = 1, sitenumber_label = sitenum,
+                return_html = TRUE, launch_browser = FALSE, site_method = method)
+  } else {
+    ejam2report(out, sitenumber = sitenum, return_html = TRUE, launch_browser = FALSE, site_method = method)
+  }
 }
 ####################################################### #
 

--- a/man/ejam2map.Rd
+++ b/man/ejam2map.Rd
@@ -13,7 +13,8 @@ ejam2map(
   sitenumber = NULL,
   shape = NULL,
   shapefile = NULL,
-  buffer = NULL
+  buffer = NULL,
+  sitenumber_label = NULL
 )
 }
 \arguments{
@@ -34,6 +35,11 @@ ejam2map(
 \item{shapefile}{alias (synonym) for shp}
 
 \item{buffer}{alias (synonym) for radius}
+
+\item{sitenumber_label}{optional, display-only override (a number or short text) of the
+site number shown in map popups, in place of the auto-assigned row number/ejam_uniq_id.
+Only relevant when mapping a single site -- see \code{\link[=ejam2report]{ejam2report()}}, whose
+sitenumber_label parameter this supports.}
 }
 \value{
 like what \code{\link[=mapfastej]{mapfastej()}} returns

--- a/man/ejam2report.Rd
+++ b/man/ejam2report.Rd
@@ -38,6 +38,7 @@ ejam2report(
   filename = NULL,
   return_html = FALSE,
   launch_browser = TRUE,
+  sitenumber_label = NULL,
   shape = NULL,
   shapefile = NULL
 )
@@ -120,6 +121,15 @@ PDF output is required when this option is selected; it is not optional.}
 \item{return_html}{set TRUE to have function return HTML object instead of URL of local file}
 
 \item{launch_browser}{set TRUE to have it launch browser and show report.}
+
+\item{sitenumber_label}{optional, display-only override (a number or short text) of the site
+identifier shown in the 1-site report header, in place of the \code{sitenumber} row index.
+\code{sitenumber} still selects which row of \code{ejamitout$results_bysite} to report on; this
+only changes the label displayed. Useful when one site from a larger analysis has been
+re-analyzed alone -- e.g., the EJAM API per-site report links made by \code{\link[=url_ejamapi]{url_ejamapi()}}
+re-analyze a single site that was row N of the original multisite results, so its row
+index in the regenerated results (1) is not the site number the user expects to see.
+A number N is shown as "Site N"; text is shown as-is. Ignored for a multisite report.}
 
 \item{shape}{alias (synonym) for shp}
 

--- a/man/ejam2report.Rd
+++ b/man/ejam2report.Rd
@@ -123,7 +123,8 @@ PDF output is required when this option is selected; it is not optional.}
 \item{launch_browser}{set TRUE to have it launch browser and show report.}
 
 \item{sitenumber_label}{optional, display-only override (a number or short text) of the site
-identifier shown in the 1-site report header, in place of the \code{sitenumber} row index.
+identifier shown in the 1-site report header and in the report map's marker popup,
+in place of the \code{sitenumber} row index.
 \code{sitenumber} still selects which row of \code{ejamitout$results_bysite} to report on; this
 only changes the label displayed. Useful when one site from a larger analysis has been
 re-analyzed alone -- e.g., the EJAM API per-site report links made by \code{\link[=url_ejamapi]{url_ejamapi()}}

--- a/man/map_ejam_plus_shp.Rd
+++ b/man/map_ejam_plus_shp.Rd
@@ -9,7 +9,8 @@ map_ejam_plus_shp(
   out,
   radius_buffer = NULL,
   circle_color = "#000080",
-  launch_browser = FALSE
+  launch_browser = FALSE,
+  sitenumber_label = NULL
 )
 }
 \arguments{
@@ -22,6 +23,11 @@ map_ejam_plus_shp(
 \item{circle_color}{optional}
 
 \item{launch_browser}{set TRUE to have it launch browser to show map.}
+
+\item{sitenumber_label}{optional, display-only override (a number or short text) of the
+site number shown in map popups, passed to \code{\link[=popup_from_ejscreen]{popup_from_ejscreen()}}.
+Only relevant when mapping a single site -- see \code{\link[=ejam2report]{ejam2report()}}, whose
+sitenumber_label parameter this supports.}
 }
 \value{
 map html widget

--- a/man/mapfast.Rd
+++ b/man/mapfast.Rd
@@ -10,7 +10,8 @@ mapfast(
   column_names = "all",
   labels = column_names,
   launch_browser = FALSE,
-  color = "#03F"
+  color = "#03F",
+  sitenumber_label = NULL
 )
 }
 \arguments{
@@ -44,6 +45,12 @@ and print the temp filepath and filename in the console.
 Normally the map would be shown in the default RStudio viewer pane.}
 
 \item{color}{color of circles or polygons}
+
+\item{sitenumber_label}{optional, display-only override (a number or short text) of the
+site number shown in map popups, in place of the auto-assigned row number/ejam_uniq_id.
+Passed to \code{\link[=popup_from_ejscreen]{popup_from_ejscreen()}} (so used only if column_names is "ej"), and only
+relevant when mydf is a single-site (1-row) table -- see \code{\link[=ejam2report]{ejam2report()}}, whose
+sitenumber_label parameter this supports.}
 }
 \value{
 plots a map via the leaflet package, with popups with all the columns from mydf,

--- a/man/mapfastej.Rd
+++ b/man/mapfastej.Rd
@@ -10,7 +10,8 @@ mapfastej(
   column_names = "ej",
   labels = column_names,
   launch_browser = FALSE,
-  color = "#03F"
+  color = "#03F",
+  sitenumber_label = NULL
 )
 }
 \arguments{
@@ -44,6 +45,12 @@ and print the temp filepath and filename in the console.
 Normally the map would be shown in the default RStudio viewer pane.}
 
 \item{color}{color of circles or polygons}
+
+\item{sitenumber_label}{optional, display-only override (a number or short text) of the
+site number shown in map popups, in place of the auto-assigned row number/ejam_uniq_id.
+Passed to \code{\link[=popup_from_ejscreen]{popup_from_ejscreen()}} (so used only if column_names is "ej"), and only
+relevant when mydf is a single-site (1-row) table -- see \code{\link[=ejam2report]{ejam2report()}}, whose
+sitenumber_label parameter this supports.}
 }
 \value{
 like what \code{\link[=mapfast]{mapfast()}} returns

--- a/man/popup_from_ejscreen.Rd
+++ b/man/popup_from_ejscreen.Rd
@@ -8,7 +8,8 @@ popup_from_ejscreen(
   out,
   linkcolnames = sapply(global_or_param("default_reports"), function(x) x$header),
   verbose = FALSE,
-  site_method = NULL
+  site_method = NULL,
+  sitenumber_label = NULL
 )
 }
 \arguments{
@@ -35,6 +36,13 @@ beyond what \code{sitetype} provides (e.g., from \code{ejamit()$sitetype} or \co
 
 The shiny app server provides \code{site_method} from the reactive called submitted_upload_method()
 which is much like the one called current_upload_method().}
+
+\item{sitenumber_label}{optional, display-only override (a number or short text) of the
+site number shown in the popup, in place of the auto-assigned row number/ejam_uniq_id.
+Only used when \code{out} is a single-site (1-row) table, as when \code{\link[=ejam2report]{ejam2report()}} re-analyzes
+one site that was row N of a larger analysis (e.g., the EJAM API per-site report links
+made by \code{\link[=url_ejamapi]{url_ejamapi()}}) -- the regenerated run's row index (1) is not the site number
+the user expects to see. A number N is shown as "Site N"; text is shown as-is.}
 }
 \value{
 HTML ready to be used for map popups

--- a/man/report_residents_within_xyz_from_ejamit.Rd
+++ b/man/report_residents_within_xyz_from_ejamit.Rd
@@ -8,7 +8,8 @@ report_residents_within_xyz_from_ejamit(
   ejamitout,
   sitenumber = NULL,
   site_method = NULL,
-  ...
+  ...,
+  sitenumber_label = NULL
 )
 }
 \arguments{
@@ -23,6 +24,14 @@ parameters that can be specified -- they get passed from here to that function.
 For example, if it is a 1-site report as via sitenumber=2,
 and you set ejam_uniq_id = "Jones Mill Site" it will use that in the header
 instead of using "ejam_uniq_id 2" (but ejam_uniq_id is ignored for a multisite summary report).}
+
+\item{sitenumber_label}{optional, display-only override (a number or short text) of the
+site identifier shown in a 1-site report header, in place of the \code{sitenumber} row index.
+Useful when one site from a larger analysis has been re-analyzed alone -- e.g., the
+EJAM API per-site report links made by \code{\link[=url_ejamapi]{url_ejamapi()}} re-analyze a single site that
+was row N of the original multisite results, so its row index here (1) is not the
+site number the user expects to see. A number N is shown as "Site N"; text is shown
+as-is. Ignored for a multisite/overall summary report.}
 }
 \value{
 text string such as "Residents within 1 mile of any of the 99 specified points\if{html}{\out{<br>}}Area in Square Miles: 311.02"

--- a/man/url_ejamapi.Rd
+++ b/man/url_ejamapi.Rd
@@ -59,17 +59,22 @@ followed by "/report?". See \code{\link[=ejamapi]{ejamapi()}} for a better way t
 \item \code{"each"} (or \code{-1}) -- \strong{the default} -- returns a vector of URLs, one per site
 (one single-site report per site). Unlike \code{\link[=ejam2report]{ejam2report()}}/\code{\link[=ejam2map]{ejam2map()}}, which never
 return a vector, the \verb{url_*} helpers can; that vector-per-site output is the main
-reason this parameter exists.
+reason this parameter exists. Each URL sends only its own site to the API but also
+carries \code{sitenumber=N} (that site's row number in the inputs) so the API labels the
+report header "Site N" instead of calling every per-site report Site 1
+(Public-Environmental-Data-Partners/EJAM#348).
 \item \code{"overall"} (or \code{0}, \code{NULL}, or \code{""}) -- returns a single URL requesting one
 aggregate \emph{multisite} report combining all sites (sent to the API as \code{sitenumber=0};
 assumes >1 site was provided).
 \item \code{N} (a number \verb{> 0}) -- returns a single URL for just the Nth site found in the
-inputs (e.g. the 3rd point, fips, or polygon).
+inputs (e.g. the 3rd point, fips, or polygon). The URL carries \code{sitenumber=N} when
+\code{N > 1} (as for "each" above; omitted when N is 1 since Site 1 is the API's default label).
 }
 
 Single-site auto-override: when the inputs resolve to exactly one site (one row of
 sitepoints, one fips code, or one polygon), sitenumber is coerced to \code{1} regardless of what
-was requested, so a lone place yields a single-site report URL.}
+was requested, so a lone place yields a single-site report URL (with no \code{sitenumber}
+parameter in it).}
 
 \item{version}{optional EJAM version tag (e.g. "3.2024.0") sent to the API as
 version=\if{html}{\out{<ver>}} so the API can serve the matching data vintage. Default NULL
@@ -114,7 +119,12 @@ note below on unsupported options).
 \code{sitenumber = 1} requests a single-site report (the API's per-request default when
 none is supplied), and \code{sitenumber = 0} (or "overall") produces an aggregate
 \emph{multisite} report. (Note \code{url_ejamapi()}'s own default is \code{sitenumber = "each"} --
-see the parameter docs below.) The API leaves the
+see the parameter docs below.) When a URL sends only ONE site to the API but says
+\code{sitenumber=N}, N identifies which row that site was in the original multisite
+analysis, so the API can label the report header "Site N" instead of mislabeling
+every per-site report as Site 1
+(Public-Environmental-Data-Partners/EJAM#348) -- the per-site URLs this
+function returns carry that. The API leaves the
 report title to \code{\link[=ejam2report]{ejam2report()}}, which uses "EJSCREEN Community Report" for a
 single site and "EJSCREEN Multisite Summary" for the aggregate. Many or large
 polygons can exceed URL length for this GET-based path; the API also provides

--- a/tests/testthat/test-ejam2map.R
+++ b/tests/testthat/test-ejam2map.R
@@ -74,6 +74,17 @@ test_that("map popups honor sitenumber_label for a regenerated 1-site run (issue
   # label is display-only for a single site: ignored for a multisite table
   popmulti <- popup_from_ejscreen(testoutput_ejamit_10pts_1miles$results_bysite, sitenumber_label = 5)
   expect_true(grepl("(Site 2, ejam_uniq_id 2)", popmulti[2], fixed = TRUE))
+
+  # a numeric ejam_uniq_id that is NOT the auto row-number of a regenerated run
+  # (does not equal 1, the row index of a 1-row table) is kept alongside the label
+  out5 <- testoutput_ejamit_10pts_1miles$results_bysite[5, ] # ejam_uniq_id is 5
+  popkeep <- popup_from_ejscreen(out5, sitenumber_label = 7)
+  expect_true(grepl("(Site 7, ejam_uniq_id 5)", popkeep, fixed = TRUE))
+  expect_true(grepl("Site ID (ejam_uniq_id): 5", popkeep, fixed = TRUE))
+
+  # an invalid label (not a number or short text) is ignored, leaving popups unchanged
+  popbad <- popup_from_ejscreen(out1, sitenumber_label = TRUE)
+  expect_true(grepl("(Site 1, ejam_uniq_id 1)", popbad, fixed = TRUE))
 })
 ############################################## #
 

--- a/tests/testthat/test-ejam2map.R
+++ b/tests/testthat/test-ejam2map.R
@@ -42,6 +42,41 @@ test_that("ejam2map() works latlon", {
 })
 ############################################## #
 
+test_that("map popups honor sitenumber_label for a regenerated 1-site run (issue #348)", {
+  # (Public-Environmental-Data-Partners/EJAM#348) The API's per-site report links re-analyze
+  # one site that was row N of a larger analysis, so the regenerated results_bysite has the
+  # auto row-number ejam_uniq_id of 1. The report header shows "(Site N)" via ejam2report()'s
+  # display-only sitenumber_label; the map marker popup must match, not say "Site 1".
+  out1 <- testoutput_ejamit_10pts_1miles$results_bysite[1, ] # ejam_uniq_id is 1, as in a regenerated run
+
+  # popup builder itself
+  pop <- popup_from_ejscreen(out1, sitenumber_label = 5)
+  expect_true(grepl("(Site 5)", pop, fixed = TRUE))
+  expect_true(grepl("Site ID: 5", pop, fixed = TRUE))
+  expect_false(grepl("ejam_uniq_id 1", pop, fixed = TRUE)) # auto row id would contradict the label
+  expect_false(grepl("(Site 1", pop, fixed = TRUE))
+
+  # via mapfastej(), as ejam2report() builds the 1-site latlon map
+  suppressWarnings({
+    mymap <- mapfastej(out1, radius = 1, sitenumber_label = 5)
+  })
+  pp <- map2popups(mymap)
+  expect_true(any(grepl("(Site 5)", pp, fixed = TRUE)))
+  expect_false(any(grepl("ejam_uniq_id 1", pp, fixed = TRUE)))
+
+  # without a label, popups are unchanged
+  suppressWarnings({
+    mymap0 <- mapfastej(out1, radius = 1)
+  })
+  pp0 <- map2popups(mymap0)
+  expect_true(any(grepl("(Site 1, ejam_uniq_id 1)", pp0, fixed = TRUE)))
+
+  # label is display-only for a single site: ignored for a multisite table
+  popmulti <- popup_from_ejscreen(testoutput_ejamit_10pts_1miles$results_bysite, sitenumber_label = 5)
+  expect_true(grepl("(Site 2, ejam_uniq_id 2)", popmulti[2], fixed = TRUE))
+})
+############################################## #
+
 # need more tests
 
 ## how to check polygons shown are good?

--- a/tests/testthat/test-ejam2report.R
+++ b/tests/testthat/test-ejam2report.R
@@ -246,3 +246,48 @@ test_that("ejam2report normalizes default_format1pager fallback without a leadin
   )
   expect_match(basename(result), "\\.pdf$")
 })
+
+test_that("ejam2report passes sitenumber_label through to the report header helper (issue #348)", {
+  # (Public-Environmental-Data-Partners/EJAM#348) The API's per-site report links
+  # re-analyze one site that was row N of a larger analysis; ejam2report() must hand
+  # the display label to report_residents_within_xyz_from_ejamit() so the header
+  # says "Site N" instead of "Site 1".
+  seen <- new.env(parent = emptyenv())
+  local_mocked_bindings(
+    shapes_from_fips = function(fips) data.frame(fips = fips),
+    shape_buffered_from_shapefile = function(shapefile, radius.miles, ...) shapefile,
+    fips2name = function(fips) paste("FIPS", fips),
+    report_residents_within_xyz_from_ejamit = function(..., sitenumber_label = NULL) {
+      seen$label <- sitenumber_label
+      "residents"
+    },
+    report_setup_temp_files = function(...) "template.Rmd",
+    create_filename = function(...) "report.html",
+    build_community_report = function(...) "<section>report</section>",
+    plot_barplot_ratios_ez = function(...) ggplot2::ggplot(),
+    ejam2map = function(...) "map",
+    ensure_pandoc_available_for_ejam = function(...) invisible(TRUE),
+    .package = "EJAM"
+  )
+  local_mocked_bindings(
+    pandoc_available = function(...) TRUE,
+    render = function(input, output_format, output_file, params, envir, quiet, ...) {
+      writeLines("<html>report</html>", output_file)
+      output_file
+    },
+    .package = "rmarkdown"
+  )
+
+  expect_no_error(
+    ejam2report(
+      fips_report_test_output(radius = 1),
+      sitenumber = 1,
+      sitenumber_label = 7,
+      report_title = "Report",
+      analysis_title = "Analysis",
+      return_html = TRUE,
+      launch_browser = FALSE
+    )
+  )
+  expect_equal(seen$label, 7)
+})

--- a/tests/testthat/test-ejam2report.R
+++ b/tests/testthat/test-ejam2report.R
@@ -251,7 +251,8 @@ test_that("ejam2report passes sitenumber_label through to the report header help
   # (Public-Environmental-Data-Partners/EJAM#348) The API's per-site report links
   # re-analyze one site that was row N of a larger analysis; ejam2report() must hand
   # the display label to report_residents_within_xyz_from_ejamit() so the header
-  # says "Site N" instead of "Site 1".
+  # says "Site N" instead of "Site 1", and to the map builder so the marker popup
+  # says "Site N" too.
   seen <- new.env(parent = emptyenv())
   local_mocked_bindings(
     shapes_from_fips = function(fips) data.frame(fips = fips),
@@ -265,7 +266,10 @@ test_that("ejam2report passes sitenumber_label through to the report header help
     create_filename = function(...) "report.html",
     build_community_report = function(...) "<section>report</section>",
     plot_barplot_ratios_ez = function(...) ggplot2::ggplot(),
-    ejam2map = function(...) "map",
+    ejam2map = function(..., sitenumber_label = NULL) {
+      seen$maplabel <- sitenumber_label
+      "map"
+    },
     ensure_pandoc_available_for_ejam = function(...) invisible(TRUE),
     .package = "EJAM"
   )
@@ -290,4 +294,5 @@ test_that("ejam2report passes sitenumber_label through to the report header help
     )
   )
   expect_equal(seen$label, 7)
+  expect_equal(seen$maplabel, 7)
 })

--- a/tests/testthat/test-report_residents_within_xyz.R
+++ b/tests/testthat/test-report_residents_within_xyz.R
@@ -544,7 +544,18 @@ test_that("sitenumber_label overrides the displayed site number (issue #348)", {
   expect_true(grepl("Site 7", xf, fixed = TRUE))
   expect_true(grepl("FIPS", xf, fixed = TRUE))
 
+  # a numeric ejam_uniq_id that is NOT the auto row-number (does not equal the row index)
+  # may be meaningful, so it is kept alongside the label
+  out_ids <- out
+  out_ids$results_bysite <- data.table::copy(out$results_bysite)
+  out_ids$results_bysite$ejam_uniq_id <- 100 + seq_len(NROW(out_ids$results_bysite))
+  xkeep <- report_residents_within_xyz_from_ejamit(out_ids, sitenumber = 1, sitenumber_label = 5)
+  expect_true(grepl("Site 5", xkeep, fixed = TRUE))
+  expect_true(grepl("ejam_uniq_id 101", xkeep, fixed = TRUE))
+
   # invalid labels are rejected
   expect_error(report_residents_within_xyz_from_ejamit(out, sitenumber = 1, sitenumber_label = c(1, 2)))
   expect_error(report_residents_within_xyz_from_ejamit(out, sitenumber = 1, sitenumber_label = NA))
+  # only a number or short text is a valid label (e.g., logical would show as "Site TRUE")
+  expect_error(report_residents_within_xyz_from_ejamit(out, sitenumber = 1, sitenumber_label = TRUE))
 })

--- a/tests/testthat/test-report_residents_within_xyz.R
+++ b/tests/testthat/test-report_residents_within_xyz.R
@@ -505,3 +505,46 @@ if (FALSE) {
 
 
 }
+############################## #   ############################## #
+# sitenumber_label: display-only override of the site number shown in the header,
+# so a 1-site re-analysis of what was row N of a larger analysis is not
+# mislabeled "Site 1" (Public-Environmental-Data-Partners/EJAM#348)
+
+test_that("sitenumber_label overrides the displayed site number (issue #348)", {
+  out <- testoutput_ejamit_10pts_1miles
+
+  # default behavior unchanged: the row index is shown
+  x1 <- report_residents_within_xyz_from_ejamit(out, sitenumber = 1)
+  expect_true(grepl("Site 1", x1, fixed = TRUE))
+
+  # numeric label: shows the original site number, not this table's row index
+  x5 <- report_residents_within_xyz_from_ejamit(out, sitenumber = 1, sitenumber_label = 5)
+  expect_true(grepl("Site 5", x5, fixed = TRUE))
+  expect_false(grepl("Site 1", x5, fixed = TRUE))
+  # the auto row-number ejam_uniq_id is dropped since it would contradict the label
+  expect_false(grepl("ejam_uniq_id", x5, fixed = TRUE))
+
+  # text label is shown as-is
+  xt <- report_residents_within_xyz_from_ejamit(out, sitenumber = 1, sitenumber_label = "Jones Mill Site")
+  expect_true(grepl("Jones Mill Site", xt, fixed = TRUE))
+
+  # ignored for a multisite / overall summary report
+  xall <- report_residents_within_xyz_from_ejamit(out, sitenumber = 0, sitenumber_label = 5)
+  expect_false(grepl("Site 5", xall, fixed = TRUE))
+
+  # an explicitly provided ejam_uniq_id is still respected, shown alongside the label
+  xid <- report_residents_within_xyz_from_ejamit(out, sitenumber = 1, sitenumber_label = 5,
+                                                 ejam_uniq_id = "Custom ID")
+  expect_true(grepl("Site 5", xid, fixed = TRUE))
+  expect_true(grepl("Custom ID", xid, fixed = TRUE))
+
+  # a FIPS analysis keeps the stable FIPS id next to the label
+  xf <- report_residents_within_xyz_from_ejamit(testoutput_ejamit_fips_cities,
+                                                sitenumber = 2, sitenumber_label = 7)
+  expect_true(grepl("Site 7", xf, fixed = TRUE))
+  expect_true(grepl("FIPS", xf, fixed = TRUE))
+
+  # invalid labels are rejected
+  expect_error(report_residents_within_xyz_from_ejamit(out, sitenumber = 1, sitenumber_label = c(1, 2)))
+  expect_error(report_residents_within_xyz_from_ejamit(out, sitenumber = 1, sitenumber_label = NA))
+})

--- a/tests/testthat/test-url_ejamapi.R
+++ b/tests/testthat/test-url_ejamapi.R
@@ -267,11 +267,52 @@ test_that("url_ejamapi fileextension: auto = pdf for single-site, html for multi
   )
 })
 
+# per-site links carry the original site number ####
+# (Public-Environmental-Data-Partners/EJAM#348: per-site report links used to omit
+# sitenumber, so the API's regenerated one-site analysis labeled every report "Site 1")
+
+test_that("per-site 'each' links carry each site's original sitenumber (latlon) - issue #348", {
+  x <- url_ejamapi(sitepoints = testpoints_10[1:3, ], radius = 1)  # default sitenumber = "each"
+  expect_equal(length(x), 3)
+  expect_true(grepl("[&?]sitenumber=1(&|$)", x[1]))
+  expect_true(grepl("[&?]sitenumber=2(&|$)", x[2]))
+  expect_true(grepl("[&?]sitenumber=3(&|$)", x[3]))
+})
+
+test_that("per-site 'each' links carry each site's original sitenumber (fips) - issue #348", {
+  fips2 <- testinput_fips_counties[1:2]
+  x <- url_ejamapi(fips = fips2)
+  expect_equal(length(x), 2)
+  expect_true(grepl("[&?]sitenumber=1(&|$)", x[1]))
+  expect_true(grepl("[&?]sitenumber=2(&|$)", x[2]))
+  # and each link still sends only its own site to the API
+  expect_true(grepl(paste0("fips=", fips2[1]), x[1], fixed = TRUE))
+  expect_true(grepl(paste0("fips=", fips2[2]), x[2], fixed = TRUE))
+  expect_false(grepl(fips2[1], x[2], fixed = TRUE))
+})
+
+test_that("a single-site link for site N carries sitenumber=N; site-1/lone-site links omit it - issue #348", {
+  x5 <- url_ejamapi(sitepoints = testpoints_10, radius = 1, sitenumber = 5)
+  expect_equal(length(x5), 1)
+  expect_true(grepl("[&?]sitenumber=5(&|$)", x5))
+
+  # site 1 or a lone site: Site 1 is the API's default label, so the param is omitted
+  # (these URLs are unchanged from before the issue #348 fix)
+  x1 <- url_ejamapi(sitepoints = testpoints_10, radius = 1, sitenumber = 1)
+  expect_false(grepl("sitenumber", x1, fixed = TRUE))
+  xlone <- url_ejamapi(sitepoints = testpoints_10[1, ], radius = 1)
+  expect_false(grepl("sitenumber", xlone, fixed = TRUE))
+
+  # the aggregate multisite link still passes sitenumber=0
+  x0 <- url_ejamapi(sitepoints = testpoints_10, radius = 1, sitenumber = 0)
+  expect_true(grepl("[&?]sitenumber=0(&|$)", x0))
+})
+
 # sitenumber (overall vs 1-site) ####
 
 # N  means Nth site report
-# -1 means "overall" report
-# 0  means "each" site report, in a vector of URLs
+# 0 (or "overall") means "overall" report
+# -1 (or "each") means "each" site report, in a vector of URLs
 
 
 if (FALSE) {


### PR DESCRIPTION
## Summary

Fixes Public-Environmental-Data-Partners/EJAM#348: per-site "EJAM Report" links generated for `results_bysite` omitted the original site number, and the bundled `GET /report` endpoint hard-coded `ejam2report(..., sitenumber = 1)`, so a per-site report opened from row 2, 3, ... was labeled "(Site 1)" in the header.

**After this PR, a per-site link for row N produces a report whose header says "Site N".**

## What changed

- **`R/url_ejamapi.R`** — per-site report URLs now carry the display-site identifier:
  - default `sitenumber = "each"`: each URL still sends only its own site to the API, but adds `sitenumber=N` (that site's row in the original inputs), for both latlon and fips inputs;
  - a requested single site `sitenumber = N` adds `sitenumber=N` when `N > 1`;
  - lone-site links, `sitenumber = 1` links, and the aggregate `sitenumber=0` ("overall") link are byte-for-byte unchanged;
  - per-polygon links are unchanged (they are app-fallback links, not API `/report` URLs; noted in a comment for when those are implemented).
- **`inst/plumber/plumber.R` `GET /report`** — no longer hard-codes `sitenumber = 1`: accepts a `sitenumber` parameter, honors `0`/`"overall"` for the aggregate multisite report, and when exactly one site is submitted uses N as a display label ("Site N") for the regenerated one-site analysis.
- **`R/ejam2report.R` + `R/community_report_helper_funs.R`** — new display-only `sitenumber_label` parameter (name-only, added after existing args to avoid any positional shift). `sitenumber` still selects the `results_bysite` row; the label only changes the header text. The auto-assigned row-number `ejam_uniq_id` is dropped when it would contradict the label, while stable FIPS ids and explicitly-provided ids are kept.

## Header text, before → after (per-site link for row 5 of a 10-point analysis)

- Before: `Residents within 1 mile of this specified point (Site 1, ejam_uniq_id 1) centered at 37.64122, -122.41065`
- After: `Residents within 1 mile of this specified point (Site 5) centered at 37.64122, -122.41065`

FIPS example (site 2 of several cities, labeled as original row 7): `Residents within this specified city (Site 7, FIPS 2743306)`

## Compatibility with the deployed EJAM-API

The deployed API (Public-Environmental-Data-Partners/EJAM-API `rest_controller.r`) already accepts `sitenumber` on `GET /report` as a row picker, and treats an out-of-range N on a one-site request as invalid, falling back to a site-1 report. So the new URLs work against the deployed API today exactly as they did before (label unchanged until the API is updated), and nothing breaks. A small follow-up in EJAM-API is needed for the deployed reports to show the "Site N" label — pass `sitenumber_label` the same way the bundled endpoint now does (I did not touch that repo).

`url_ejamapi2arglist()` and the app deep-link handler ignore unknown query keys, so the added parameter is inert everywhere else.

## Tests

Added to existing test files (no new files, so `R/test_ejam.R` groups are unaffected):

- `test-url_ejamapi.R`: "each" links carry `sitenumber=1..N` (latlon + fips), site-N links carry `sitenumber=N`, lone-site/site-1 links omit it, overall links still say `sitenumber=0`;
- `test-report_residents_within_xyz.R`: label overrides "Site 1" → "Site 5", drops the contradicting row-number id, text labels shown as-is, ignored for overall reports, FIPS id kept, explicit `ejam_uniq_id` respected, invalid labels rejected;
- `test-ejam2report.R`: `sitenumber_label` is passed through to the header helper.

`devtools::test(filter = "^(url_ejamapi|report_residents_within_xyz|ejam2report)$")` passes (1 pre-existing skip: pandoc unavailable in the check shell). Roxygen docs regenerated for the three touched topics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)