### PR TITLE
dev-deploy: fix PDF (PAGEDOWN_CHROME), run full app (isPublic=FALSE), deploy reminder

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -61,6 +61,12 @@ jobs:
         run: |
           FULL_IMAGE=$REGISTRY/$ECR_REPOSITORY
 
+          # Reminder: this DEV image runs the FULL (private) app, ejamapp(isPublic = FALSE),
+          # so RC testing exercises every feature (ratio columns, etc.). PRODUCTION runs
+          # isPublic = TRUE (the streamlined public app). If you want dev to mirror what
+          # end users see, change isPublic in the Dockerfile CMD before deploying.
+          echo "▶ App mode for this deploy: ejamapp(isPublic = FALSE)  [DEV = full/private app; prod = public]"
+
           # Override EJAM_VERSION only for a manual dispatch that named a ref; a plain
           # push (or a blank input) leaves it unset so the Dockerfile's pinned default
           # stays the single source of truth (no fallback duplicated here).

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,16 @@ RUN curl -fsSL https://dl.google.com/linux/direct/google-chrome-stable_current_a
 RUN printf '#!/bin/bash\nexec /usr/bin/google-chrome-stable --no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage "$@"\n' \
     > /usr/local/bin/chrome-wrapper && chmod +x /usr/local/bin/chrome-wrapper
 
-# Point chromote/pagedown/webshot2 at the wrapper
+# Point chromote/webshot2 (report map snapshot) AND pagedown (chrome_print, the
+# PDF conversion) at the wrapper. Both env vars are needed and are read by
+# different tools: chromote uses CHROMOTE_CHROME, pagedown uses PAGEDOWN_CHROME.
+# Without PAGEDOWN_CHROME, pagedown::chrome_print() finds the raw
+# /usr/bin/google-chrome-stable via its own find_chrome() and launches it WITHOUT
+# --no-sandbox, so Chrome (running as root in the container) refuses to start and
+# the PDF fails with "Cannot find headless Chrome after 20 attempts". The wrapper
+# adds --no-sandbox / --disable-dev-shm-usage so Chrome starts.
 ENV CHROMOTE_CHROME=/usr/local/bin/chrome-wrapper
+ENV PAGEDOWN_CHROME=/usr/local/bin/chrome-wrapper
 
 # Install AWS CLI v2
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && \
@@ -182,4 +190,10 @@ WORKDIR /root
 # (calling it here made every ECS task exit 1 with "'run_app' is not an exported
 # object from 'namespace:EJAM'"). ejamapp(isPublic=...) is supported and its
 # options= list is passed to shinyApp() for host/port.
-CMD ["R", "-e", "httpuv::startServer('0.0.0.0', 2001, list(call = function(req) { list(status = 200, body = 'OK', headers = list('Content-Type' = 'text/plain')) })); library(EJAM); EJAM::ejamapp(isPublic = TRUE, options = list(host = '0.0.0.0', port = 2000))"]
+CMD ["R", "-e", "httpuv::startServer('0.0.0.0', 2001, list(call = function(req) { list(status = 200, body = 'OK', headers = list('Content-Type' = 'text/plain')) })); library(EJAM); EJAM::ejamapp(isPublic = FALSE, options = list(host = '0.0.0.0', port = 2000))"]
+
+# NOTE on isPublic: the DEV/staging server runs the FULL (private) app
+# (isPublic = FALSE) so RC testing exercises all features. PRODUCTION
+# (prod-deploy) runs isPublic = TRUE (the streamlined public app most users
+# see). Confirm which mode you want each time you deploy here -- see the
+# reminder in .github/workflows/deploy-dev.yaml.


### PR DESCRIPTION
Fixes reported while testing the v3.2022.2 RC on the dev server. ⚠️ Merging triggers a dev deploy of the pinned version; to test the RC afterward, re-run **Actions → Build & Deploy (dev) → Run workflow → ejam_version = `development`** so the new image is built with these fixes + EJAM@development.

## 1. PDF download failed: "Cannot find headless Chrome after 20 attempts"

**Root cause (not the map delay):** `pagedown::chrome_print()` — the PDF converter — finds Chrome through its *own* `find_chrome()` → raw `/usr/bin/google-chrome-stable`, launched with `--headless` but **no `--no-sandbox`**. As root in the container, Chrome refuses to start without it, so the debug port never opens. The Dockerfile's `CHROMOTE_CHROME` wrapper (which adds `--no-sandbox`) is only read by chromote/webshot2 (the map snapshot), **not** pagedown.

**Fix:** also set `ENV PAGEDOWN_CHROME=/usr/local/bin/chrome-wrapper`, so `chrome_print()` launches Chrome through the same `--no-sandbox` wrapper.

> The same fix is needed on **prod-deploy** — prod PDF is broken for the identical reason. I can add it to #494 or as a separate prod PR.

## 2. Ratio columns & color coding missing → dev ran the public app

The dev container launched `ejamapp(isPublic = TRUE)` (the streamlined public app), where those columns were off. Switched the CMD to **`isPublic = FALSE`** so dev/staging runs the FULL app for RC testing.

(Separately, on `development` I also changed the app *default* so the ratio columns show in **either** mode — commit `d086c91e`, per your request.)

**Note:** prod-deploy still runs `isPublic = TRUE` — the public app is what most end users see.

## 3. isPublic deploy reminder

Added an echo at deploy time in `deploy-dev.yaml` and a Dockerfile note surfacing the isPublic mode on every dev deploy, per your request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)