### PR TITLE
deploy-dev: make image tag unique per run (ECR immutable-tag collision)

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -53,7 +53,12 @@ jobs:
         id: build
         env:
           REGISTRY: ${{ steps.ecr-login.outputs.registry }}
-          IMAGE_TAG: dev-${{ github.sha }}
+          # Include the run id: ECR tags are IMMUTABLE, and github.sha is the
+          # DEPLOY-BRANCH commit, which does not change between manual dispatches.
+          # Two "Run workflow" dispatches (e.g. deploying EJAM@development twice, or
+          # a different ejam_version) would otherwise build the same tag and the push
+          # would fail with "tag invalid: ... already exists ... cannot be overwritten".
+          IMAGE_TAG: dev-${{ github.sha }}-${{ github.run_id }}
           # Empty on a push (deploy the Dockerfile's pinned default); set only when a
           # manual "Run workflow" dispatch supplies a ref to override the pin with.
           # Passed via env (not inlined into the shell) to avoid command injection.


### PR DESCRIPTION
## Problem

Re-dispatching the dev deploy **fails**:

```
tag invalid: The image tag 'dev-0fd24a07...' already exists in the 'ejam'
repository and cannot be overwritten because the tag is immutable.
```

The image is tagged `dev-${{ github.sha }}`, but `github.sha` is the **deploy-branch** commit — which does not change between manual "Run workflow" dispatches. So a second dispatch builds the same tag and ECR (immutable tags) rejects the push.

This breaks exactly the workflow the `ejam_version` input from #496 exists for: deploy `development` to dev, review, land fixes, deploy `development` again.

## Fix

Tag as `dev-${{ github.sha }}-${{ github.run_id }}` — keeps the deploy-branch commit visible for traceability, unique per run.

Found when re-dispatching after today's popup/page-break fixes ([run 30130743272](https://github.com/Public-Environmental-Data-Partners/EJAM/actions/runs/30130743272) failed; the dev app is still serving the previous build).

⚠️ Merging triggers a dev deploy of the **pinned** version — I'll cancel that run and immediately dispatch `ejam_version=development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)