### PR TITLE
Update GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -32,7 +32,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
-      - uses: actions/checkout@v4.3.0
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/diag-ecs-dev.yaml
+++ b/.github/workflows/diag-ecs-dev.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/install-quick-check.yaml
+++ b/.github/workflows/install-quick-check.yaml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@v7
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/install-release-user-check.yaml
+++ b/.github/workflows/install-release-user-check.yaml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
 
@@ -212,7 +212,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}
 

--- a/.github/workflows/lintr.yaml
+++ b/.github/workflows/lintr.yaml
@@ -43,13 +43,13 @@ jobs:
     steps:
 
       - name: Checkout EJAM code
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@v7
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
 
       - name: Setup lintr
-        uses: r-lib/actions/setup-r-dependencies@813ef1cb62cf0b4b51a044419024c37807fa8095
+        uses: r-lib/actions/setup-r-dependencies@v2
         with:
           cache: false
           extra-packages: lintr

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -107,7 +107,7 @@ jobs:
           echo "build_dir=$build_dir" >> "$GITHUB_OUTPUT"
           echo "Building $build_ref as $pkgdown_dev_mode; deploying $build_dir to gh-pages/$target_folder"
 
-      - uses: actions/checkout@v4.3.0
+      - uses: actions/checkout@v7
         with:
           ref: ${{ steps.deploy.outputs.build_ref }}
 

--- a/.github/workflows/test-webapp-functionality.yaml
+++ b/.github/workflows/test-webapp-functionality.yaml
@@ -34,7 +34,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
-      - uses: actions/checkout@v4.3.0
+      - uses: actions/checkout@v7
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -134,7 +134,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ runner.os }}-tests
           path: |


### PR DESCRIPTION
GitHub is retiring the Node 20 action runtime; this updates the actions in .github/workflows that still declare `node20` to their latest majors (each tag's `action.yml` runtime verified):

| Action | Was | Now | Notes |
|---|---|---|---|
| actions/checkout | v4.3.0 (node20; all v4.x are) | v7 | v7's only breaking change (blocks fork-PR checkout under `pull_request_target`/`workflow_run`) is irrelevant — no EJAM workflow uses those triggers. Requires runner >= 2.327.1 (GitHub-hosted already is). |
| actions/upload-artifact | v4 (node20) | v7 | Node 24 default since v6; v7 adds optional `archive: false` |
| aws-actions/configure-aws-credentials | v4 (node20) | v6 | latest major; Node 24 switch came in v6.0.0. The v5 boolean-input handling change doesn't affect our plain role-assume usage |
| r-lib/actions/setup-r-dependencies | SHA pin 813ef1cb (composite internally using actions/cache@v4 = node20) | @v2 | matches the other 5 uses; rolling v2 (currently v2.12.1) pins node24 SHAs internally |

Already on latest / Node 24, unchanged: other r-lib/actions/*@v2 (setup-r, setup-pandoc, check-r-package), JamesIves/github-pages-deploy-action@v4.8.0, github/codeql-action/upload-sarif@v4.

The identical commit is going to main as a workflow-only hotfix (per the hotfix exception in the branching model): Public-Environmental-Data-Partners/EJAM#481. Identical patch on both sides, so the next release sync won't conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)