### PR TITLE
Remove hardcoded local machine path from data-raw helper

### DIFF
--- a/data-raw/run_refresh_s3_outputs_safe_sequence.R
+++ b/data-raw/run_refresh_s3_outputs_safe_sequence.R
@@ -23,7 +23,16 @@
 #   These settings do not replace package data, do not run datacreate_ package
 #   data scripts, do not update FRS, and do not publish release assets.
 
-repo_dir <- "/Users/markcorrales/R PACKAGES/EJAM"
+# Path to the EJAM source package folder. Defaults to the working directory, so
+# source this file from the EJAM source folder - the same convention the
+# datacreate_ scripts use. Set EJAM_REPO_DIR to run it from somewhere else.
+repo_dir <- Sys.getenv("EJAM_REPO_DIR", unset = getwd())
+if (!file.exists(file.path(repo_dir, "DESCRIPTION")) ||
+    desc::desc_get(file = file.path(repo_dir, "DESCRIPTION"), keys = "Package") != "EJAM") {
+  stop("repo_dir must be the EJAM source package folder, but '", repo_dir,
+       "' does not look like one. Source this from the EJAM source folder, ",
+       "or set the EJAM_REPO_DIR environment variable.")
+}
 s3_pipeline_root <- "s3://pedp-data-preserved/ejscreen-data-processing/pipeline"
 epa_acs22_reference_dir <- file.path(
   s3_pipeline_root,


### PR DESCRIPTION
`data-raw/run_refresh_s3_outputs_safe_sequence.R:26` hardcoded

```r
repo_dir <- "/Users/markcorrales/R PACKAGES/EJAM"
```

which exposes a developer's home directory and username in a public repository, and makes the script unusable by anyone else without editing it.

`repo_dir` now defaults to the working directory and validates that it really is the EJAM source folder by reading `Package` from `DESCRIPTION` — the same convention the `datacreate_` scripts already use — with an `EJAM_REPO_DIR` environment variable to override. It now fails with a clear message rather than silently building paths under a directory that does not exist on the current machine.

**Scope of the exposure:** present since `7dc83574` (2026-05-30), so it is also in the v3.2022.0 and v3.2022.1 source tags. `data-raw/` is in `.Rbuildignore`, so it was never in the built package tarball — only in the public repository and source tags.

**Verified:** the file parses (20 expressions), and `repo_dir` resolves to the repo root and passes the DESCRIPTION check when sourced from the EJAM source folder. A full `git grep` across `development` and `main` found no other tracked file containing a real local path (the `C:/Users/x/...` strings in `R/utils_linesofcode_.R` are generic placeholders in a comment, not a real path).

Going to `main` as well before v3.2022.2 is tagged, so the released source tag does not carry it.