### PR TITLE
Sync release workflow (publish-the-draft) to main before August 1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,16 @@ name: 'Release: tag and publish'
 #   2. On a schedule - 13:00 UTC on August 1, to ship v3.2022.2 without anyone
 #      having to be at a keyboard.
 #
+# What it does depends on what is already on the releases page:
+#
+#   * an unpublished DRAFT exists -> that draft is published as-is, keeping the
+#     title and notes someone reviewed. Publishing is what creates the tag.
+#     This is the normal path: prepare a draft, review it, let the schedule
+#     ship it.
+#   * nothing exists -> a tag is created and a release is built from the
+#     matching NEWS.md section.
+#   * already published -> nothing happens; a shipped release is never touched.
+#
 # The scheduled path is deliberately one-shot: it refuses to do anything unless
 # DESCRIPTION on `main` still reads exactly SCHEDULED_EXPECTED_VERSION. So when
 # this cron fires again in later years it will find a different version and exit
@@ -102,19 +112,31 @@ jobs:
             SKIP=true
           fi
 
-          # A DRAFT release does not create a tag ref, so the check above cannot
-          # see one. Without this, a draft prepared by hand would be duplicated
-          # (or collide) the next time this workflow ran. Publish the draft
-          # yourself, or delete it first if you want the workflow to do it.
+          # Decide how to ship, based on what already exists on the releases page.
+          #
+          #   published -> nothing to do; never clobber a shipped release.
+          #   draft     -> publish THAT draft, keeping its reviewed title and
+          #                notes. A draft holds a tag *name* but creates no tag
+          #                ref, so the check above cannot see it; publishing is
+          #                what creates the tag.
+          #   none      -> create the tag and a release built from NEWS.md.
+          MODE=create
           if gh release view "v$VERSION" >/dev/null 2>&1; then
-            echo "::notice::A release already exists for v$VERSION (it may be an unpublished draft). Skipping so this workflow does not duplicate or clobber it."
-            SKIP=true
+            if [ "$(gh release view "v$VERSION" --json isDraft --jq .isDraft)" = 'true' ]; then
+              MODE=publish_draft
+              echo "::notice::An unpublished draft exists for v$VERSION. It will be published as-is, keeping its reviewed notes."
+            else
+              MODE=already_published
+              echo "::notice::v$VERSION is already published. Skipping."
+              SKIP=true
+            fi
           fi
 
           echo "skip=$SKIP" >> "$GITHUB_OUTPUT"
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
 
       - name: Extract the NEWS.md section for this version
-        if: steps.guard.outputs.skip == 'false'
+        if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.mode == 'create'
         id: notes
         run: |
           set -euo pipefail
@@ -161,23 +183,66 @@ jobs:
 
       - name: Dry run summary
         if: steps.guard.outputs.skip == 'false' && github.event_name == 'workflow_dispatch' && inputs.dry_run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           {
             echo "### Dry run - nothing was tagged or published"
             echo ""
             echo "- Tag that *would* be created: \`${{ steps.ver.outputs.tag }}\`"
-            echo "- Release title: ${{ steps.notes.outputs.title }}"
             echo "- Target commit: \`${{ steps.ver.outputs.sha }}\` (head of \`main\`)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ '${{ steps.guard.outputs.mode }}' = 'publish_draft' ]; then
+            {
+              echo "- Mode: **publish the existing draft** (its reviewed title and notes are kept; NEWS.md is not used)"
+              echo "- Draft title: $(gh release view '${{ steps.ver.outputs.tag }}' --json name --jq .name)"
+              echo ""
+              echo "<details><summary>Notes the draft would be published with</summary>"
+              echo ""
+              gh release view '${{ steps.ver.outputs.tag }}' --json body --jq .body
+              echo ""
+              echo "</details>"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "- Mode: **create a new release** from the NEWS.md section"
+              echo "- Release title: ${{ steps.notes.outputs.title }}"
+              echo ""
+              echo "<details><summary>Release notes that would be published</summary>"
+              echo ""
+              cat release-notes.md
+              echo ""
+              echo "</details>"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Publish the existing draft
+        if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.mode == 'publish_draft' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG='${{ steps.ver.outputs.tag }}'
+
+          # Publishing the draft is what creates the tag, at the draft's target
+          # commitish. Its reviewed title and notes are kept as-is.
+          LATEST_FLAG='--latest=false'
+          if [ '${{ github.event_name }}' = 'schedule' ] || [ '${{ inputs.mark_latest }}' = 'true' ]; then
+            LATEST_FLAG='--latest'
+          fi
+          gh release edit "$TAG" --draft=false $LATEST_FLAG
+
+          {
+            echo "### Published the reviewed draft $TAG"
             echo ""
-            echo "<details><summary>Release notes that would be published</summary>"
-            echo ""
-            cat release-notes.md
-            echo ""
-            echo "</details>"
+            echo "- https://github.com/${{ github.repository }}/releases/tag/$TAG"
+            echo "- Notes came from the draft, not from NEWS.md."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create the tag and publish the release
-        if: steps.guard.outputs.skip == 'false' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
+        if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.mode == 'create' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Carries `03281914` from `development` to `main`. **This has to be on `main` or the August 1 timer does nothing** — scheduled workflows only fire from the default branch.

Without it the schedule would also have been a no-op for a second reason: the previous guard skipped whenever any release existed for the version, including the reviewed v3.2022.2 draft.

The workflow now branches on the actual state of the releases page — publish an existing draft (keeping its reviewed notes; publishing creates the tag), create one from `NEWS.md` if nothing exists, or do nothing if already published.

Workflow file only. Verified against live repository state: resolves to `skip=false mode=publish_draft`, which would publish the existing draft targeting `main`.