### PR TITLE
infra: enable ALB target group stickiness so Shiny uploads stop 404ing (fixes #268)

### DIFF
--- a/ejam-infra/main.tf
+++ b/ejam-infra/main.tf
@@ -285,6 +285,24 @@ resource "aws_lb_target_group" "app" {
     matcher             = "200"
   }
 
+  # Keep each user pinned to one container for the life of their visit.
+  #
+  # Shiny keeps session state in the memory of a single R process, and a file
+  # upload arrives as a SEPARATE HTTP POST from the page load. Without this,
+  # the load balancer round-robins that POST to the other container, which has
+  # never heard of the session and answers 404 "<h1>Not Found</h1>" -- rendered
+  # unescaped in the app's red upload bar. See EJAM#268.
+  #
+  # This must stay in Terraform: the same fix was applied by hand in the AWS
+  # console in Feb 2026, was never codified here, and was silently lost.
+  # Only matters where desired_count > 1 (prod is 2, dev is 1), but it is set
+  # for both so dev cannot drift away from prod behavior.
+  stickiness {
+    type            = "lb_cookie"
+    enabled         = true
+    cookie_duration = 86400 # seconds (1 day); ALB max is 604800
+  }
+
   tags = { Name = "${local.name_prefix}-tg" }
 }
 


### PR DESCRIPTION
Fixes #268 — file uploads intermittently fail in production with a red `<h1>Not Found</h1>` bar.

> ## ⚠️ Do not merge this yet — merge #493 first
>
> An earlier version of this description said *"merging this PR does not change anything in AWS."* That was **wrong in the dangerous direction**, and is corrected below. Merging this today would roll the dev app back off the v3.2022.2 release candidate.
>
> Correct order: **#493 → smoke-test dev → this PR.** See [What merging actually does](#what-merging-actually-does).

## What this changes

Adds a `stickiness` block to `aws_lb_target_group "app"` in `ejam-infra/main.tf`. One block, no other changes.

## Why

Shiny keeps session state in the memory of one R process. A file upload arrives as a **separate HTTP POST** from the page load. Production runs `desired_count = 2`, and target-group stickiness is currently off, so the load balancer round-robins that POST to the other container — which has never heard of the session and answers `404 <h1>Not Found</h1>`. The app's upload bar renders that body unescaped, which is why users see raw HTML tags in the red bar.

## Reproduced 2026-07-25

Drove the real browser flow programmatically (open Shiny session over websocket → `uploadInit` → POST the real `inst/testdata/latlon/testpoints_10.xlsx` bytes to the returned `uploadUrl`). Per `shiny:::ShinySession$handleRequest`, only a POST with a live `jobId` can return `200 OK`, so a 200 proves the request reached the session's own container.

| Environment | Containers | Uploads failed |
|---|---|---|
| Production (`ejam.publicenvirodata.org`) | 2 | **6 of 12 (50%)**, perfectly alternating |
| Dev app | 1 | 0 of 12 (0%) |

Perfect alternation is round-robin across exactly two targets. Confirmed independently: prod returns no `Set-Cookie: AWSALB`, and prod is served directly by the ALB (no Cloudflare in front), so that is a true negative.

## Why it came back

This was fixed in Feb 2026 by hand in the AWS console and closed as "fixed not in this repo but in the configuration of the deployment." It was never codified in Terraform — `git grep -niE "stickiness|sticky|lb_cookie" -- 'ejam-infra/*'` returned zero hits before this PR — so it only ever existed as out-of-band console state, and it did not survive.

`cookie_duration` is 86400s (1 day); ALB allows up to 604800. This is an in-place attribute update — it does **not** replace the target group and causes no downtime.

## Note for testing

The dev app runs a single container, so this class of bug **cannot** reproduce there. Dev-app testing will never catch it.

---

<a name="what-merging-actually-does"></a>

## What merging actually does

Two separate things, and it is important not to confuse them.

**It does NOT touch the load balancer.** No workflow in this repo runs Terraform — the only occurrence of the word in `.github/workflows` is an error-message hint at `deploy-dev.yaml:123`. The 18 lines added here are inert until somebody runs `terraform apply` by hand. So merging does not fix #268.

