### PR TITLE
Sync #268 wording clarification to main before publishing v3.2022.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,8 +33,17 @@ new information in the community report about where people live.
     - docs: [apidocs.ejanalysis.com](https://apidocs.ejanalysis.com)
   
 - **Bugs fixed**, including a crash when arriving from EJScreen's "Send to EJAM"
-  button, intermittent problems uploading files, and 
-  downloaded reports that came out empty (details below).
+  button and downloaded reports that came out empty (details below).
+
+- **Intermittent upload failures on the hosted app are being fixed alongside
+  this release** (#268), but by a change to the hosting setup rather than by
+  anything in this package. The production app runs on two servers, and an
+  upload could be sent to the one that was not holding your session, which
+  answered "Not Found" -- roughly half the time. The load balancer is being set
+  to keep each session on a single server, the same fix applied in early 2026
+  that was later lost when the servers were rebuilt from their configuration
+  files. Because it is a hosting change, installing v3.2022.2 does not by itself
+  resolve it; the two are simply being done at the same time.
 
 ## Improvements
 


### PR DESCRIPTION
Carries the NEWS wording fix (`4d8a832a`) from `development` to `main` so the published tag has it.

The v3.2022.2 Highlights listed *"intermittent problems uploading files"* among the bugs fixed by this release, which would mislead anyone installing the package. #268 is the load-balancer session-affinity regression: the production app runs on two servers and an upload could be routed to the one not holding the session, which answered "Not Found". The fix lives in `ejam-infra/`, which is not on `main` or `development` and is not part of this package — **installing v3.2022.2 does not resolve it.**

It is now its own bullet saying plainly that it is being done *alongside* the release rather than *by* it, and noting it is a recurrence of the fix applied in early 2026 that was later lost when the servers were rebuilt from their configuration files.

NEWS.md only — verified byte-identical to `development`'s. No version, code, or data change. The `release.yaml` extractor still parses the section cleanly.

Needs to merge before the draft release is published, since publishing tags `main`.