### PR TITLE
Fix build_community_report()/build_barplot_report() filename stub: write the file and return the HTML

### DIFF
--- a/R/build_barplot_report.R
+++ b/R/build_barplot_report.R
@@ -13,13 +13,15 @@
 #' @param locationstr, description of the location(s) analyzed
 #'
 #' @param in_shiny, whether the function is being called in or outside of shiny - affects location of header
-#' @param filename, path to file to save HTML content to; if null, returns as string (used in Shiny app)
+#' @param filename, optional path to an .html file; if provided, the HTML content
+#'   is also written to that file. The HTML is returned either way.
 #' @param report_title generic name of this type of report, to be shown at top, like "EJAM Multisite Report"
 #' @param logo_path optional relative path to a logo for the upper right of the overall header.
 #'   Ignored if logo_html is specified and not NULL, but otherwise uses default or param set in ejamapp()
 #' @param logo_html optional HTML for img of logo for the upper right of the overall header.
 #'   If specified, it overrides logo_path. If omitted, gets created based on logo_path.
-#' @return can return HTML if filename not specified, but otherwise NULL
+#' @return HTML content of the report header as an [htmltools::HTML()] object,
+#'   whether or not `filename` was provided.
 #'
 #' @keywords internal
 #'
@@ -39,12 +41,13 @@ build_barplot_report <- function(analysis_title, totalpop, locationstr,
                          logo_html = logo_html),
     collapse = ''
   )
-  if (is.null(filename)) {
-    return(HTML(full_page))
-  } else {
-    junk <- capture.output({
-      cat(HTML(full_page))
-    })
+  if (!is.null(filename)) {
+    if (!dir.exists(dirname(filename))) {
+      stop("Cannot save the report HTML because the folder does not exist: ", dirname(filename))
+    }
+    writeLines(as.character(full_page), con = filename)
   }
-
+  # Return visibly in both cases - barplot_report_template.Rmd relies on this
+  # value auto-printing from its chunk, even when a filename is provided.
+  return(HTML(full_page))
 }

--- a/R/build_barplot_report.R
+++ b/R/build_barplot_report.R
@@ -8,12 +8,12 @@
 #' see [ejam2report()] which relies on [build_community_report()]
 #'
 #'
-#' @param analysis_title, title to use in header of report
-#' @param totalpop, total population included in location(s) analyzed
-#' @param locationstr, description of the location(s) analyzed
+#' @param analysis_title title to use in header of report
+#' @param totalpop total population included in location(s) analyzed
+#' @param locationstr description of the location(s) analyzed
 #'
-#' @param in_shiny, whether the function is being called in or outside of shiny - affects location of header
-#' @param filename, optional path to an .html file; if provided, the HTML content
+#' @param in_shiny whether the function is being called in or outside of shiny - affects location of header
+#' @param filename optional path to an .html file; if provided, the HTML content
 #'   is also written to that file. The HTML is returned either way.
 #' @param report_title generic name of this type of report, to be shown at top, like "EJAM Multisite Report"
 #' @param logo_path optional relative path to a logo for the upper right of the overall header.