**It DOES rebuild and redeploy the dev app, and today that is a rollback.** `deploy-dev.yaml` is `on: push: branches: [dev-deploy]` with **no path filter**, so any commit landing on `dev-deploy` — including this one, including a revert — rebuilds the image and force-redeploys the ECS dev service. `origin/dev-deploy:Dockerfile` still reads `ARG EJAM_VERSION=v3.2022.1`, while the dev app is currently running the **v3.2022.2 release candidate**, installed by a `workflow_dispatch` override (`EJAM_VERSION_INPUT: development`, run `30134389497`, 2026-07-24). A push-triggered build takes no such override, so it would rebuild from the stale pin and put v3.2022.1 back on the dev app.

**#493 is the PR that moves that pin** to `v3.2022.2`. Merge it first and this problem disappears.

| Step | PR | Effect |
|---|---|---|
| 1 | #493 → `dev-deploy` | moves the pin to v3.2022.2, rebuilds dev on the released version |
| 2 | — | smoke-test the dev app |
| 3 | **this PR** → `dev-deploy` | adds the Terraform lines; rebuild is now a no-op re-deploy of the same version |
| 4 | #494 → `prod-deploy` | prod pin + `PAGEDOWN_CHROME` fix, **and** the prod copy of these Terraform lines (folded in from #516) |
| 5 | — | `terraform apply` (manual, @Gabe-Epic) — this is what actually fixes #268 |

Merging #493 or #494 before the `v3.2022.2` tag exists fails the build at `install_github('...EJAM@v3.2022.2')` — a red run, not an outage.

> **Companion PR:** #516 made the identical change on `prod-deploy`. Its commit has been **folded into #494** so production rebuilds once instead of twice; #516 is now redundant and has been marked a draft. Nothing further is needed from it.

---

## How to apply this (for @Gabe-Epic)

**Merging this PR does not enable stickiness.** Terraform is entirely manual here. Two steps:

### 1. Immediate unbreak (~1 minute, no Terraform needed) — please do this now

AWS Console → **EC2 → Target Groups → `ejam-prod-tg` → Attributes → Edit → turn Stickiness on.**
Type: *load balancer generated cookie*. Duration: *1 day*.

This fixes production right away for users, and does not depend on any of the PRs above.

### 2. Make it permanent — please wait until we say the Terraform change is merged

⚠️ **Do not run `terraform apply` on these target groups before step 4 in the table above lands.** The stickiness lines are not on `dev-deploy`/`prod-deploy` yet, so an apply from the current code would read your console change as drift and switch stickiness **back off** — which is exactly how the Feb 2026 fix was lost. If you need to apply for an unrelated reason in the meantime, tell us first.

Run locally from the `ejam-infra/` directory of a checkout of the relevant deploy branch. Requires `terraform` + `awscli` and the custom `ejam-terraform-deploy` IAM policy on your user.

State lives in S3 bucket `ejam-terraform-state-<ACCOUNT_ID>`, with a **separate state key per environment** — so prod and dev are applied independently.

**Production** (this is the one that fixes the bug — prod runs 2 containers):

```bash
terraform init -backend-config="key=prod/terraform.tfstate"
terraform plan  -var-file=prod.tfvars -var="aws_account_id=<ACCOUNT_ID>"
terraform apply -var-file=prod.tfvars -var="aws_account_id=<ACCOUNT_ID>"
```

**Dev** (optional — dev runs 1 container so stickiness is a no-op there, but applying keeps the two environments consistent):

```bash
terraform init -backend-config="key=dev/terraform.tfstate" -reconfigure
terraform apply -var-file=dev.tfvars -var="aws_account_id=<ACCOUNT_ID>"
```

### Please check the plan output

`terraform plan` should show **exactly one in-place update** to `aws_lb_target_group.app` (`~ update in-place`), adding the `stickiness` block. It is an attribute change, so there is **no downtime**.

⚠️ If the plan proposes to **replace / destroy** the target group, stop and check with us first — that would drop traffic.

### Both steps are needed

Step 1 alone is exactly what happened in Feb 2026 — the console setting was never codified, and it was silently lost. Step 2 alone leaves production broken until someone applies. They just cannot happen on the same day this time, for the ordering reason above.

### Verifying it worked

```bash
curl -sS -D - -o /dev/null https://ejam.publicenvirodata.org/ | grep -i set-cookie
```

Once stickiness is on, that prints an `AWSALB` cookie. As of 2026-07-27 it still prints nothing.
