### PR TITLE
Remove hardcoded local machine path from data-raw helper (main)

### DIFF
--- a/data-raw/run_refresh_s3_outputs_safe_sequence.R
+++ b/data-raw/run_refresh_s3_outputs_safe_sequence.R
@@ -23,7 +23,16 @@
 #   These settings do not replace package data, do not run datacreate_ package
 #   data scripts, do not update FRS, and do not publish release assets.
 
-repo_dir <- "/Users/markcorrales/R PACKAGES/EJAM"
+# Path to the EJAM source package folder. Defaults to the working directory, so
+# source this file from the EJAM source folder - the same convention the
+# datacreate_ scripts use. Set EJAM_REPO_DIR to run it from somewhere else.
+repo_dir <- Sys.getenv("EJAM_REPO_DIR", unset = getwd())
+if (!file.exists(file.path(repo_dir, "DESCRIPTION")) ||
+    desc::desc_get(file = file.path(repo_dir, "DESCRIPTION"), keys = "Package") != "EJAM") {
+  stop("repo_dir must be the EJAM source package folder, but '", repo_dir,
+       "' does not look like one. Source this from the EJAM source folder, ",
+       "or set the EJAM_REPO_DIR environment variable.")
+}
 s3_pipeline_root <- "s3://pedp-data-preserved/ejscreen-data-processing/pipeline"
 epa_acs22_reference_dir <- file.path(
   s3_pipeline_root,


### PR DESCRIPTION
Carries `987390d2` from `development` to `main` so the v3.2022.2 source tag does not ship a developer's home directory.

`data-raw/run_refresh_s3_outputs_safe_sequence.R:26` hardcoded `repo_dir <- "/Users/markcorrales/R PACKAGES/EJAM"`. It now defaults to the working directory and validates that it is really the EJAM source folder by reading `Package` from `DESCRIPTION` — the convention the `datacreate_` scripts already use — with `EJAM_REPO_DIR` to override.

Present since `7dc83574` (2026-05-30), so it is already in the v3.2022.0 and v3.2022.1 source tags. `data-raw/` is in `.Rbuildignore`, so it was never in the built tarball.

**This needs to merge before the release is published**, since publishing creates the tag from `main`.

A scan of all 16 remote branches found the same line on 13 of them; the rest are being backported separately. `development` and `gh-pages` are already clean.