### PR TITLE
Document development package documentation URLs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ url_ejamrepo: https://github.com/Public-Environmental-Data-Partners/EJAM
 url_ejamrepo_alias: https://ejamrepo.ejanalysis.com
 url_ejamrepo_redirect: https://ejanalysis.com/ejamrepo
 url_ejamdocs: https://public-environmental-data-partners.github.io/EJAM
-url_ejamdocs_alias: https://ejamdocs.ejanalysis.com
+url_ejamdocs_alias: https://docs.ejanalysis.com
 url_ejamdocs_redirect: https://ejanalysis.com/ejamdocs
 url_ejscreenapp: https://pedp-ejscreen.azurewebsites.net/index.html
 url_ejscreenapp_alias: https://ejscreen.ejanalysis.com

--- a/R/url_package.R
+++ b/R/url_package.R
@@ -35,7 +35,7 @@
 #' url_ejamrepo_redirect: https://ejanalysis.com/ejamrepo
 #'
 #' url_ejamdocs: https://public-environmental-data-partners.github.io/EJAM
-#' url_ejamdocs_alias: https://ejamdocs.ejanalysis.com
+#' url_ejamdocs_alias: https://docs.ejanalysis.com
 #' url_ejamdocs_redirect: https://ejanalysis.com/ejamdocs
 #'
 #' url_ejscreenapp: https://pedp-ejscreen.azurewebsites.net/index.html
@@ -70,6 +70,9 @@
 #'   "_alias" or "_redirect" as a suffix,
 #'   such as the "url_ejamdocs_alias" field in DESCRIPTION providing the URL for
 #'   type = "ejamdocs" and desc_or_alias = "alias".
+#'   The "_alias" suffix is part of the DESCRIPTION field name, not a `type`
+#'   value: use `url_package("apidocs", desc_or_alias = "alias")`, not
+#'   `url_package("apidocs_alias")`.
 #'
 #' DOCUMENTATION SITES:
 #'
@@ -137,6 +140,7 @@
 #'  reponame
 #'
 #'  url_package("docs")
+#'  url_package("docs", docs_version = "dev")
 #'
 #'  url_package("code")
 #'  url_package("code", get_full_url = TRUE)
@@ -150,10 +154,16 @@
 #'  url_package("ejamapp", desc_or_alias = "alias")
 #'  url_package("ejscreenapp")
 #'
-#'  url_package("docs", desc_or_alias="alias")
-#'  url_package("docs", desc_or_alias="redirect")
-#'  url_package("code", desc_or_alias="alias")
-#'  url_package("data", desc_or_alias="alias")
+#'  url_package("docs", desc_or_alias = "alias")
+#'  paste0(url_package("docs", desc_or_alias = "alias"), "/dev")
+#'  url_package("docs", desc_or_alias = "redirect")
+#'
+#'  url_package("apidocs")
+#'  url_package("apidocs", desc_or_alias = "alias")
+#'  # Not url_package("apidocs_alias"): select the alias separately as above.
+#'
+#'  url_package("code", desc_or_alias = "alias")
+#'  url_package("data", desc_or_alias = "alias")
 #'
 #' @return a single URL or owner/repo as a character string
 #'

--- a/man/url_package.Rd
+++ b/man/url_package.Rd
@@ -26,6 +26,9 @@ stored in the DESCRIPTION file field that has
 "_alias" or "_redirect" as a suffix,
 such as the "url_ejamdocs_alias" field in DESCRIPTION providing the URL for
 type = "ejamdocs" and desc_or_alias = "alias".
