### PR TITLE
Speed up the Details tab Site-by-Site Table ~4x (fixes #127)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,7 +69,7 @@ packaged ACS or environmental data.
 ## Improvements
 
 - **The web app's Site-by-Site Table (Details tab) is built about 4x faster**
-  (#127): profiling showed the lag after clicking the tab was not the
+  (#491 fixes #127): profiling showed the lag after clicking the tab was not the
   URL-generating functions (links are created earlier, during the analysis) but
   two steps in building the table view. `table_round()` copied the entire wide
   table once per column, costing over half a second even for a small analysis,

--- a/NEWS.md
+++ b/NEWS.md
@@ -68,6 +68,19 @@ packaged ACS or environmental data.
 
 ## Improvements
 
+- **The web app's Site-by-Site Table (Details tab) is built about 4x faster**
+  (#127): profiling showed the lag after clicking the tab was not the
+  URL-generating functions (links are created earlier, during the analysis) but
+  two steps in building the table view. `table_round()` copied the entire wide
+  table once per column, costing over half a second even for a small analysis,
+  and a `shiny::actionButton()` tag was rendered separately for every site
+  (about 1 second per 1,000 sites). Rounding now updates each column in place
+  and the per-site download buttons are filled in from a single rendered
+  template, producing byte-identical output while cutting server-side table
+  construction from about 2.1s to 0.6s for 1,000 sites. `table_round()` is also
+  used by map popups (`popup_from_ejscreen()`), `ejam2means()`, and
+  `ejam2table_tall()`, which get the same speedup.
+
 - **All PDF reports are about 7 seconds (~46%) faster** (#473 helps with #293): 
   the two unconditional render pauses were trimmed (report-map snapshot 4s -> 1s,
   print-to-PDF 5s -> 2s), and both are now settable without a rebuild -- via the

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,16 @@ packaged ACS or environmental data.
 
 ## Bug Fixes
 
+- **Rounding helpers no longer mangle data.table inputs** (#491): `table_round()`,
+  `table_signif()`, `table_x100()`, and `is.numericish()` used to convert a
+  data.table argument into a data.frame *in the caller's environment* (a
+  `setDF()` side effect that was never undone because a later copy broke the
+  reference before the restoring `setDT()`), and `table_round()` /
+  `table_signif()` then also returned a plain data.frame. All four now leave
+  the caller's object untouched and return the same class they were given,
+  with identical values (verified cell-for-cell against the old behavior for
+  points, FIPS, and shapefile analysis outputs).
+
 - **Percentages displayed as "0" or "1" (or unrounded) in reports, tables, and
   map popups**: two related metadata problems were fixed. The derived
   `names_pct_as_fraction_ejamit` / `names_pct_as_fraction_blockgroupstats`

--- a/NEWS.md
+++ b/NEWS.md
@@ -95,9 +95,10 @@ packaged ACS or environmental data.
   of 100 -- together these cut the time until the table appears from ~6.4s to
   well under 1s for a 1,000-site analysis. Users can add any columns via the
   advanced tab's column picker (which had never rendered, due to `renderUI()`
-  being used in the UI where `uiOutput()` belongs -- also fixed), can choose
-  100 rows per page from the length menu, and always get every column in the
-  downloaded spreadsheet.
+  being used in the UI where `uiOutput()` belongs -- also fixed, along with
+  the button-column-name field next to it, which displayed "FALSE" because it
+  was bound to the wrong setting), can choose 100 rows per page from the
+  length menu, and always get every column in the downloaded spreadsheet.
 
 - **All PDF reports are about 7 seconds (~46%) faster** (#473 helps with #293): 
   the two unconditional render pauses were trimmed (report-map snapshot 4s -> 1s,

--- a/NEWS.md
+++ b/NEWS.md
@@ -89,7 +89,15 @@ packaged ACS or environmental data.
   template, producing byte-identical output while cutting server-side table
   construction from about 2.1s to 0.6s for 1,000 sites. `table_round()` is also
   used by map popups (`popup_from_ejscreen()`), `ejam2means()`, and
-  `ejam2table_tall()`, which get the same speedup.
+  `ejam2table_tall()`, which get the same speedup. In addition, the table now
+  starts from the default column subset (`default_bysite_webtable_colnames`,
+  ~50 columns) instead of all ~700 columns, and shows 50 rows per page instead
+  of 100 -- together these cut the time until the table appears from ~6.4s to
+  well under 1s for a 1,000-site analysis. Users can add any columns via the
+  advanced tab's column picker (which had never rendered, due to `renderUI()`
+  being used in the UI where `uiOutput()` belongs -- also fixed), can choose
+  100 rows per page from the length menu, and always get every column in the
+  downloaded spreadsheet.
 
 - **All PDF reports are about 7 seconds (~46%) faster** (#473 helps with #293): 
   the two unconditional render pauses were trimmed (report-map snapshot 4s -> 1s,

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -3291,10 +3291,12 @@ app_server <- function(input, output, session) {
                                  sitereport_download_buttons_colname = input$sitereport_download_buttons_colname, # "Download EJAM Report", # for DOWNLOAD BUTTON in each row, to get 1-site reports. could change to be an input$ in advanced tab possibly
 
                                  ## show the default column subset until the user picks
-                                 ## columns in the advanced tab (the input is NULL until
-                                 ## that picker has been rendered) - showing all ~700
-                                 ## columns made this table several times slower to appear (#127)
-                                 columns_used = if (is.null(input$bysite_webtable_colnames)) {
+                                 ## columns in the advanced tab - showing all ~700
+                                 ## columns made this table several times slower to appear (#127).
+                                 ## length()==0 covers both NULL (picker never rendered)
+                                 ## and character(0) (user cleared every selection), since
+                                 ## an empty columns_used would mean "all columns"
+                                 columns_used = if (length(input$bysite_webtable_colnames) == 0) {
                                    global_or_param("default_bysite_webtable_colnames")
                                  } else {
                                    input$bysite_webtable_colnames

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -3290,8 +3290,15 @@ app_server <- function(input, output, session) {
                                  sitereport_download_buttons_show = isTRUE(as.logical(input$sitereport_download_buttons_show)),
                                  sitereport_download_buttons_colname = input$sitereport_download_buttons_colname, # "Download EJAM Report", # for DOWNLOAD BUTTON in each row, to get 1-site reports. could change to be an input$ in advanced tab possibly
 
-                                 columns_used = input$bysite_webtable_colnames
-                                 ## if NULL, uses all available from data_processed()
+                                 ## show the default column subset until the user picks
+                                 ## columns in the advanced tab (the input is NULL until
+                                 ## that picker has been rendered) - showing all ~700
+                                 ## columns made this table several times slower to appear (#127)
+                                 columns_used = if (is.null(input$bysite_webtable_colnames)) {
+                                   global_or_param("default_bysite_webtable_colnames")
+                                 } else {
+                                   input$bysite_webtable_colnames
+                                 }
     )
     # enable download button only after DT::renderDT
     download_button_enable_js(id = 'download_results_spreadsheet')
@@ -3302,17 +3309,20 @@ app_server <- function(input, output, session) {
   # but note this is not the same as controlling the url report columns defined by default_reports
   output$bysite_webtable_colnames_ui <- renderUI({
 
-    choicelist =  list(names(testoutput_ejamit_10pts_1miles$results_overall))
-    names(choicelist)  <- fixcolnames(rnames, 'r', 'short')
+    # offer every column the site-by-site table can show, labeled with short names
+    # (this had referenced an undefined object and results_overall, but was never
+    # reached because the ui used renderUI() instead of uiOutput() - fixed in #491)
+    choicevec <- names(testoutput_ejamit_10pts_1miles$results_bysite)
+    choicelabels <- fixcolnames(choicevec, 'r', 'short')
+    choicelabels[is.na(choicelabels)] <- choicevec[is.na(choicelabels)]
 
     shiny::selectInput("bysite_webtable_colnames",
                        label = "Columns to show in interactive table",
                        multiple = TRUE,
-                       ### shows ALL available if this input is  NULL
-                       # choices = names(testoutput_ejamit_10pts_1miles$results_overall), # simpler
-                       choices = choicelist
-                       # comment out selected to start with none picked.
-                       , selected <- global_or_param("default_bysite_webtable_colnames")
+                       choices = stats::setNames(choicevec, choicelabels),
+                       # starts as the default subset; if emptied, the server falls
+                       # back to that same default subset
+                       selected = global_or_param("default_bysite_webtable_colnames")
     )
   })
 

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -1412,8 +1412,10 @@ app_ui <- function(request) {
 
                  # sitereport_download_buttons_colname = "Download EJAM Report", # input$sitereport_download_buttons_colname
                  shiny::textInput("sitereport_download_buttons_colname",
-                                  label = "Name of column of uttons that download 1-site report per row",
-                                  value = global_or_param("sitereport_download_buttons_show")),
+                                  label = "Name of column of buttons that download 1-site report per row",
+                                  # was bound to ..._show (a logical), so the field said "FALSE"
+                                  # and enabling the buttons named the column "FALSE" (#491)
+                                  value = global_or_param("sitereport_download_buttons_colname")),
 
                  checkboxInput("sitereport_download_buttons_show",
                                label = "Show column of buttons that download 1-site report per row",

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -1404,7 +1404,9 @@ app_ui <- function(request) {
                  ### By-site interactive table of results ####
                  h3("By-site interactive table of results"),
 
-                 shiny::renderUI("bysite_webtable_colnames_ui"),
+                 # uiOutput (not renderUI, which is server-side and rendered nothing here)
+                 # displays the column picker for the site-by-site table (#491)
+                 shiny::uiOutput("bysite_webtable_colnames_ui"),
 
                  # default_reports is not adjustable here-  changing this in advance tab is complicated since it is a list of functions, etc.
 

--- a/R/create_interactive_table.R
+++ b/R/create_interactive_table.R
@@ -64,22 +64,22 @@ create_interactive_table <- function(out,
   ## BUTTONS for 1-site reports ####
 
   if (sitereport_download_buttons_show) {
-  # function to create shiny UI buttons, one per row (site), to download 1-site report for given site
-  shinyInputmaker <- function(FUN, len, id, ...) {
-    inputs <- character(len)
-    for (i in seq_len(len)) {
-      inputs[i] <- as.character(FUN(id[i], ...))
-    }
-    inputs
-  }
-  index <- 1:NROW(x)
-  buttoncolumn <- shinyInputmaker(
-    FUN = shiny::actionButton,
-    len = length(index),
-    id = paste0('button_', index),
+  # One shiny UI button per row (site), to download the 1-site report for that site.
+  # Rendering a shiny::actionButton() tag per row was a big part of why this table
+  # was slow to appear for analyses with many sites (issue #127), so render the tag
+  # only once, with placeholder tokens, and fill in each row's id and onclick via
+  # string substitution, which produces exactly the same HTML.
+  index <- seq_len(NROW(x))
+  button_template <- as.character(shiny::actionButton(
+    "EJAMROWIDTOKEN",
     label = "Download",
-    onclick = paste0('Shiny.onInputChange(\"single_site_report_button', index,'\", this.id)' )
-  )
+    onclick = 'Shiny.onInputChange(\"single_site_report_buttonEJAMROWNUMTOKEN\", this.id)'
+  ))
+  buttoncolumn <- vapply(index, function(i) {
+    gsub("EJAMROWNUMTOKEN", i,
+         gsub("EJAMROWIDTOKEN", paste0("button_", i), button_template, fixed = TRUE),
+         fixed = TRUE)
+  }, character(1))
   x$buttoncolumn <- buttoncolumn
   x <- dplyr::relocate(x, buttoncolumn)  # will be second column
   names(x) <- gsub("buttoncolumn", sitereport_download_buttons_colname, names(x))

--- a/R/ejam2tableviewer.R
+++ b/R/ejam2tableviewer.R
@@ -78,7 +78,9 @@ ejam2tableviewer = function(out, filename = 'automatic', maxrows = 1000, launch_
 
                            ## freeze header row when scrolling down
                            fixedHeader = TRUE,
-                           pageLength = 100,
+                           # 50 rows/page renders about 2x faster than 100 for wide
+                           # tables (#127 / #491); users can pick 100 from the length menu
+                           pageLength = 50,
                            ## set scroll height up and down
                            scrollY = '500px',
 

--- a/R/table_round.R
+++ b/R/table_round.R
@@ -55,7 +55,16 @@ table_round <- function(x, var = names(x), varnametype="rname", ...) {
 
   } else {
     # table, not  a vector
-    if (data.table::is.data.table(x)) {data.table::setDF(x); wasdt <- TRUE} else {wasdt <- FALSE}
+    if (data.table::is.data.table(x)) {
+      # work on a plain data.frame copy, so the caller's data.table is never
+      # converted or altered by reference (setDF() here used to leak: the
+      # caller's object was left as a data.frame, and this function returned
+      # a data.frame instead of a data.table)
+      x <- as.data.frame(x)
+      wasdt <- TRUE
+    } else {
+      wasdt <- FALSE
+    }
 
     # Round each roundable column in place, one at a time.
     # (Assigning via x[ , roundable][ , i] <- ... copied the whole roundable

--- a/R/table_round.R
+++ b/R/table_round.R
@@ -57,8 +57,19 @@ table_round <- function(x, var = names(x), varnametype="rname", ...) {
     # table, not  a vector
     if (data.table::is.data.table(x)) {data.table::setDF(x); wasdt <- TRUE} else {wasdt <- FALSE}
 
-    for (i in 1:sum(roundable)) {
-      x[ , roundable][ , i] <- round(x[ , roundable][ , i], dig[roundable][i])
+    # Round each roundable column in place, one at a time.
+    # (Assigning via x[ , roundable][ , i] <- ... copied the whole roundable
+    # subset of the table on every iteration, which took over half a second
+    # for a wide table like ejamit()$results_bysite regardless of row count.)
+    if (is.data.frame(x)) {
+      for (i in which(roundable)) {
+        x[[i]] <- round(x[[i]], dig[i])
+      }
+    } else {
+      # e.g., a matrix
+      for (i in which(roundable)) {
+        x[ , i] <- round(x[ , i], dig[i])
+      }
     }
     if (wasdt) {data.table::setDT(x)}
     return(x)

--- a/R/table_signif.R
+++ b/R/table_signif.R
@@ -35,12 +35,17 @@ table_signif <- function(dat, digits = NULL) {
   }
 
   signifarray.api <- function(dat, digits = NULL) {
-    if (!(is.data.frame(dat))) {dat <- as.data.frame(dat)}
+    # work on a plain data.frame (a copy, so a data.table input is never
+    # altered by reference) since the subset-assignment below relies on
+    # data.frame semantics, then return the same class that came in
+    wasdt <- data.table::is.data.table(dat)
+    if (wasdt || !is.data.frame(dat)) {dat <- as.data.frame(dat)}
     if (length(digits) != NCOL(dat)) {
       if (length(digits) == 1) {
         digits <- rep(digits, NCOL(dat))
       } else {
         warning("length of digits parameter does not match number of columns in dat. cannot set significant digits.")
+        if (wasdt) {data.table::setDT(dat)}
         return(dat)
       }
     }
@@ -48,6 +53,7 @@ table_signif <- function(dat, digits = NULL) {
     digits[!is.numericish(dat)] <- NA
     dat[,!is.na(digits)] <- mapply(FUN = signif, x = dat[,!is.na(digits)], digits = digits[!is.na(digits)])
     # dat <- mapply(FUN = signif, x = dat, digits = digits)
+    if (wasdt) {data.table::setDT(dat)}
     return(dat)
   }
 

--- a/R/table_signif.R
+++ b/R/table_signif.R
@@ -37,7 +37,8 @@ table_signif <- function(dat, digits = NULL) {
   signifarray.api <- function(dat, digits = NULL) {
     # work on a plain data.frame (a copy, so a data.table input is never
     # altered by reference) since the subset-assignment below relies on
-    # data.frame semantics, then return the same class that came in
+    # data.frame semantics; a data.table in gets a data.table back, while
+    # any other input (matrix, etc.) is returned as a data.frame, as before
     wasdt <- data.table::is.data.table(dat)
     if (wasdt || !is.data.frame(dat)) {dat <- as.data.frame(dat)}
     if (length(digits) != NCOL(dat)) {

--- a/R/table_x100.R
+++ b/R/table_x100.R
@@ -71,7 +71,12 @@ table_x100 <- function(df, cnames = names_pct_as_fraction_ejamit
     #
     # df[ , (tofix) := lapply(.SD, function(z) z * 100), .SDcols = tofix]
 
-    setDF(df)
+    # work on a plain data.frame copy: setDF(df) here used to convert the
+    # CALLER's data.table to a data.frame by reference and never restore it
+    # (e.g., rendering map popups silently changed the class of the app's
+    # results_bysite), because the subset-assignment below broke the
+    # reference before the restoring setDT() ran
+    df <- as.data.frame(df)
     df[ , tofix] <- df[ , tofix] * 100
     setDT(df)
     return(df)

--- a/R/test_ejam.R
+++ b/R/test_ejam.R
@@ -411,6 +411,7 @@ instead of tests/testthat/_logs
         "test-plot_vs_us.R",
 
         "test-create_interactive_table.R",
+        "test-table_round.R",
         "test-shinytest2-app-dir.R",
         "test-map_headernames-report-ratio-metadata.R"
       ),
@@ -604,7 +605,7 @@ and all filenames listed there actually exist as in that folder called `test`.\n
               "test-test2.R", "test-URL_FUNCTIONS_part1.R", "test-URL_FUNCTIONS_part2.R",
               "test-ejamapi.R", "test-url_columns_bysite.R", "test-url_ejamapi.R",
               "test-url_package.R", "test-ejam2boxplot_ratios.R", "test-shiny-1-14-compat.R",
-              "test-build_community_report.R"),
+              "test-build_community_report.R", "test-table_round.R"),
           seconds_byfile =
             c(0, 0, 0, 0, 0, 0, 0,
               0, 0, 2, 0, 1, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 6, 0, 0, 0,
@@ -612,9 +613,10 @@ and all filenames listed there actually exist as in that folder called `test`.\n
               39, 0, 11, 11, 0, 5, 32, 5, 0, 5, 0, 2, 0, 140, 2, 8, 0, 3, 2,
               23, 0, 7, 0, 12, 0, 4, 5, 1, 0, 3, 0, 3, 0, 0, 0, 0, 1, 0, 4,
               2, 0, 0, 0, 0, 1, 0, 0, 16, 8, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
-              0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 12, 0, 4, 0, 0, 0, 0, 1)),
+              0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 12, 0, 4, 0, 0, 0, 0, 1,
+              1)),
           row.names = c(NA,
-                        -127L), class = "data.frame")
+                        -128L), class = "data.frame")
       )
 
 

--- a/R/utils_is.numericish.R
+++ b/R/utils_is.numericish.R
@@ -60,22 +60,26 @@ is.numericish <- function(
   } else {
     # table not vector
 
-    if (data.table::is.data.table(x)) {data.table::setDF(x); wasdt <- TRUE} else {wasdt <- FALSE}
+    # Check one column at a time, without converting x.
+    # (This used to setDF() a data.table input, which leaked out: the caller's
+    # object was converted to a data.frame by reference and never restored,
+    # because the copy made while replacing NA values broke the reference
+    # before the restoring setDT() ran.)
 
     answer <- vector(length = NCOL(x))
 
-    # if it is just NA, treat it as potentially a number.
-    x[is.na(x)] <- 0 # this works cell by cell in a table, faster than in loop
     for (i in 1:NCOL(x)) {
-
+      # x[[i]] gets the column from a data.frame or data.table; a matrix needs x[ , i]
+      coli <- if (is.data.frame(x)) x[[i]] else x[ , i]
+      # if it is just NA, treat it as potentially a number.
+      coli[is.na(coli)] <- 0
       answer[i] <-  all(suppressWarnings(
-        !is.na(as.numeric(x[,i]))
-        # x[ , i] == as.numeric(x[ , i]) # this way had trouble with trailing zeroes
+        !is.na(as.numeric(coli))
+        # coli == as.numeric(coli) # this way had trouble with trailing zeroes
         ))
       # answer[i][is.na(answer[i])] <- FALSE
     }
 
-    if (wasdt) {data.table::setDT(x)}
     return(answer)
   }
 

--- a/tests/testthat/test-create_interactive_table.R
+++ b/tests/testthat/test-create_interactive_table.R
@@ -27,3 +27,42 @@ test_that("create_interactive_table does not mutate results_bysite by reference"
   expect_s3_class(interactive_table, "datatables")
   expect_true(data.table::is.data.table(out$results_bysite))
 })
+
+test_that("download-button column HTML matches rendering a shiny::actionButton() per row", {
+  # The button column is built from a single rendered actionButton template with
+  # per-row string substitution (much faster for many sites, issue #127).
+  # This test keeps that template in sync with whatever HTML shiny currently
+  # produces, by comparing against the straightforward one-button-per-row way.
+  env <- new.env(parent = emptyenv())
+  data("testoutput_ejamit_10pts_1miles", package = "EJAM", envir = env)
+  out <- get("testoutput_ejamit_10pts_1miles", envir = env, inherits = FALSE)
+
+  local_mocked_bindings(
+    saveWidget = function(widget, file, ...) {
+      writeLines("<html></html>", file)
+      invisible(file)
+    },
+    .package = "htmlwidgets"
+  )
+
+  interactive_table <- EJAM:::create_interactive_table(
+    out = out,
+    # keep lat/lon so ejam2tableviewer() can infer sitetype without a warning
+    columns_used = c("ejam_uniq_id", "lat", "lon", "pop", "statename")
+  )
+
+  shown <- interactive_table$x$data
+  expect_true("Download EJAM Report" %in% names(shown))
+  buttoncol <- shown[["Download EJAM Report"]]
+  n <- NROW(out$results_bysite)
+  expect_length(buttoncol, n)
+
+  expected <- vapply(seq_len(n), function(i) {
+    as.character(shiny::actionButton(
+      paste0("button_", i),
+      label = "Download",
+      onclick = paste0('Shiny.onInputChange(\"single_site_report_button', i, '\", this.id)')
+    ))
+  }, character(1))
+  expect_identical(as.character(buttoncol), expected)
+})

--- a/tests/testthat/test-create_interactive_table.R
+++ b/tests/testthat/test-create_interactive_table.R
@@ -66,3 +66,46 @@ test_that("download-button column HTML matches rendering a shiny::actionButton()
   }, character(1))
   expect_identical(as.character(buttoncol), expected)
 })
+
+test_that("faster table defaults from #491: pageLength 50, and the default column subset is usable", {
+  env <- new.env(parent = emptyenv())
+  data("testoutput_ejamit_10pts_1miles", package = "EJAM", envir = env)
+  out <- get("testoutput_ejamit_10pts_1miles", envir = env, inherits = FALSE)
+
+  local_mocked_bindings(
+    saveWidget = function(widget, file, ...) {
+      writeLines("<html></html>", file)
+      invisible(file)
+    },
+    .package = "htmlwidgets"
+  )
+
+  # the app's server falls back to this subset when the user has not picked columns.
+  # (in the running app global_or_param() reads it from golem options, which are
+  # populated at launch from the same defaults assembled here)
+  opts_before <- options()
+  gopts <- EJAM:::get_global_defaults_or_user_options(
+    user_specified_options = list(), bookmarking_allowed = "disable"
+  )
+  # undo the options that assembling the defaults sets as a side effect
+  # (shiny.*, spinner.*), so this test leaves global state unchanged
+  opts_added <- setdiff(names(options()), names(opts_before))
+  if (length(opts_added) > 0) {
+    do.call(options, stats::setNames(vector("list", length(opts_added)), opts_added))
+  }
+  options(opts_before)
+  default_cols <- gopts$default_bysite_webtable_colnames
+  expect_true(is.character(default_cols) && length(default_cols) > 10)
+  expect_true(all(default_cols %in% names(out$results_bysite)))
+
+  tbl <- EJAM:::create_interactive_table(
+    out = out,
+    columns_used = default_cols,
+    sitereport_download_buttons_show = FALSE
+  )
+  expect_equal(tbl$x$options$pageLength, 50)
+  shown_cols <- ncol(tbl$x$data)
+  # the subset (plus the few summary columns bound on) - nowhere near the ~700 total
+  expect_gt(shown_cols, 40)
+  expect_lt(shown_cols, length(default_cols) + 10)
+})

--- a/tests/testthat/test-is.numericish.R
+++ b/tests/testthat/test-is.numericish.R
@@ -69,3 +69,16 @@ test_that("is.numericish ok for data.frame", {
      all(x[,6:7] == FALSE)
    )
 })
+
+test_that("is.numericish does not alter a data.table input, and matches the data.frame result", {
+  # it used to setDF() a data.table input by reference and never restore it
+  # (the caller's object was left as a data.frame)
+  df <- data.frame(a = c(1.5, NA, 3), b = c("x", "", "z"), c = c("08", "1.90", NA),
+                   stringsAsFactors = FALSE)
+  dt <- data.table::as.data.table(df)
+  snapshot <- data.table::copy(dt)
+
+  expect_identical(is.numericish(dt), is.numericish(df))
+  expect_true(data.table::is.data.table(dt))
+  expect_identical(dt, snapshot)
+})

--- a/tests/testthat/test-table_round.R
+++ b/tests/testthat/test-table_round.R
@@ -1,0 +1,59 @@
+## unit tests for table_round()
+## (rewritten for speed for issue #127 - these tests pin down the contract:
+##  each roundable column is rounded to its per-column digits from
+##  table_rounding_info(), everything else is untouched)
+
+test_that("table_round rounds each roundable column of a wide results_bysite table correctly", {
+  env <- new.env(parent = emptyenv())
+  data("testoutput_ejamit_10pts_1miles", package = "EJAM", envir = env)
+  out <- get("testoutput_ejamit_10pts_1miles", envir = env, inherits = FALSE)
+  x <- as.data.frame(out$results_bysite)
+
+  result <- EJAM:::table_round(x)
+
+  # reference: the same rounding rules applied independently, column by column
+  dig <- EJAM:::table_rounding_info(var = names(x), varnametype = "rname")
+  roundable <- EJAM:::is.numericish(x)
+  roundable[is.na(dig)] <- FALSE
+  expected <- x
+  for (i in which(roundable)) {
+    expected[[i]] <- round(expected[[i]], dig[i])
+  }
+
+  expect_identical(result, expected)
+  # something was actually rounded, and non-roundable columns are untouched
+  expect_gt(sum(roundable), 0)
+  expect_identical(result[!roundable], x[!roundable])
+  expect_identical(dim(result), dim(x))
+  expect_identical(names(result), names(x))
+})
+
+test_that("table_round on a data.table gives the same values as on a data.frame", {
+  env <- new.env(parent = emptyenv())
+  data("testoutput_ejamit_10pts_1miles", package = "EJAM", envir = env)
+  out <- get("testoutput_ejamit_10pts_1miles", envir = env, inherits = FALSE)
+  df <- as.data.frame(out$results_bysite)
+
+  from_df <- EJAM:::table_round(df)
+  from_dt <- EJAM:::table_round(data.table::as.data.table(df))
+
+  expect_identical(as.data.frame(from_dt), from_df)
+})
+
+test_that("table_round works on a vector", {
+  v <- c(12.123456, 9, NA)
+  dig <- EJAM:::table_rounding_info(var = "pm", varnametype = "rname")
+  expect_identical(EJAM:::table_round(v, "pm"), round(v, dig))
+})
+
+test_that("table_round works on a matrix", {
+  m <- matrix(c(12.123456, 9.87654, 1.234567, 2.345678), nrow = 2,
+              dimnames = list(NULL, c("pm", "o3")))
+  result <- EJAM:::table_round(m, var = colnames(m))
+  dig <- EJAM:::table_rounding_info(var = colnames(m), varnametype = "rname")
+  expected <- m
+  for (i in seq_along(dig)) {
+    expected[, i] <- round(expected[, i], dig[i])
+  }
+  expect_identical(result, expected)
+})

--- a/tests/testthat/test-table_round.R
+++ b/tests/testthat/test-table_round.R
@@ -28,16 +28,47 @@ test_that("table_round rounds each roundable column of a wide results_bysite tab
   expect_identical(names(result), names(x))
 })
 
-test_that("table_round on a data.table gives the same values as on a data.frame", {
+test_that("table_round on a data.table: same values, returns a data.table, caller untouched", {
   env <- new.env(parent = emptyenv())
   data("testoutput_ejamit_10pts_1miles", package = "EJAM", envir = env)
   out <- get("testoutput_ejamit_10pts_1miles", envir = env, inherits = FALSE)
   df <- as.data.frame(out$results_bysite)
 
   from_df <- EJAM:::table_round(df)
-  from_dt <- EJAM:::table_round(data.table::as.data.table(df))
+  dt_in <- data.table::as.data.table(df)
+  snapshot <- data.table::copy(dt_in)
+  from_dt <- EJAM:::table_round(dt_in)
 
   expect_identical(as.data.frame(from_dt), from_df)
+  # a data.table in gives a data.table back (it used to fall back to data.frame
+  # by accident, via a setDF() side effect inside is.numericish())
+  expect_true(data.table::is.data.table(from_dt))
+  # and the caller's object is not converted or altered by reference
+  expect_true(data.table::is.data.table(dt_in))
+  expect_identical(dt_in, snapshot)
+})
+
+test_that("table_x100, table_signif, and the table_signif_round_x100 chain are also data.table-stable", {
+  # same contract as table_round for the rest of the rounding-helper family:
+  # data.table in -> data.table back, same values as the data.frame path,
+  # and never convert or modify the caller's object by reference
+  env <- new.env(parent = emptyenv())
+  data("testoutput_ejamit_10pts_1miles", package = "EJAM", envir = env)
+  out <- get("testoutput_ejamit_10pts_1miles", envir = env, inherits = FALSE)
+  df <- as.data.frame(out$results_bysite)
+
+  for (fname in c("table_x100", "table_signif", "table_signif_round_x100")) {
+    f <- get(fname, envir = asNamespace("EJAM"))
+    from_df <- f(df)
+    dt_in <- data.table::as.data.table(df)
+    snapshot <- data.table::copy(dt_in)
+    from_dt <- f(dt_in)
+
+    expect_identical(as.data.frame(from_dt), as.data.frame(from_df), label = fname)
+    expect_true(data.table::is.data.table(from_dt), label = paste(fname, "returns data.table"))
+    expect_true(data.table::is.data.table(dt_in), label = paste(fname, "caller class"))
+    expect_identical(dt_in, snapshot, label = paste(fname, "caller values"))
+  }
 })
 
 test_that("table_round works on a vector", {


### PR DESCRIPTION
## Summary

Fixes Public-Environmental-Data-Partners/EJAM#127 (web app Details tab / Site-by-Site Table too sluggish when first viewed). Click → table painted drops from **~7.0 s to ~0.33 s** for a 1,000-site analysis, via two rounds of changes: behavior-preserving server-side fixes (byte-identical output), then two **deliberate UX-default changes chosen by Mark after measurement** (default column subset + 50 rows/page). Also makes the rounding-helper family data.table-safe, and repairs two advanced-tab controls that had never worked.

**Answering the question in the issue** ("is it the url-generating functions?"): no — the URL/link columns are created during `ejamit()` (analysis time), not when the tab is clicked.

## Changes

### Round 1 — server-side speedups (output byte-identical)

| Tab-click step | Before | After |
|---|---|---|
| per-row `shiny::actionButton()` rendering | ~1.0 s per 1,000 sites (85.7 s for 10,000 sites with the buttons option on) | ~0.01 s |
| `table_round()` column loop | ~0.54 s regardless of row count | ~0.01 s |
| `DT::datatable(filter='top', ...)` | ~0.4 s | ~0.4 s (unchanged; filter-row tag rendering) |

1. **`R/table_round.R`** — the loop assigned via `x[ , roundable][ , i] <- ...`, copying the entire ~640-column roundable subset on every iteration (O(columns²)). Now each column is rounded in place, matrix fallback preserved. Also speeds up `popup_from_ejscreen()` (map popups), `ejam2means()`, `ejam2table_tall()`.
2. **`R/create_interactive_table.R`** — the per-site Download button column rendered an `actionButton()` tag per row; now one rendered template with per-row `gsub()`, byte-identical HTML (asserted by a test that re-renders real `actionButton()`s for comparison).

### Round 2 — data.table safety in the rounding helpers (review request)

3. **`table_round()`, `table_signif()`, `table_x100()`, `is.numericish()`** — all four used a `setDF()` on the shared input object; the caller's data.table was converted to data.frame by reference (never restored, because a later copy broke the reference before the restoring `setDT()`), and `table_round()`/`table_signif()` returned data.frames. All four now leave the caller's object untouched and return a data.table when given one, with values verified cell-for-cell identical against the old implementations (points/FIPS/shapes × data.frame/data.table, plus vector/matrix paths and end-to-end `popup_from_ejscreen()` output). Note `popup_from_ejscreen()` itself was never affected — it copies its input up front; only direct callers of the helpers saw the side effect.

### Round 3 — UX defaults chosen from the benchmarks (review request; **user-visible changes**)

4. **Default column subset**: the table now starts from `default_bysite_webtable_colnames` (52 columns) instead of all ~700. `app_server.R` falls back to that global whenever the picker input is empty (`length() == 0`, covering both NULL and a fully cleared picker). Measured: 6.4 s → **0.33 s** click→painted for 1,000 sites.
5. **`pageLength = 50`** (was 100) in `ejam2tableviewer()`; the length menu still offers 100.
6. **Advanced-tab repairs**: the column picker had never rendered (`renderUI()` used in the UI where `uiOutput()` belongs; its server block also referenced an undefined object and would have errored on first render) — fixed, choices now from `results_bysite` names with short labels, default subset preselected. The button-column-name field was bound to the wrong global (displayed "FALSE", and would have named the button column "FALSE") — rebound, label typo fixed.

## Benchmarks (details in PR comments)

- Server-side table build, old → new: 1,000 sites 1.10 → 0.47 s (buttons off, the deployed default); 10,000 sites with buttons on **85.7 → 0.52 s** (the old per-row button loop ran before the 1,000-row display cap).
- Browser (headless Chrome, real `renderDT(server=TRUE)` path, click → painted, median of 3): all-columns baseline 6.4 s; column subset 0.36 s (−94%); pageLength=25 2.7 s; autoWidth=FALSE −6%; no-filter-row −19%. New defaults as shipped: **0.33 s**.
- The table displays at most the first 1,000 rows (`ejam2tableviewer(maxrows=)` default), so a 10,000-site analysis renders the same DOM as a 1,000-site one.

## Tests

New `tests/testthat/test-table_round.R` (rounding contract + data.table type-stability for the whole helper family; registered in `R/test_ejam.R` group list + timing per repo convention); `test-create_interactive_table.R` extended (button-HTML equivalence, pageLength 50, default-subset validity); `test-is.numericish.R` extended (no caller mutation). Local: 49 pass / 0 fail across the three table test files; `test-MAP_FUNCTIONS.R` 81 pass; `test-webapp-ui_and_server.R` 75 pass.

## Notes

- `fixedHeader = TRUE` in the DT options is a no-op (FixedHeader extension not loaded) — harmless, left as is.
- Release reminder: per the branching model, restate `Fixes #127` in the dev→main sync PR body so the issue auto-closes on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
