### PR TITLE
Deploy (PROD): pin EJAM v3.2022.2, switch AOI to ericnost fork, update deploy-workflow actions

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -26,10 +26,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,11 +38,11 @@ jobs:
 
       # ── Checkout ───────────────────────────
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # ── AWS Credentials ────────────────────
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           # Option A: Access keys (store in repo/org secrets)
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,16 @@ RUN curl -fsSL https://dl.google.com/linux/direct/google-chrome-stable_current_a
 RUN printf '#!/bin/bash\nexec /usr/bin/google-chrome-stable --no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage "$@"\n' \
     > /usr/local/bin/chrome-wrapper && chmod +x /usr/local/bin/chrome-wrapper
 
-# Point chromote/pagedown/webshot2 at the wrapper
+# Point chromote/webshot2 (report map snapshot) AND pagedown (chrome_print, the
+# PDF conversion) at the wrapper. Both env vars are needed and are read by
+# different tools: chromote uses CHROMOTE_CHROME, pagedown uses PAGEDOWN_CHROME.
+# Without PAGEDOWN_CHROME, pagedown::chrome_print() finds the raw
+# /usr/bin/google-chrome-stable via its own find_chrome() and launches it WITHOUT
+# --no-sandbox, so Chrome (running as root in the container) refuses to start and
+# the PDF fails with "Cannot find headless Chrome after 20 attempts". The wrapper
+# adds --no-sandbox / --disable-dev-shm-usage so Chrome starts.
 ENV CHROMOTE_CHROME=/usr/local/bin/chrome-wrapper
+ENV PAGEDOWN_CHROME=/usr/local/bin/chrome-wrapper
 
 # Install AWS CLI v2
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ARG GITHUB_PAT
 # EJAM-API image's EJAM_VERSION build-arg so both deploys pin EJAM the same way,
 # and makes the deployed version EXPLICIT (rather than implicitly tied to whatever
 # source happens to be checked out on this deploy branch).
-ARG EJAM_VERSION=v3.2022.1
+ARG EJAM_VERSION=v3.2022.2
 ENV EJAM_VERSION=${EJAM_VERSION}
 
 WORKDIR /root
