### PR TITLE
dev-deploy: switch AOI pre-install to the ericnost fork (port of #478)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,7 @@ RUN install2.r --error \
     && rm -rf /tmp/downloaded_packages /tmp/*.rds
 
 # GitHub packages
-RUN R -e "remotes::install_github('mikejohnson51/AOI')" && \
+RUN R -e "remotes::install_github('ericnost/AOI')" && \
     R -e "remotes::install_github('hrbrmstr/hrbrthemes')" && \
     rm -rf /tmp/downloaded_packages /tmp/*.rds
 


### PR DESCRIPTION
One line: the Dockerfile's AOI pre-install now uses **`ericnost/AOI`**, matching what EJAM's DESCRIPTION has declared in `Remotes:` since #478 (and what v3.2022.2 will require).

## Why now

Testing the release candidate on dev (via #496's `ejam_version` dispatch input, e.g. `development`) would otherwise run against the **old `mikejohnson51/AOI` fork**: the Dockerfile pre-installs AOI *before* installing EJAM, and `remotes` won't reinstall an already-present package — so the RC's `Remotes:` declaration never takes effect in the image. This makes today's RC test faithful without waiting for the tag.

## Scope guard

- `EJAM_VERSION` pin **untouched** (still `v3.2022.1`) — the bump to v3.2022.2 stays in #493, which must wait for the tag.
- ⚠️ Merging this pushes to `dev-deploy` → auto-deploys the **pinned v3.2022.1** with the new AOI fork to the **dev server only**. Both forks work with v3.2022.1, so that interim deploy is safe (and will be superseded by the RC dispatch anyway).
- #493 makes this same change as part of its bundle; git resolves identical changes cleanly, so merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)