### PR TITLE
Improve url_package invalid type errors

### DIFF
--- a/R/url_package.R
+++ b/R/url_package.R
@@ -213,7 +213,21 @@ url_package <- function(
   # (get_full_url = FALSE) makes sense
   repo_types <- c("code", "ejamrepo", "ejscreenrepo", "apirepo", "data", "datarepo")
 
-  stopifnot(length(type) == 1, type %in% names(field_by_type))
+  valid_types <- names(field_by_type)
+  if (length(type) != 1 || is.na(type) || !(type %in% valid_types)) {
+    supplied_type <- if (length(type) == 0) {
+      "<empty>"
+    } else {
+      paste(encodeString(as.character(type), quote = "\""), collapse = ", ")
+    }
+    stop(
+      "Invalid `type` value: ", supplied_type, ". ",
+      "`type` must be one of: ",
+      paste(encodeString(valid_types, quote = "\""), collapse = ", "),
+      ". See ?url_package.",
+      call. = FALSE
+    )
+  }
   stopifnot(length(desc_or_alias) == 1, desc_or_alias %in% c("desc", "alias", "redirect"))
 
   if (desc_or_alias %in% c("alias", "redirect") && get_full_url == FALSE) {

--- a/R/url_package.R
+++ b/R/url_package.R
@@ -182,7 +182,10 @@ url_package <- function(
     domain = NULL
 ) {
 
-  if (all(type %in% c("github.com", "github.io"))) {
+  # length guard: all(character(0) %in% ...) is vacuously TRUE, so without it an
+  # empty `type` slipped into this legacy block and errored on `type[1]` (NA)
+  # instead of reaching the invalid-`type` validation below
+  if (length(type) == 1L && all(type %in% c("github.com", "github.io"))) {
     # warning("this function no longer uses the 'domain' parameter. Use 'type' instead.")
     domain <- type[1]
   }

--- a/tests/testthat/test-url_package.R
+++ b/tests/testthat/test-url_package.R
@@ -134,9 +134,29 @@ testthat::test_that("url_package alias and redirect variants return full URLs", 
   expect_identical(url_package("api", desc_or_alias = "redirect"), "https://ejanalysis.com/api")
 })
 
-testthat::test_that("url_package rejects unknown types", {
-  expect_error(url_package("nonsense"))
+testthat::test_that("url_package gives useful errors for invalid types", {
+  type_error <- tryCatch(
+    url_package("nonsense"),
+    error = function(error) conditionMessage(error)
+  )
+  expect_match(
+    type_error,
+    'Invalid `type` value: "nonsense".',
+    fixed = TRUE
+  )
+  expect_match(
+    type_error,
+    '`type` must be one of: "code", "ejamrepo"',
+    fixed = TRUE
+  )
+  expect_match(type_error, '"api". See ?url_package.', fixed = TRUE)
+
   expect_error(url_package("apidocker")) # informational field, not an accepted type
+  expect_error(
+    url_package(c("docs", "api")),
+    "`type` must be one of:",
+    fixed = TRUE
+  )
 })
 
 testthat::test_that("url_package docs_version appends subpath for docs types", {

--- a/tests/testthat/test-url_package.R
+++ b/tests/testthat/test-url_package.R
@@ -157,6 +157,11 @@ testthat::test_that("url_package gives useful errors for invalid types", {
     "`type` must be one of:",
     fixed = TRUE
   )
+  expect_error(
+    url_package(character()),
+    "Invalid `type` value: <empty>",
+    fixed = TRUE
+  )
 })
 
 testthat::test_that("url_package docs_version appends subpath for docs types", {


### PR DESCRIPTION
## What changed

- Replaced the assertion-style `stopifnot()` check for `url_package(type = ...)` with an explicit, user-facing error.
- The error reports the supplied invalid value, lists every accepted `type`, and points users to `?url_package`.
- Added focused assertions for the invalid value, the beginning and end of the valid-option list, the help pointer, and multi-value input.

## Why

The previous assertion message exposed the implementation condition but did not tell users which values were valid or where to find the function documentation.

## User impact

Invalid calls now produce guidance such as:

```
Invalid `type` value: "not-a-real-type". `type` must be one of: "code", ... "api". See ?url_package.
```

## Validation

- Sourced `R/url_package.R` and ran `testthat::test_file("tests/testthat/test-url_package.R")` — 65 passed, 0 failed/warned/skipped
- Manually verified the complete invalid-type error text
- `git diff --check`

The broader `devtools::test(filter = "url_package")` entry point was blocked during package startup because the isolated worktree does not contain EJAM's ignored local Arrow datasets and its fallback dataset download failed; the focused test file itself passed completely using the sourced implementation.

— Codex