--- a/R/build_community_report.R
+++ b/R/build_community_report.R
@@ -103,8 +103,11 @@ report_setup_temp_files <- function(Rmd_name = 'community_report_template.Rmd',
 #'   as with many of names_d_language, in extra table of demog. subgroups, etc.'
 #'
 #' @param in_shiny whether the function is being called in or outside of shiny - affects location of header
-#' @param filename path to file to save HTML content to; if null, returns as string (used in Shiny app)
+#' @param filename optional path to an .html file; if provided, the assembled HTML
+#'   content is also written to that file. The HTML is returned either way.
 #'
+#' @return HTML content of the report body (header and tables) as an
+#'   [htmltools::HTML()] object, whether or not `filename` was provided.
 #'
 #' @seealso [ejam2report()]
 #'
@@ -178,10 +181,18 @@ build_community_report <- function(
   output_df_rounded <- format_ejamit_columns(output_df_rounded, names(output_df_rounded))
 
   if (missing(totalpop) || is.null(totalpop)) {
-    if ("pop" %in% names(output_df_rounded)) {
-      totalpop <- prettyNum(round(output_df_rounded$pop, 0), big.mark = ',')
+    if ("pop" %in% names(output_df)) {
+      # use pop from output_df not output_df_rounded - format_ejamit_columns()
+      # already turned the rounded copy into text like "10,000" so round() would fail on it
+      pop_raw <- as.data.frame(output_df)$pop
+      pop_num <- suppressWarnings(as.numeric(gsub(",", "", pop_raw)))
+      if (!anyNA(pop_num)) {
+        totalpop <- prettyNum(round(pop_num, 0), big.mark = ',')
+      } else {
+        totalpop <- as.character(pop_raw) # was already formatted text, or not numeric
+      }
     } else {
-      warning('totalpop parameter or output_df_rounded$pop is required')
+      warning('totalpop parameter or output_df$pop is required')
       totalpop <- "NA" # text works here rather than NA
     }
   }
@@ -258,13 +269,13 @@ build_community_report <- function(
 #   > map, barplot, footer are elsewhere < ####
 
   ############################################################# #
-  if (is.null(filename)) {
-    return(HTML(full_page))
-  } else {
-    junk <- capture.output({
-      cat(HTML(full_page))
-    })
-    # DO WE NEED TO RENDER  HERE? ***
-    # OR CAN WE WRITE junk TO A .html FILE - WILL THAT WORK?
+  if (!is.null(filename)) {
+    if (!dir.exists(dirname(filename))) {
+      stop("Cannot save the report HTML because the folder does not exist: ", dirname(filename))
+    }
+    writeLines(as.character(full_page), con = filename)
   }
+  # Return visibly in both cases - community_report_template.Rmd relies on this
+  # value auto-printing from its chunk, even when a filename is provided.
+  return(HTML(full_page))
 }

--- a/R/test_ejam.R
+++ b/R/test_ejam.R
@@ -342,6 +342,7 @@ instead of tests/testthat/_logs
         "test-ejamit_sitetype_from_output.R",
 
         "test-ejam2report.R",
+        "test-build_community_report.R",
         "test-ejam2excel.R",
         "test-ejam2barplot_sites.R",
         "test-ejam2barplot_indicators.R",
@@ -602,7 +603,8 @@ and all filenames listed there actually exist as in that folder called `test`.\n
               "test-naics_is.valid.R", "test-naics_subcodes_from_code.R", "test-test1.R",
               "test-test2.R", "test-URL_FUNCTIONS_part1.R", "test-URL_FUNCTIONS_part2.R",
               "test-ejamapi.R", "test-url_columns_bysite.R", "test-url_ejamapi.R",
-              "test-url_package.R", "test-ejam2boxplot_ratios.R", "test-shiny-1-14-compat.R"),
+              "test-url_package.R", "test-ejam2boxplot_ratios.R", "test-shiny-1-14-compat.R",
+              "test-build_community_report.R"),
           seconds_byfile =
             c(0, 0, 0, 0, 0, 0, 0,
               0, 0, 2, 0, 1, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 6, 0, 0, 0,
@@ -610,9 +612,9 @@ and all filenames listed there actually exist as in that folder called `test`.\n
               39, 0, 11, 11, 0, 5, 32, 5, 0, 5, 0, 2, 0, 140, 2, 8, 0, 3, 2,
               23, 0, 7, 0, 12, 0, 4, 5, 1, 0, 3, 0, 3, 0, 0, 0, 0, 1, 0, 4,
               2, 0, 0, 0, 0, 1, 0, 0, 16, 8, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
-              0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 12, 0, 4, 0, 0, 0, 0)),
+              0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 12, 0, 4, 0, 0, 0, 0, 1)),
           row.names = c(NA,
-                        -126L), class = "data.frame")
+                        -127L), class = "data.frame")
       )
 
 