+The "_alias" suffix is part of the DESCRIPTION field name, not a \code{type}
+value: use \code{url_package("apidocs", desc_or_alias = "alias")}, not
+\code{url_package("apidocs_alias")}.
 
 DOCUMENTATION SITES:
 \itemize{
@@ -121,7 +124,7 @@ url_ejamrepo_alias: https://ejamrepo.ejanalysis.com
 url_ejamrepo_redirect: https://ejanalysis.com/ejamrepo
 
 url_ejamdocs: https://public-environmental-data-partners.github.io/EJAM
-url_ejamdocs_alias: https://ejamdocs.ejanalysis.com
+url_ejamdocs_alias: https://docs.ejanalysis.com
 url_ejamdocs_redirect: https://ejanalysis.com/ejamdocs
 
 url_ejscreenapp: https://pedp-ejscreen.azurewebsites.net/index.html
@@ -152,6 +155,7 @@ only -- they are stored in DESCRIPTION but are not \code{type} values this funct
  reponame
 
  url_package("docs")
+ url_package("docs", docs_version = "dev")
 
  url_package("code")
  url_package("code", get_full_url = TRUE)
@@ -165,10 +169,16 @@ only -- they are stored in DESCRIPTION but are not \code{type} values this funct
  url_package("ejamapp", desc_or_alias = "alias")
  url_package("ejscreenapp")
 
- url_package("docs", desc_or_alias="alias")
- url_package("docs", desc_or_alias="redirect")
- url_package("code", desc_or_alias="alias")
- url_package("data", desc_or_alias="alias")
+ url_package("docs", desc_or_alias = "alias")
+ paste0(url_package("docs", desc_or_alias = "alias"), "/dev")
+ url_package("docs", desc_or_alias = "redirect")
+
+ url_package("apidocs")
+ url_package("apidocs", desc_or_alias = "alias")
+ # Not url_package("apidocs_alias"): select the alias separately as above.
+
+ url_package("code", desc_or_alias = "alias")
+ url_package("data", desc_or_alias = "alias")
 
 }
 \seealso{

--- a/tests/testthat/test-url_package.R
+++ b/tests/testthat/test-url_package.R
@@ -27,9 +27,9 @@ testthat::test_that("url_package docs gives full URL", {
 
 
 testthat::test_that("url_package docs alias gives full URL", {
-  expect_match(
+  expect_identical(
     url_package("docs", get_full_url = TRUE, desc_or_alias = "alias"),
-    "^https://"
+    "https://docs.ejanalysis.com"
   )
 })
 testthat::test_that("url_package code alias gives full URL", {
@@ -127,16 +127,21 @@ testthat::test_that("url_package repo types give owner/repo shorthand by default
 })
 
 testthat::test_that("url_package alias and redirect variants return full URLs", {
-  for (ty in c("code", "data", "docs", "ejamapp", "ejscreenapp", "api")) {
+  for (ty in c("code", "data", "docs", "apidocs", "ejamapp", "ejscreenapp", "api")) {
     expect_match(url_package(ty, desc_or_alias = "alias"), "^https://", info = ty)
     expect_match(url_package(ty, desc_or_alias = "redirect"), "^https://", info = ty)
   }
+  expect_identical(
+    url_package("apidocs", desc_or_alias = "alias"),
+    "https://apidocs.ejanalysis.com"
+  )
   expect_identical(url_package("api", desc_or_alias = "redirect"), "https://ejanalysis.com/api")
 })
 
 testthat::test_that("url_package rejects unknown types", {
   expect_error(url_package("nonsense"))
   expect_error(url_package("apidocker")) # informational field, not an accepted type
+  expect_error(url_package("apidocs_alias")) # select with desc_or_alias = "alias"
 })
 
 testthat::test_that("url_package docs_version appends subpath for docs types", {

--- a/vignettes/dev-app-settings.Rmd
+++ b/vignettes/dev-app-settings.Rmd
@@ -37,6 +37,23 @@ if (!exists("blockgroupstats")) {library(EJAM)} # use installed version only if 
 # indexblocks()
 ```
 
+# Stable documentation links while testing settings
+
+When testing app settings against the `development` branch, use
+[https://docs.ejanalysis.com/dev](https://docs.ejanalysis.com/dev) to see the
+package documentation built from that branch. In particular:
+
+- [the development version of this settings article](https://docs.ejanalysis.com/dev/articles/dev-app-settings.html)
+- [the development `ejamapp()` reference page](https://docs.ejanalysis.com/dev/reference/ejamapp.html)
+- [the development article index](https://docs.ejanalysis.com/dev/articles)
+
+Without `/dev`, the same paths select the root documentation built from `main`;
+for example, <https://docs.ejanalysis.com/reference/ejamapp.html> and
+<https://docs.ejanalysis.com/articles>. The stable root alias is returned by
+`EJAM::url_package("docs", desc_or_alias = "alias")`; append `"/dev"` to that
+value for the development build. See
+[Updating Documentation](dev-update-documentation.html#published-release-and-development-documentation-urls)
+for a fuller list and the API-documentation shortcuts.
 
 # Deep links: launch the EJAM app pre-loaded via URL parameters
 

--- a/vignettes/dev-update-documentation.Rmd
+++ b/vignettes/dev-update-documentation.Rmd
@@ -183,6 +183,52 @@ In normal documentation work, edit and commit source files such as `.R`, `.Rmd`,
 roxygen comments, and `_pkgdown.yml`. Do not edit `docs/` or the `gh-pages`
 branch by hand; those are generated deployment outputs.
 
+#### Published release and development documentation URLs
+
+The stable alias [https://docs.ejanalysis.com](https://docs.ejanalysis.com)
+preserves the path after the hostname. The site root contains the documentation
+built from `main`; the `/dev/` folder contains the version built from the
+`development` branch. This makes
+[https://docs.ejanalysis.com/dev](https://docs.ejanalysis.com/dev) the place to
+check documentation for the development version of the package before a
+release.
+
+The same page paths work in both builds:
+
+| Page | `main` documentation | `development` documentation |
+|---|---|---|
+| Home | <https://docs.ejanalysis.com> | <https://docs.ejanalysis.com/dev> |
+| Function and dataset index | <https://docs.ejanalysis.com/reference> | <https://docs.ejanalysis.com/dev/reference> |
+| `ejamapp()` reference | <https://docs.ejanalysis.com/reference/ejamapp.html> | <https://docs.ejanalysis.com/dev/reference/ejamapp.html> |
+| Article index | <https://docs.ejanalysis.com/articles> | <https://docs.ejanalysis.com/dev/articles> |
+| "What is EJAM?" article | <https://docs.ejanalysis.com/articles/whatis.html> | <https://docs.ejanalysis.com/dev/articles/whatis.html> |
+| API article | <https://docs.ejanalysis.com/articles/dev-api.html> | <https://docs.ejanalysis.com/dev/articles/dev-api.html> |
+
+The API article also has the stable shortcut
+[https://apidocs.ejanalysis.com](https://apidocs.ejanalysis.com). That shortcut
+points to the API article in the root documentation build; use the `/dev/`
+article URL in the table when reviewing the version from `development`.
+
+These URLs can also be obtained from package metadata:
+
+```{r documentation-urls, eval=FALSE}
+# Canonical GitHub Pages URLs
+EJAM::url_package("docs")
+EJAM::url_package("docs", docs_version = "dev")
+EJAM::url_package("apidocs")
+
+# Stable aliases
+docs_alias <- EJAM::url_package("docs", desc_or_alias = "alias")
+docs_alias
+paste0(docs_alias, "/dev")
+EJAM::url_package("apidocs", desc_or_alias = "alias")
+```
+
+Here, `type = "apidocs"` selects the API documentation and
+`desc_or_alias = "alias"` selects its alias. The DESCRIPTION field is named
+`url_apidocs_alias`, but `"apidocs_alias"` is **not** an accepted `type`, so
+`EJAM::url_package("apidocs_alias")` is not correct.
+
 #### Normal workflow for a vignette edit
 
 1.  Edit the relevant `.Rmd` file in `vignettes/`.

--- a/vignettes/dev-update-package.Rmd
+++ b/vignettes/dev-update-package.Rmd
@@ -153,6 +153,28 @@ domain, update that URL in `DESCRIPTION`.
 return the full URL where documentation is published (currently
 `r EJAM::url_package("docs")`).
 
+- Before a release, compare the published development documentation at
+  [https://docs.ejanalysis.com/dev](https://docs.ejanalysis.com/dev) with the
+  root documentation at
+  [https://docs.ejanalysis.com](https://docs.ejanalysis.com). For example,
+  compare `/dev/reference/ejamapp.html` with `/reference/ejamapp.html`, and
+  `/dev/articles/whatis.html` with `/articles/whatis.html`. The development
+  site is the documentation built from `development`; the root site is built
+  from `main`.
+
+- `EJAM::url_package("docs", docs_version = "dev")` returns the canonical
+  development-site URL.
+  `EJAM::url_package("docs", desc_or_alias = "alias")` returns the stable
+  root alias, and appending `"/dev"` selects its development build. The API
+  documentation can be found with `EJAM::url_package("apidocs")` or its stable
+  alias, <https://apidocs.ejanalysis.com>. Use
+  `EJAM::url_package("apidocs", desc_or_alias = "alias")` to request that
+  alias; `EJAM::url_package("apidocs_alias")` is not valid.
+
+- See [Updating Documentation](dev-update-documentation.html) for a table of
+  root and development URLs for the reference index, individual help pages,
+  article index, and individual articles.
+
 
 ## APP TITLE: If relevant, carefully change the title of the web app
 


### PR DESCRIPTION
## What changed

- Documented `https://docs.ejanalysis.com/dev` as the package documentation built from `development`.
- Added a root-versus-development URL table for the reference index, `ejamapp()` help, article index, What is EJAM article, and API article.
- Added concise guidance to the app-settings and release-update vignettes.
- Updated `url_ejamdocs_alias` so `EJAM::url_package("docs", desc_or_alias = "alias")` returns `https://docs.ejanalysis.com`.
- Documented and tested the correct API-docs forms, including that `EJAM::url_package("apidocs_alias")` is not valid; aliases are selected with `desc_or_alias = "alias"`.

## Why

Maintainers need a stable, memorable way to inspect documentation for the development version before a release and to navigate directly to equivalent root and development pages.

## Validation

- `devtools::test(filter = "url_package")` — 67 passed, 0 failed/warned/skipped
- `tools::checkRd("man/url_package.Rd")`
- Rendered `dev-app-settings`, `dev-update-documentation`, and `dev-update-package` with the local pkgdown preview helper
- Confirmed all documented root and `/dev` URLs return HTTP 200
- `git diff --check`

— Codex
