### PR TITLE
Add ?advanced=TRUE launch-URL param to show the Advanced Settings tab

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -517,6 +517,24 @@ app_server <- function(input, output, session) {
     if (is.null(search) || !nzchar(search)) {return(NULL)}
     q <- shiny::parseQueryString(search)
 
+    ## Advanced Settings tab via launch URL, e.g. ?advanced=TRUE (?advanced=1/yes also work;
+    ## show_advanced_settings is accepted as a synonym). This is a clean, per-visitor query
+    ## param -- unlike ejamapp(default_show_advanced_settings=) which is fixed per deploy, and
+    ## unlike Shiny's bookmark URLs which encode the whole input state. Updating the radio flows
+    ## through the priority=10 observer above that shows/hides the tab; can_show_advanced_settings
+    ## is also enabled so the tab can appear even on a public deploy (where it defaults off), and
+    ## showTab() is called directly so it appears immediately without waiting for the input
+    ## round-trip. An explicit false (?advanced=FALSE/0/no) hides it.
+    adv <- q$advanced %||% q$show_advanced_settings
+    if (!is.null(adv) && nzchar(trimws(adv))) {
+      showadv <- tolower(trimws(adv)) %in% c("1", "true", "t", "yes", "y")
+      updateRadioButtons(session, inputId = "show_advanced_settings", selected = as.character(showadv))
+      if (showadv) {
+        updateRadioButtons(session, inputId = "can_show_advanced_settings", selected = "TRUE")
+        showTab(inputId = "all_tabs", target = "Advanced Settings")
+      }
+    }
+
     # base URL of the EJAM API that mints/resolves handoff tokens. Single source of
     # truth is in the DESCRIPTION file; read it via url_package("api"),
     # and if that is unavailable derive it from url_ejamapi()'s resolved base (its


### PR DESCRIPTION
## What

Adds a clean launch-URL query parameter that opens the app with the **Advanced Settings** tab shown:

- `https://ejamdev.ejanalysis.com/?advanced=TRUE`  (also `1`, `yes`, `t`; `show_advanced_settings` is accepted as a synonym)
- `?advanced=FALSE` (also `0`, `no`) explicitly hides it.

## Why

The init observer in `R/app_server.R` only parsed a fixed set of launch-URL params (`handoff`, `lat`/`lon`, `fips`, `shape`, `radius`/`buffer`). Advanced-tab visibility was driven entirely by the `show_advanced_settings` / `can_show_advanced_settings` inputs, seeded from globals via `global_or_param()`. As a result **none** of the intuitive URLs did anything:

- `?default_show_advanced_settings=TRUE` — that name is only resolved from golem options / `global_defaults_*.R`, never from the URL.
- `?ui_show_advanced_settings=1` — that is an `actionButton` `inputId`, not a query param.
- `?advanced=TRUE` — not a recognized name.

Until now the only ways to start with the tab open were `ejamapp(default_show_advanced_settings = TRUE)` (fixed per deploy, server-side) or a Shiny bookmark URL (encodes the whole input state).

## How

In the same `session$clientData$url_search` observer, after `parseQueryString()`, read `?advanced=` (synonym `show_advanced_settings`). When truthy it `updateRadioButtons()` on `show_advanced_settings` (which flows through the existing `priority = 10` show/hide observer), also flips `can_show_advanced_settings` on so the tab can appear even on a **public** deploy where it defaults off, and calls `showTab()` directly for immediate display. An explicit false hides it.

~18 lines, no new dependencies, no behavior change when the param is absent.

## Follow-up (not in this PR)

The vignette on customizing app launch should be updated to document which params can be passed to the hosted live app via URL (vs. only via bookmark). Tracked separately.