### PR TITLE
Simplify test-ejamit.R report-URL check now that #488 regenerated the reference

### DIFF
--- a/tests/testthat/test-ejamit.R
+++ b/tests/testthat/test-ejamit.R
@@ -447,24 +447,17 @@ test_that("ejamit() still returns results_bysite with same EJAM Report column", 
     suppressMessages({
       # if (!exists("ejamitoutnow")) {stop("ejamitoutnow is missing but should have been created by EJAM/tests/testthat/setup.R")}
       # ejamitoutnow <- ejamit(testpoints_10, radius = 1, quiet = T, silentinteractive = TRUE) # see setup.R - takes roughly 5-10 seconds
-      ## Compare column 1, the EJAM Report URLs. Strip the parts that legitimately
-      ## vary independently of the per-site query values this test is about
-      ## (lat/lon/buffer/sitetype); the URL base and format are covered by the URL
-      ## function tests. Specifically drop:
-      ##  - the version= parameter: url_ejamapi() now omits it by default (it is only
-      ##    sent when a caller passes version=), while the stored reference was built
-      ##    when a version tag was still emitted, so strip it from either side;
-      ##  - the API base URL (the branded api.ejanalysis.com host replaced the raw
-      ##    Cloud Run host without regenerating the stored reference);
-      ##  - the fileextension= parameter (explicit fileextension=pdf, likewise).
+      ## Compare column 1, the EJAM Report URLs. The stored reference was regenerated
+      ## in #488, so it now matches current url_ejamapi() output exactly (branded
+      ## api.ejanalysis.com host, no version= tag, per-site sitenumber=, current
+      ## lat/lon formatting). The workarounds that were needed while the reference was
+      ## stale are therefore gone, and this is now a strict comparison -- which also
+      ## means it again covers sitenumber=, the host, and fileextension=.
+      ## The one thing still normalized is version=: url_ejamapi() omits it by default,
+      ## but if it is ever re-enabled it embeds the package version, which changes on
+      ## every release and would otherwise break this check at each version bump.
       norm_report_url <- function(x) {
-        x <- gsub("&version=[^&\"]*", "", x)          # version omitted by default now; only sent if a caller passes it
-        x <- gsub("&sitenumber=[0-9]+", "", x)        # per-site "Site N" label added after the stored reference (#470)
-        x <- gsub("https://[^/\"]+/report\\?", "https://HOST/report?", x)
-        x <- gsub("&fileextension=[[:alnum:]]+", "", x)
-        x <- gsub("=(?:%20)+", "=", x, perl = TRUE)                       # stale reference URL-encoded a leading space in lat/lon
-        x <- gsub("(=-?[0-9.]*[1-9])0+(?=[&\"])", "\\1", x, perl = TRUE)  # drop trailing zeros in lat/lon/buffer
-        x
+        gsub("&version=[^&\"]*", "", x)
       }
       expect_equal(
         norm_report_url(as.vector(unlist(ejamitoutnow$results_bysite[,1]))),


### PR DESCRIPTION
## Why

#488 regenerated `testoutput_ejamit_10pts_1miles` (and the other `testoutput*` fixtures), so the stored EJAM Report URLs now match current `url_ejamapi()` output **exactly**: branded `api.ejanalysis.com` host, no `version=` tag, per-site `sitenumber=` (#470), current lat/lon formatting.

Verified: freshly generated URLs are **byte-identical** to the stored reference for all 10 sites, with no normalization at all.

## What

The workarounds #487 added while the reference was stale are now obsolete, so they're removed:
- ~~strip `sitenumber=`~~ (was actively costing coverage of a real feature)
- ~~normalize the host~~
- ~~strip `fileextension=`~~
- ~~strip the `%20` leading space~~
- ~~drop trailing zeros in lat/lon/buffer~~

This restores a **strict comparison**, which again covers `sitenumber=`, the host, and `fileextension=`.

Kept only the `version=` strip: `url_ejamapi()` omits version by default, but if it is ever re-enabled it embeds the package version, which changes on every release and would otherwise break this check at each version bump.

All 28 tests in `test-ejamit.R` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)