--- a/man/build_barplot_report.Rd
+++ b/man/build_barplot_report.Rd
@@ -16,15 +16,15 @@ build_barplot_report(
 )
 }
 \arguments{
-\item{analysis_title, }{title to use in header of report}
+\item{analysis_title}{title to use in header of report}
 
-\item{totalpop, }{total population included in location(s) analyzed}
+\item{totalpop}{total population included in location(s) analyzed}
 
-\item{locationstr, }{description of the location(s) analyzed}
+\item{locationstr}{description of the location(s) analyzed}
 
-\item{in_shiny, }{whether the function is being called in or outside of shiny - affects location of header}
+\item{in_shiny}{whether the function is being called in or outside of shiny - affects location of header}
 
-\item{filename, }{optional path to an .html file; if provided, the HTML content
+\item{filename}{optional path to an .html file; if provided, the HTML content
 is also written to that file. The HTML is returned either way.}
 
 \item{report_title}{generic name of this type of report, to be shown at top, like "EJAM Multisite Report"}

--- a/man/build_barplot_report.Rd
+++ b/man/build_barplot_report.Rd
@@ -24,7 +24,8 @@ build_barplot_report(
 
 \item{in_shiny, }{whether the function is being called in or outside of shiny - affects location of header}
 
-\item{filename, }{path to file to save HTML content to; if null, returns as string (used in Shiny app)}
+\item{filename, }{optional path to an .html file; if provided, the HTML content
+is also written to that file. The HTML is returned either way.}
 
 \item{report_title}{generic name of this type of report, to be shown at top, like "EJAM Multisite Report"}
 
@@ -35,7 +36,8 @@ Ignored if logo_html is specified and not NULL, but otherwise uses default or pa
 If specified, it overrides logo_path. If omitted, gets created based on logo_path.}
 }
 \value{
-can return HTML if filename not specified, but otherwise NULL
+HTML content of the report header as an \code{\link[htmltools:HTML]{htmltools::HTML()}} object,
+whether or not \code{filename} was provided.
 }
 \description{
 Creates header and footer of 1 page report to include a barplot on results for one site (to supplement the EJSCREEN Community Report)

--- a/man/build_community_report.Rd
+++ b/man/build_community_report.Rd
@@ -75,7 +75,12 @@ as with many of names_d_language, in extra table of demog. subgroups, etc.'}
 
 \item{in_shiny}{whether the function is being called in or outside of shiny - affects location of header}
 
-\item{filename}{path to file to save HTML content to; if null, returns as string (used in Shiny app)}
+\item{filename}{optional path to an .html file; if provided, the assembled HTML
+content is also written to that file. The HTML is returned either way.}
+}
+\value{
+HTML content of the report body (header and tables) as an
+\code{\link[htmltools:HTML]{htmltools::HTML()}} object, whether or not \code{filename} was provided.
 }
 \description{
 Just assembles the report, given the header info, tables, map, and plot

--- a/tests/testthat/test-build_community_report.R
+++ b/tests/testthat/test-build_community_report.R
@@ -1,0 +1,88 @@
+
+## Tests for build_community_report() and build_barplot_report()
+## focusing on the filename parameter: when provided, the HTML must be
+## written to that file AND still be returned (identical to the filename=NULL
+## return), since callers and the report .Rmd templates use the return value.
+## (Previously the filename branch discarded the content, which is the root
+## cause behind the empty saved reports addressed in
+## Public-Environmental-Data-Partners/EJAM#471.)
+
+test_that("build_community_report(filename=NULL) returns the report HTML", {
+  returned <- EJAM:::build_community_report(
+    output_df = testoutput_ejamit_10pts_1miles$results_overall,
+    analysis_title = "MARKER TITLE nullcase",
+    report_title = "Test Report",
+    in_shiny = FALSE
+  )
+  expect_s3_class(returned, "html")
+  expect_match(as.character(returned), "MARKER TITLE nullcase", fixed = TRUE)
+})
+
+test_that("build_community_report(filename=) writes the HTML to the file and still returns it", {
+  outfile <- file.path(tempdir(), "build_community_report_test_output.html")
+  on.exit(unlink(outfile), add = TRUE)
+
+  returned <- EJAM:::build_community_report(
+    output_df = testoutput_ejamit_10pts_1miles$results_overall,
+    analysis_title = "MARKER TITLE filecase",
+    report_title = "Test Report",
+    in_shiny = FALSE,
+    filename = outfile
+  )
+
+  # return value must be the same HTML as in the filename=NULL case, not NULL
+  expect_s3_class(returned, "html")
+  expect_match(as.character(returned), "MARKER TITLE filecase", fixed = TRUE)
+
+  # and the same content must have been saved to the file
+  expect_true(file.exists(outfile))
+  saved <- paste(readLines(outfile, warn = FALSE), collapse = "\n")
+  expect_match(saved, "MARKER TITLE filecase", fixed = TRUE)
+  expect_identical(trimws(saved), trimws(as.character(returned)))
+})
+
+test_that("build_community_report() derives totalpop from output_df$pop when not provided", {
+  out <- testoutput_ejamit_10pts_1miles$results_overall
+  expected_popstr <- prettyNum(round(as.numeric(out$pop), 0), big.mark = ",")
+  returned <- EJAM:::build_community_report(
+    output_df = out,
+    analysis_title = "irrelevant",
+    report_title = "Test Report"
+  )
+  expect_match(as.character(returned), expected_popstr, fixed = TRUE)
+})
+
+test_that("build_community_report(filename=) errors clearly when the folder does not exist", {
+  badpath <- file.path(tempdir(), "no_such_subfolder_for_test", "report.html")
+  expect_error(
+    EJAM:::build_community_report(
+      output_df = testoutput_ejamit_10pts_1miles$results_overall,
+      analysis_title = "irrelevant",
+      report_title = "Test Report",
+      filename = badpath
+    ),
+    "does not exist"
+  )
+})
+
+test_that("build_barplot_report(filename=) writes the HTML to the file and still returns it", {
+  outfile <- file.path(tempdir(), "build_barplot_report_test_output.html")
+  on.exit(unlink(outfile), add = TRUE)
+
+  returned <- EJAM:::build_barplot_report(
+    analysis_title = "MARKER BARPLOT TITLE",
+    totalpop = "1,234",
+    locationstr = "Test location",
+    report_title = "Test Barplot Report",
+    in_shiny = FALSE,
+    filename = outfile
+  )
+
+  expect_s3_class(returned, "html")
+  expect_match(as.character(returned), "MARKER BARPLOT TITLE", fixed = TRUE)
+
+  expect_true(file.exists(outfile))
+  saved <- paste(readLines(outfile, warn = FALSE), collapse = "\n")
+  expect_match(saved, "MARKER BARPLOT TITLE", fixed = TRUE)
+  expect_identical(trimws(saved), trimws(as.character(returned)))
+})


### PR DESCRIPTION
## Root cause fix behind the empty-saved-report bug

`build_community_report()` and `build_barplot_report()` both had an unfinished `filename` branch:

```r
} else {
  junk <- capture.output({
    cat(HTML(full_page))
  })
  # DO WE NEED TO RENDER  HERE? ***
}
```

When `filename` was non-NULL, no file was written and the function returned the captured lines invisibly - stripped of the `html` class and split into a character vector - instead of the HTML. This is the root cause behind the empty saved community reports; Public-Environmental-Data-Partners/EJAM#471 works around it in `ejam2report()` by always passing `filename = NULL`, but any other caller passing a filename (e.g. `community_report_template.Rmd` passes `filename = params$filename`) could still hit the stub.

## Change

- A non-NULL `filename` now **writes the assembled HTML to that file** (with a clear error if the folder does not exist), and the HTML is **returned visibly either way**. Visible (not `invisible()`) return matters because `community_report_template.Rmd` and `barplot_report_template.Rmd` rely on the call auto-printing from its chunk; an invisible return would reproduce the empty-report symptom via that path.
- Also fixes the never-working `totalpop` fallback in `build_community_report()`: it derived `totalpop` from `output_df_rounded$pop` **after** `format_ejamit_columns()` had already turned it into text like `"10,000"`, so `round()` always errored. It now derives from the unformatted value and tolerates already-formatted input. (Real callers always passed `totalpop`, so this branch had never worked.)
- Roxygen `@param filename` / `@return` updated for both functions; docs regenerated.

## Compatibility

- No overlap with Public-Environmental-Data-Partners/EJAM#471 (different files); either merge order is fine. Until #471 merges, `ejam2report()` on development passes a non-NULL filename - with this fix that path now returns real HTML, so this PR independently repairs the saved-report content too.
- `filename = NULL` callers (app_server.R, and ejam2report() after #471) see identical behavior to before.

## Tests

New `tests/testthat/test-build_community_report.R` (registered in `R/test_ejam.R` group lists + timing table):
- `filename = NULL` returns the report HTML (behavior lock)
- `filename =` writes the file, content matches the returned HTML exactly, return value unchanged
- clear error when the target folder does not exist
- `totalpop` derived from `output_df$pop` when omitted
- same write-and-return coverage for `build_barplot_report()`

Verified locally: new file 14/14 pass; existing `test-ejam2report.R` 46/46 pass with pandoc (including the full render-with-filename integration path against the changed function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)