@@ -139,7 +139,7 @@ RUN install2.r --error \
     && rm -rf /tmp/downloaded_packages /tmp/*.rds
 
 # GitHub packages
-RUN R -e "remotes::install_github('mikejohnson51/AOI')" && \
+RUN R -e "remotes::install_github('ericnost/AOI')" && \
     R -e "remotes::install_github('hrbrmstr/hrbrthemes')" && \
     rm -rf /tmp/downloaded_packages /tmp/*.rds
 
@@ -155,7 +155,7 @@ RUN R -e "remotes::install_github(paste0('Public-Environmental-Data-Partners/EJA
 # Download ejamdata arrow files from GitHub release
 # Must run AFTER the EJAM package install so the data/ folder is not overwritten by the installer
 # EJAMDATA_VERSION: pinned by default to v3.2022.0 -- the ejamdata release that
-#   EJAM v3.2022.1 requires (its DESCRIPTION `ejamdata_required_tag`). Keep this in
+#   EJAM v3.2022.2 requires (its DESCRIPTION `ejamdata_required_tag`). Keep this in
 #   sync with EJAM_VERSION when bumping releases; override with
 #   --build-arg EJAMDATA_VERSION=vX.Y.Z. (An explicit empty string falls back to the
 #   latest ejamdata release via the GitHub API below.)

--- a/data-raw/run_refresh_s3_outputs_safe_sequence.R
+++ b/data-raw/run_refresh_s3_outputs_safe_sequence.R
@@ -23,7 +23,16 @@
 #   These settings do not replace package data, do not run datacreate_ package
 #   data scripts, do not update FRS, and do not publish release assets.
 
-repo_dir <- "/Users/markcorrales/R PACKAGES/EJAM"
+# Path to the EJAM source package folder. Defaults to the working directory, so
+# source this file from the EJAM source folder - the same convention the
+# datacreate_ scripts use. Set EJAM_REPO_DIR to run it from somewhere else.
+repo_dir <- Sys.getenv("EJAM_REPO_DIR", unset = getwd())
+if (!file.exists(file.path(repo_dir, "DESCRIPTION")) ||
+    desc::desc_get(file = file.path(repo_dir, "DESCRIPTION"), keys = "Package") != "EJAM") {
+  stop("repo_dir must be the EJAM source package folder, but '", repo_dir,
+       "' does not look like one. Source this from the EJAM source folder, ",
+       "or set the EJAM_REPO_DIR environment variable.")
+}
 s3_pipeline_root <- "s3://pedp-data-preserved/ejscreen-data-processing/pipeline"
 epa_acs22_reference_dir <- file.path(
   s3_pipeline_root,

--- a/ejam-infra/main.tf
+++ b/ejam-infra/main.tf
@@ -285,6 +285,24 @@ resource "aws_lb_target_group" "app" {
     matcher             = "200"
   }
 
+  # Keep each user pinned to one container for the life of their visit.
+  #
+  # Shiny keeps session state in the memory of a single R process, and a file
+  # upload arrives as a SEPARATE HTTP POST from the page load. Without this,
+  # the load balancer round-robins that POST to the other container, which has
+  # never heard of the session and answers 404 "<h1>Not Found</h1>" -- rendered
+  # unescaped in the app's red upload bar. See EJAM#268.
+  #
+  # This must stay in Terraform: the same fix was applied by hand in the AWS
+  # console in Feb 2026, was never codified here, and was silently lost.
+  # Only matters where desired_count > 1 (prod is 2, dev is 1), but it is set
+  # for both so dev cannot drift away from prod behavior.
+  stickiness {
+    type            = "lb_cookie"
+    enabled         = true
+    cookie_duration = 86400 # seconds (1 day); ALB max is 604800
+  }
+
   tags = { Name = "${local.name_prefix}-tg" }
 }
 


### PR DESCRIPTION
## 🛑 DRAFT — merging this deploys to PRODUCTION

`deploy.yaml` runs on any push to `prod-deploy` and builds + deploys to **`ejam-prod-cluster` / `ejam-prod-service`** (the live app). There is no gate between merge and production.

**Merge only after both:**
1. the **`v3.2022.2` release tag exists** on `main` — the image installs `EJAM@${EJAM_VERSION}` from GitHub, so an absent tag fails the build; and
2. **[#493](https://github.com/Public-Environmental-Data-Partners/EJAM/pull/493) has been merged and the dev app verified.**

Kept as a draft deliberately so it can't be merged by accident.

## 📦 Now also carries the prod stickiness fix (folded in from #516)

`ejam-infra/main.tf` — the 18-line `stickiness` block that was previously its own PR (#516), cherry-picked here **byte-identical** (commit `3ce892b7` → `dc083713`, `git diff` on `main.tf` is empty).

**Why fold it in:** every push to `prod-deploy` rebuilds the image and force-redeploys the live ECS service. Merging #516 separately would spend a second full production rebuild (~30–60 min) to add 18 lines of Terraform that do not affect the image at all. One merge, one rebuild.

**#516 is now redundant** and has been marked a draft; nothing needs to be merged from it.

⚠️ Merging this does **not** enable stickiness. No workflow in this repo runs Terraform (the only mention in `.github/workflows` is an error-message hint at `deploy-dev.yaml:123`). @Gabe-Epic still has to run `terraform apply` by hand afterwards — and must **not** run it before this merges, or the apply will read his console toggle as drift and switch stickiness back off. See #514 for the full instructions.


## What changed in the image — identical to #493

Cherry-picked from #493's branch; the touched files were byte-identical between `dev-deploy` and `prod-deploy` beforehand, and are byte-identical to #493's versions afterward (verified). The Dockerfile also sets **`PAGEDOWN_CHROME`** (line 40), which is the fix for the production multisite-PDF 500 — `prod-deploy` currently sets only `CHROMOTE_CHROME`, which is why prod PDFs fail and dev PDFs work. Nothing tests this automatically (see #510), so **download a multisite PDF by hand after the redeploy.**

### `Dockerfile`

| Line | Before | After |
|---|---|---|
| 47 | `ARG EJAM_VERSION=v3.2022.1` | `ARG EJAM_VERSION=v3.2022.2` |
| 142 | `install_github('mikejohnson51/AOI')` | `install_github('ericnost/AOI')` |
| 158 | comment: "EJAM v3.2022.1 requires" | comment: "EJAM v3.2022.2 requires" |

The AOI line was **not** broken before — it matched the pin. v3.2022.1 declares `mikejohnson51/AOI`; v3.2022.2 declares `ericnost/AOI` (switched in #478). Changing either alone creates a mismatch, so they move together.

`EJAMDATA_VERSION` correctly stays **v3.2022.0** — both releases declare that `ejamdata_required_tag`; only the comment changed.

### `deploy-dev.yaml` + `deploy.yaml`

These exist **only on the deploy branches**, so the Node 24 updates (#480 → development, #481 → main) never reached them — yet they're the only workflows that run here.

| Action | Before | After | Why |
|---|---|---|---|
| `actions/checkout` | `v4` (node20) | `v7` (node24) | latest major v7.0.1; matches main |
| `aws-actions/configure-aws-credentials` | `v4` (node20) | `v6` (node24) | latest major v6.2.3; matches main |
| `aws-actions/amazon-ecr-login` | `v2` | **unchanged** | already node24; v2 is current (v2.1.6) |

Runtimes read from each action's `action.yml`, not assumed. Both files re-validated as parseable YAML, and `deploy.yaml` still targets `ejam-prod-cluster` / `ejam-prod-service`.

## Base

Branched from and targeting **`prod-deploy`** — deploy-branch-local config only, so the diff stays at 7 lines instead of dragging source history across.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
