### PR TITLE
chore: refresh open issue ranking report

### DIFF
--- a/inst/issues/ejam_issues_scored_by_risk_and_value.MD
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.MD
@@ -1,6 +1,6 @@
 # EJAM Open Issues — Scored by Cost & Benefit
 
-**Total open issues:** 137  |  **Generated:** 2026-07-24  |  **Source:** Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)
+**Total open issues:** 130  |  **Generated:** 2026-07-25  |  **Source:** Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)
 
 **Score payload:** `inst/issues/ejam_issues_scored_by_risk_and_value.json`
 
@@ -13,9 +13,9 @@
 | Metric | Value |
 |--------|-------|
 | Previous run | 2026-07-24 |
-| Issues opened since previous run | 0 |
-| Issues closed since previous run | 0 |
-| Issues whose quadrant changed | 0 |
+| Issues opened since previous run | 4 |
+| Issues closed since previous run | 11 |
+| Issues whose quadrant changed | 17 |
 
 ---
 
@@ -23,30 +23,29 @@
 
 | Cost / Benefit | **LOW Benefit**<br>value < median | **HIGH Benefit**<br>value ≥ median |
 |---|---|---|
-| **LOW Cost**<br>cost < median | **C — Might As Well**<br>14 issues | **A — BEST CANDIDATES**<br>37 issues |
-| **HIGH Cost**<br>cost ≥ median | **D — WORST CANDIDATES**<br>32 issues | **B — OK Candidates**<br>54 issues |
+| **LOW Cost**<br>cost < median | **C — Might As Well**<br>21 issues | **A — BEST CANDIDATES**<br>40 issues |
+| **HIGH Cost**<br>cost ≥ median | **D — WORST CANDIDATES**<br>23 issues | **B — OK Candidates**<br>46 issues |
 
 ---
 
 ## Quadrant A — BEST CANDIDATES — Low Cost, High Benefit
 *Easy fixes with clear high value. Prioritize these above all others.*
 
-**37 issues**
+**40 issues**
 
-- [#156](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/156) — in app - add view of   ejam2areafeatures(out)  (info on % of pop with certain things nearby)
+- [#504](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504) — Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate task during blockgroup join
 - [#152](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/152) — build_community_report() needs unit tests, table_signif_round_x100() or table_round() too
-- [#385](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/385) — ejam2report() fails to save a file when the filename parameter is used
-- [#348](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/348) — API report links from multisite results label every per-site report as site 1
 - [#274](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/274) — Add the features not yet restored from the pre-2025 EPA version of the Community Report
-- [#205](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/205) — adjust summary report fonts and row heights/line spacing to make text more legible
+- [#342](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342) — use renv package to create lock state for what versions of what packages are used
+- [#341](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341) — Align map_headernames and/or generated avg/pctile/ratio metadata with columns doaggregate() can produce for the report
 - [#16](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16) — need new/updated "User Guide" ("Help" in header at right) since UI has changed a lot, etc.
-- [#144](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/144) — use or remove or explain the sitenumber parameter in ejam2map() for fips case
-- [#127](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/127) — web app details tab with table of all sites is too sluggish as it appears after clicking to view that tab
+- [#400](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400) — improve how webapp users can find info on data vintage (in EJAM web app UI, from community report, and from EJScreen UI)
 - [#344](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344) — Show an example of a community report - e.g., in or linked from "basics" vignette
 - [#249](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/249) — ejam2report() fails if filename is specified without path, or with "./xyz.html"
-- [#410](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/410) — "FEATURES AND LOCATION INFORMATION" on report need explanation and less rounding
 - [#137](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/137) — fix bug in popshare_at_top_x_pct() - results sometimes not quite right. seems to interpolate badly.
+- [#268](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/268) — Uploading a file was failing intermittently when live app hosted using AWS with load balancing
 - [#109](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/109) — Update & correct the article "Defaults and Custom Settings for the Web App"
+- [#73](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73) — in web app, add ways to analyze multiple radii at once or even continuous radius
 - [#354](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/354) — consider if downloaded report map and/or excel can use polygons in map to do POST API request for 1-site report
 - [#166](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/166) — could simplify polygons before mapping, saving - check if useful and then implement
 - [#223](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/223) — app_title parameter is not working in ejamapp()
@@ -61,32 +60,35 @@
 - [#136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) — in web app, fix console  error msg when uploading a shapefile
 - [#288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) — ratio of 1.0 should not be yellow on community report
 - [#70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) — set up alerts that monitor and alert staff when the app goes down - ensure available
+- [#484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) — in overall table, change EJAM Report link for 1-site analysis
 - [#486](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486) — allow zip code analysis in EJAM shiny web app
+- [#284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) — resolve warning about datum, in logs/console, when web app tries to upload/read some shapefiles
 - [#102](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102) — Remove NA console messages from `doaggregate`
 - [#455](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/455) — fix radius slider behavior after deep link passes a radius and then user changes it
 - [#403](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403) — Add explanation of what "average in state" or "percentile in state" means for a multisite report
 - [#350](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350) — Add report regression tests for FIPS, shapefile, sitenumber, NAICS, and PDF-unavailable paths
 - [#96](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/96) — Detailed Table UI Filtering improvements
 - [#92](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92) — Excel's new tab with upload needs cap on size
-- [#69](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/69) — enable other units like kilometers for entry of radius
 - [#58](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58) — joining FIPS upload data to preview table
+- [#454](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454) — fix when should radius slider reset to 0 vs 1 mile (a method-specific default) if radio button used to switch between points and polygon/fips type sites
+- [#224](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224) — report correct population for a single block (if block is analyzed via block fips code)
+- [#40](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40) — Allow abort site selection processing when selections are changed
 
 | # | Issue | Cost | Benefit | Milestone | Priority | Labels (key) |
 |---|-------|------|---------|-----------|----------|--------------|
-| [156](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/156) | in app - add view of   ejam2areafeatures(out)  (info on % of pop with … | 0 (🟢 Very Low) | 17 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | test, Affects Web App, rank:A-high-value-low-cost |
+| [504](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504) | Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate tas… | 3 (🔵 Low) | 17 (🟩🟩 Very High) | v4 | PRIORITY MEDIUM | BUG, Affects Web App |
 | [152](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/152) | build_community_report() needs unit tests, table_signif_round_x100() o… | 0 (🟢 Very Low) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | test, Affects Web App, Community Report, rank:A-high-value-low-cost |
-| [385](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/385) | ejam2report() fails to save a file when the filename parameter is used | 1 (🟢 Very Low) | 15 (🟩🟩 Very High) | v4 | PRIORITY MEDIUM | BUG, Affects R users only - NOT web app users, Community Report, rank:A-high-value-low-cost |
-| [348](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/348) | API report links from multisite results label every per-site report as… | 2 (🔵 Low) | 15 (🟩🟩 Very High) | v3.2022.2 | PRIORITY MEDIUM | BUG, URL-related, Affects Web App, API |
 | [274](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/274) | Add the features not yet restored from the pre-2025 EPA version of the… | 2 (🔵 Low) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | Affects Web App, Community Report, rank:A-high-value-low-cost |
-| [205](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/205) | adjust summary report fonts and row heights/line spacing to make text … | 2 (🔵 Low) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | help wanted, Affects Web App, Community Report, rank:A-high-value-low-cost |
+| [342](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342) | use renv package to create lock state for what versions of what packag… | 3 (🔵 Low) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | help wanted, Affects Web App, rank:A-high-value-low-cost |
+| [341](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341) | Align map_headernames and/or generated avg/pctile/ratio metadata with … | 3 (🔵 Low) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | Affects Web App, Community Report, rank:A-high-value-low-cost |
 | [16](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16) | need new/updated "User Guide" ("Help" in header at right) since UI has… | 2 (🔵 Low) | 14 (🟩🟩 Very High) | v4 | PRIORITY HIGH | BUG, documentation, help wanted, good first issue |
-| [144](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/144) | use or remove or explain the sitenumber parameter in ejam2map() for fi… | 0 (🟢 Very Low) | 13 (🟩🟩 Very High) | v3.2022.2 | PRIORITY MEDIUM | BUG, Affects Web App, API, rank:A-high-value-low-cost |
-| [127](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/127) | web app details tab with table of all sites is too sluggish as it appe… | 0 (🟢 Very Low) | 13 (🟩🟩 Very High) | v3.2022.2 | PRIORITY MEDIUM | BUG, Affects Web App, rank:A-high-value-low-cost |
-| [344](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344) | Show an example of a community report - e.g., in or linked from "basic… | 2 (🔵 Low) | 12 (🟩🟦 High) | NA | PRIORITY HIGH-ish but not a bug | documentation, help wanted, good first issue, rank:A-high-value-low-cost |
+| [400](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400) | improve how webapp users can find info on data vintage (in EJAM web ap… | 3 (🔵 Low) | 13 (🟩🟩 Very High) | NA | PRIORITY HIGH | Affects Web App, rank:A-high-value-low-cost |
+| [344](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344) | Show an example of a community report - e.g., in or linked from "basic… | 2 (🔵 Low) | 12 (🟩🟦 High) | v4 | PRIORITY HIGH-ish but not a bug | documentation, help wanted, good first issue, rank:A-high-value-low-cost |
 | [249](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/249) | ejam2report() fails if filename is specified without path, or with "./… | 2 (🔵 Low) | 12 (🟩🟦 High) | v3.2022.2 | PRIORITY LOW | BUG, Affects R users only - NOT web app users, rank:A-high-value-low-cost |
-| [410](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/410) | "FEATURES AND LOCATION INFORMATION" on report need explanation and les… | 1 (🟢 Very Low) | 11 (🟩🟦 High) | v3.2022.2 | PRIORITY MEDIUM | BUG, Affects Web App, Community Report, rank:A-high-value-low-cost |
 | [137](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/137) | fix bug in popshare_at_top_x_pct() - results sometimes not quite right… | 1 (🟢 Very Low) | 11 (🟩🟦 High) | v4 | PRIORITY MEDIUM | BUG, Affects Web App, rank:A-high-value-low-cost |
-| [109](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/109) | Update & correct the article "Defaults and Custom Settings for the Web… | 1 (🟢 Very Low) | 10 (🟩🟦 High) | NA | PRIORITY LOW | BUG, documentation, Affects R users only - NOT web app users, rank:A-high-value-low-cost |
+| [268](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/268) | Uploading a file was failing intermittently when live app hosted using… | 2 (🔵 Low) | 11 (🟩🟦 High) | NA | — | BUG, Affects Web App |
+| [109](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/109) | Update & correct the article "Defaults and Custom Settings for the Web… | 1 (🟢 Very Low) | 10 (🟩🟦 High) | v4 | PRIORITY LOW | BUG, documentation, Affects R users only - NOT web app users, rank:A-high-value-low-cost |
+| [73](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73) | in web app, add ways to analyze multiple radii at once or even continu… | 3 (🔵 Low) | 10 (🟩🟦 High) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
 | [354](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/354) | consider if downloaded report map and/or excel can use polygons in map… | 2 (🔵 Low) | 9 (🟩🟦 High) | NA | PRIORITY MEDIUM | Affects Web App, Community Report, rank:A-high-value-low-cost |
 | [166](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/166) | could simplify polygons before mapping, saving - check if useful and t… | 2 (🔵 Low) | 9 (🟩🟦 High) | NA | PRIORITY MEDIUM | Affects Web App, API, rank:A-high-value-low-cost |
 | [223](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/223) | app_title parameter is not working in ejamapp() | 2 (🔵 Low) | 8 (🟦 Medium) | NA | PRIORITY LOW | BUG, Affects Web App, rank:A-high-value-low-cost |
@@ -97,50 +99,50 @@
 | [490](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490) | swap us and state ratio columns | 1 (🟢 Very Low) | 7 (🟦 Medium) | v4 | PRIORITY MEDIUM | Affects Web App, Community Report |
 | [361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) | Add date and time of last updated to help with deploys | 1 (🟢 Very Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
 | [163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) | put certain columns last in table of results (bg count, block count, r… | 1 (🟢 Very Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
-| [162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) | rename "in_how_many_states"   column  in table of results | 1 (🟢 Very Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
-| [136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | in web app, fix console  error msg when uploading a shapefile | 1 (🟢 Very Low) | 7 (🟦 Medium) | NA | PRIORITY LOW | BUG, rank:A-high-value-low-cost |
-| [288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) | ratio of 1.0 should not be yellow on community report | 2 (🔵 Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, Community Report, rank:A-high-value-low-cost |
+| [162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) | rename "in_how_many_states"   column  in table of results | 1 (🟢 Very Low) | 7 (🟦 Medium) | v4 | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
+| [136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | in web app, fix console  error msg when uploading a shapefile | 1 (🟢 Very Low) | 7 (🟦 Medium) | v4 | PRIORITY LOW | BUG, rank:A-high-value-low-cost |
+| [288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) | ratio of 1.0 should not be yellow on community report | 2 (🔵 Low) | 7 (🟦 Medium) | v3.2022.2 | PRIORITY MEDIUM | Affects Web App, Community Report, rank:A-high-value-low-cost |
 | [70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) | set up alerts that monitor and alert staff when the app goes down - en… | 2 (🔵 Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | rank:A-high-value-low-cost |
+| [484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) | in overall table, change EJAM Report link for 1-site analysis | 3 (🔵 Low) | 7 (🟦 Medium) | v4 | PRIORITY MEDIUM | Affects Web App |
 | [486](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486) | allow zip code analysis in EJAM shiny web app | 1 (🟢 Very Low) | 6 (🟦 Medium) | v4 | PRIORITY LOW | Affects Web App |
+| [284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) | resolve warning about datum, in logs/console, when web app tries to up… | 3 (🔵 Low) | 6 (🟦 Medium) | NA | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
 | [102](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102) | Remove NA console messages from `doaggregate` | 0 (🟢 Very Low) | 5 (🟦 Medium) | NA | PRIORITY LOW | Affects R users only - NOT web app users, rank:C-low-value-low-cost |
 | [455](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/455) | fix radius slider behavior after deep link passes a radius and then us… | 1 (🟢 Very Low) | 5 (🟦 Medium) | v4 | PRIORITY LOW | BUG |
 | [403](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403) | Add explanation of what "average in state" or "percentile in state" me… | 1 (🟢 Very Low) | 5 (🟦 Medium) | NA | PRIORITY MEDIUM | documentation, Affects Web App, rank:C-low-value-low-cost |
 | [350](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350) | Add report regression tests for FIPS, shapefile, sitenumber, NAICS, an… | 2 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY LOW | BUG, test, Community Report, rank:C-low-value-low-cost |
 | [96](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/96) | Detailed Table UI Filtering improvements | 2 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
 | [92](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92) | Excel's new tab with upload needs cap on size | 2 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
-| [69](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/69) | enable other units like kilometers for entry of radius | 2 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY MEDIUM | rank:C-low-value-low-cost |
 | [58](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58) | joining FIPS upload data to preview table | 2 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY MEDIUM | rank:C-low-value-low-cost |
+| [454](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454) | fix when should radius slider reset to 0 vs 1 mile (a method-specific … | 3 (🔵 Low) | 5 (🟦 Medium) | v4 | PRIORITY LOW | BUG |
+| [224](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224) | report correct population for a single block (if block is analyzed via… | 3 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY LOW | BUG, rank:C-low-value-low-cost |
+| [40](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40) | Allow abort site selection processing when selections are changed | 3 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY MEDIUM | rank:C-low-value-low-cost |
 
 ---
 
 ## Quadrant B — OK Candidates — High Cost, High Benefit
 *Worth doing but require more effort or expertise. Plan carefully before starting.*
 
-**54 issues**
+**46 issues**
 
-- [#467](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/467) — ejam2report() fails for zero-population or otherwise analysis-invalid sites
 - [#293](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/293) — API takes too long to create a community report from when user clicks
-- [#504](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504) — Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate task during blockgroup join
+- [#513](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/513) — need better ETA estimates (predicted seconds to completion are too high)
 - [#52](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/52) — Create density score /proximity score/ count-nearby functions, then provide via web app, and API
 - [#44](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/44) — Investigate options for asynchronous processing in R Shiny (espec for speed / performance at launch)
 - [#226](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/226) — NOTES on SPEEDING UP app & functions (incl load testing)
-- [#342](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342) — use renv package to create lock state for what versions of what packages are used
-- [#341](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341) — Align map_headernames and/or generated avg/pctile/ratio metadata with columns doaggregate() can produce for the report
 - [#349](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/349) — Polygon report links recompute API reports from simplified GeoJSON
 - [#153](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/153) — revisit work in progress on this list of .R files
 - [#193](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/193) — Create Executive Summary helper functions - summarizer / Methods for Identifying and Focusing on Key Findings
-- [#400](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400) — improve how webapp users can find info on data vintage (in EJAM web app UI, from community report, and from EJScreen UI)
 - [#68](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/68) — allow user to type in radius not only use slider
 - [#46](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46) — Long Report text needed
 - [#126](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126) — enable 1-site report on Polygons / Shapefile, via links/buttons in shiny map popups and table of sites (but NOT outside shiny like in URL-based/link in Excel table)
-- [#73](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73) — in web app, add ways to analyze multiple radii at once or even continuous radius
 - [#279](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279) — Prepare the package to submit to CRAN (and get it accepted for hosting on CRAN)
 - [#87](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/87) — Enable shiny.telemetry log file that is not just a text file on server
 - [#31](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31) — fix distance_avg in doaggregate()$results_bybg_people
 - [#56](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/56) — check/ fix Distance and Site Count summary stats, in doaggregate()
 - [#135](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135) — finish work in progress on default_ss_choose_method  vs input$ ?
 - [#19](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/19) — FIPS missing/problems (mostly in Connecticut)
-- [#484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) — in overall table, change EJAM Report link for 1-site analysis
+- [#511](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/511) — CI runs only on PRs into main: development and deploy PRs get no checks at all
+- [#510](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/510) — Smoke-test PDF generation in the built image and after deploy (prod PDF broke undetected)
 - [#172](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/172) — create "sites_from_anything" func to allow any types of inputs specifying any types of places
 - [#82](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/82) — confusing UI: a user names the analysis #1, then forgets to change title when runs 2d analysis
 - [#81](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/81) — confusion in UI: if user tries a second analysis by uploading new stuff, they sometimes click on See Results instead of reclicking "Start Analysis"
@@ -152,13 +154,9 @@
 - [#168](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/168) — refactor/reconcile "report_logo" vs "logo_path" (parameters and/or global defaults
 - [#256](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/256) — speed up some functions by using .arrow not .rda version of each large dataset more consistently
 - [#169](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/169) — harmonize/refactor functions that create or sanitize filenames, paths
-- [#284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) — resolve warning about datum, in logs/console, when web app tries to upload/read some shapefiles
 - [#194](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194) — Create visualizations of overall results in app  - engaging & insightful
 - [#54](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/54) — correctly handle cases where the adjusted distance (via block_radius_miles) is > radius the user specified
 - [#66](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66) — EJAM & EJScreen report on avg PERSON generally but State Average or US Avg shown is avg BLOCK GROUP ! Decide how to reconcile this.
-- [#454](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454) — fix when should radius slider reset to 0 vs 1 mile (a method-specific default) if radio button used to switch between points and polygon/fips type sites
-- [#224](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224) — report correct population for a single block (if block is analyzed via block fips code)
-- [#40](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40) — Allow abort site selection processing when selections are changed
 - [#83](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/83) — enable selecting a folder as way to upload shapefile(s)
 - [#74](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/74) — Develop options for defining the Reference Zone or Ref. Group - avg person vs bg vs "other 3-mile circles" - in rural, county, user-defined etc.
 - [#72](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/72) — find a way to map more polygons (than just 159 cap)
@@ -175,29 +173,25 @@
 
 | # | Issue | Cost | Benefit | Milestone | Priority | Labels (key) |
 |---|-------|------|---------|-----------|----------|--------------|
-| [467](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/467) | ejam2report() fails for zero-population or otherwise analysis-invalid … | 4 (🟡 Medium) | 20 (🟩🟩 Very High) | v3.2022.2 | PRIORITY HIGH | BUG, API, Community Report |
 | [293](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/293) | API takes too long to create a community report from when user clicks | 5 (🟡 Medium) | 19 (🟩🟩 Very High) | v4 | PRIORITY HIGH-ish but not a bug | speed / performance (see #226), Affects Web App, API, rank:B-high-value-high-cost |
-| [504](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504) | Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate tas… | 3 (🔵 Low) | 17 (🟩🟩 Very High) | v4 | PRIORITY MEDIUM | BUG, Affects Web App |
+| [513](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/513) | need better ETA estimates (predicted seconds to completion are too hig… | 6 (🟡 Medium) | 17 (🟩🟩 Very High) | v4 | PRIORITY HIGH | BUG, speed / performance (see #226), Affects Web App |
 | [52](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/52) | Create density score /proximity score/ count-nearby functions, then pr… | 8 (🟠 High) | 17 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | distance-related, future plan list, rank:B-high-value-high-cost |
 | [44](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/44) | Investigate options for asynchronous processing in R Shiny (espec for … | 18 (⛔ Very High) | 17 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | datasets-related, speed / performance (see #226), API, rank:B-high-value-high-cost |
 | [226](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/226) | NOTES on SPEEDING UP app & functions (incl load testing) | 7 (🟠 High) | 16 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | speed / performance (see #226), Affects Web App, rank:B-high-value-high-cost |
-| [342](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342) | use renv package to create lock state for what versions of what packag… | 3 (🔵 Low) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | help wanted, Affects Web App, rank:A-high-value-low-cost |
-| [341](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341) | Align map_headernames and/or generated avg/pctile/ratio metadata with … | 3 (🔵 Low) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | Affects Web App, Community Report, rank:A-high-value-low-cost |
 | [349](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/349) | Polygon report links recompute API reports from simplified GeoJSON | 4 (🟡 Medium) | 15 (🟩🟩 Very High) | v4 | PRIORITY MEDIUM | BUG, shapefile-related, URL-related, Affects Web App |
 | [153](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/153) | revisit work in progress on this list of .R files | 4 (🟡 Medium) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | test, Affects Web App, rank:B-high-value-high-cost |
 | [193](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/193) | Create Executive Summary helper functions - summarizer / Methods for I… | 5 (🟡 Medium) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | LongReport_output, Affects Web App, future plan list, rank:B-high-value-high-cost |
-| [400](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400) | improve how webapp users can find info on data vintage (in EJAM web ap… | 3 (🔵 Low) | 13 (🟩🟩 Very High) | NA | PRIORITY HIGH | Affects Web App, rank:A-high-value-low-cost |
 | [68](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/68) | allow user to type in radius not only use slider | 4 (🟡 Medium) | 13 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | rank:B-high-value-high-cost |
 | [46](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46) | Long Report text needed | 8 (🟠 High) | 13 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | LongReport_output, future plan list, rank:B-high-value-high-cost |
 | [126](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126) | enable 1-site report on Polygons / Shapefile, via links/buttons in shi… | 4 (🟡 Medium) | 11 (🟩🟦 High) | NA | PRIORITY MEDIUM | Affects Web App, API, rank:B-high-value-high-cost |
-| [73](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73) | in web app, add ways to analyze multiple radii at once or even continu… | 3 (🔵 Low) | 10 (🟩🟦 High) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
 | [279](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279) | Prepare the package to submit to CRAN (and get it accepted for hosting… | 5 (🟡 Medium) | 10 (🟩🟦 High) | NA | PRIORITY MEDIUM | help wanted, Affects R users only - NOT web app users, rank:B-high-value-high-cost |
 | [87](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/87) | Enable shiny.telemetry log file that is not just a text file on server | 6 (🟡 Medium) | 10 (🟩🟦 High) | NA | PRIORITY MEDIUM | datasets-related, Affects Web App, rank:B-high-value-high-cost |
 | [31](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31) | fix distance_avg in doaggregate()$results_bybg_people | 4 (🟡 Medium) | 9 (🟩🟦 High) | NA | PRIORITY MEDIUM | BUG, distance-related, rank:B-high-value-high-cost |
 | [56](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/56) | check/ fix Distance and Site Count summary stats, in doaggregate() | 6 (🟡 Medium) | 9 (🟩🟦 High) | NA | PRIORITY MEDIUM | BUG, documentation, calculate/validate to EJScreen, distance-related |
 | [135](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135) | finish work in progress on default_ss_choose_method  vs input$ ? | 4 (🟡 Medium) | 8 (🟦 Medium) | NA | PRIORITY LOW | BUG, Affects R users only - NOT web app users, rank:B-high-value-high-cost |
 | [19](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/19) | FIPS missing/problems (mostly in Connecticut) | 6 (🟡 Medium) | 8 (🟦 Medium) | Data Updates | PRIORITY MEDIUM | BUG, help wanted, maps-related, datasets-related |
-| [484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) | in overall table, change EJAM Report link for 1-site analysis | 3 (🔵 Low) | 7 (🟦 Medium) | v4 | PRIORITY MEDIUM | Affects Web App |
+| [511](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/511) | CI runs only on PRs into main: development and deploy PRs get no check… | 4 (🟡 Medium) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | test, Affects Web App |
+| [510](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/510) | Smoke-test PDF generation in the built image and after deploy (prod PD… | 4 (🟡 Medium) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | test, Affects Web App |
 | [172](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/172) | create "sites_from_anything" func to allow any types of inputs specify… | 4 (🟡 Medium) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | refactor, Affects R users only - NOT web app users, rank:B-high-value-high-cost |
 | [82](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/82) | confusing UI: a user names the analysis #1, then forgets to change tit… | 4 (🟡 Medium) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | still relevant?, Affects Web App, rank:B-high-value-high-cost |
 | [81](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/81) | confusion in UI: if user tries a second analysis by uploading new stuf… | 4 (🟡 Medium) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | still relevant?, Affects Web App, rank:B-high-value-high-cost |
@@ -209,13 +203,9 @@
 | [168](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/168) | refactor/reconcile "report_logo" vs "logo_path" (parameters and/or glo… | 8 (🟠 High) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | refactor, Affects R users only - NOT web app users, Community Report, rank:B-high-value-high-cost |
 | [256](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/256) | speed up some functions by using .arrow not .rda version of each large… | 9 (🟠 High) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | datasets-related, speed / performance (see #226), Affects Web App, rank:B-high-value-high-cost |
 | [169](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/169) | harmonize/refactor functions that create or sanitize filenames, paths | 9 (🟠 High) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | refactor, Affects R users only - NOT web app users, rank:B-high-value-high-cost |
-| [284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) | resolve warning about datum, in logs/console, when web app tries to up… | 3 (🔵 Low) | 6 (🟦 Medium) | NA | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
 | [194](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194) | Create visualizations of overall results in app  - engaging & insightf… | 5 (🟡 Medium) | 6 (🟦 Medium) | NA | PRIORITY MEDIUM | plots-graphs-related, future plan list, rank:D-defer |
 | [54](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/54) | correctly handle cases where the adjusted distance (via block_radius_m… | 9 (🟠 High) | 6 (🟦 Medium) | NA | PRIORITY LOW | BUG, calculate/validate to EJScreen, distance-related, rank:D-defer |
 | [66](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66) | EJAM & EJScreen report on avg PERSON generally but State Average or US… | 10 (🟠 High) | 6 (🟦 Medium) | v4 | PRIORITY LOW | BUG, calculate/validate to EJScreen, Community Report, rank:D-defer |
-| [454](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454) | fix when should radius slider reset to 0 vs 1 mile (a method-specific … | 3 (🔵 Low) | 5 (🟦 Medium) | v4 | PRIORITY LOW | BUG |
-| [224](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224) | report correct population for a single block (if block is analyzed via… | 3 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY LOW | BUG, rank:C-low-value-low-cost |
-| [40](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40) | Allow abort site selection processing when selections are changed | 3 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY MEDIUM | rank:C-low-value-low-cost |
 | [83](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/83) | enable selecting a folder as way to upload shapefile(s) | 4 (🟡 Medium) | 5 (🟦 Medium) | NA | PRIORITY LOW | shapefile-related, Affects Web App, rank:D-defer |
 | [74](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/74) | Develop options for defining the Reference Zone or Ref. Group - avg pe… | 4 (🟡 Medium) | 5 (🟦 Medium) | NA | PRIORITY MEDIUM | rank:D-defer |
 | [72](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/72) | find a way to map more polygons (than just 159 cap) | 4 (🟡 Medium) | 5 (🟦 Medium) | NA | PRIORITY MEDIUM | shapefile-related, maps-related, rank:D-defer |
@@ -235,22 +225,29 @@
 ## Quadrant C — Might As Well — Low Cost, Low Benefit
 *Cheap to do; low urgency. Pick these up when bandwidth allows or combine with nearby work.*
 
-**14 issues**
+**21 issues**
 
 - [#177](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/177) — pick which approach is faster among functions like sf_nearest_points() and related
 - [#176](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/176) — popups reports in county case are not normal/ignore reports settings?
 - [#175](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/175) — drop the excel column called "Area of block group in geodatabase" and others
 - [#458](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458) — in-app report header for a 1-site analysis should say Community Report not Multisite Summary
+- [#159](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/159) — integrate file-naming function and header-creating functions
+- [#24](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/24) — map popups in make.popups.api() and other functions are too cluttered, move most info to separate popup (see example in comment)
 - [#179](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/179) — in ejam2excel() rename parameter fname to filename for consistency w other functions
 - [#174](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/174) — round to only 1 digit the area in square miles in header of summary report
 - [#464](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/464) — Investigate and solve high cost on AWS Fargate
 - [#181](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/181) — add other ejam2xyz functions to basics.Rmd as examples
 - [#93](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/93) — make Demog. section of summary report table more visually prominent
 - [#59](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/59) — Improve MACT-related  lat lon data
+- [#184](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/184) — trim the extremely long unit test names
+- [#43](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/43) — Enable fast site selection map during category scrolling
+- [#41](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/41) — Include indicator formulas in Community Report
+- [#39](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/39) — Review/revise/expand unit testing for SIC functions
 - [#482](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/482) — Feature: zipcode analysis — accept zipcode parameter in ejamit() and key functions
 - [#183](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/183) — use more standardized format in NEWS / changelog?
 - [#343](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/343) — check/loosen/drop minimum required version of each package specified in DESCRIPTION file
 - [#42](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/42) — Remove unused report template files
+- [#60](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60) — Rename community report functions with common convention
 
 | # | Issue | Cost | Benefit | Milestone | Priority | Labels (key) |
 |---|-------|------|---------|-----------|----------|--------------|
@@ -258,35 +255,33 @@
 | [176](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/176) | popups reports in county case are not normal/ignore reports settings? | 0 (🟢 Very Low) | 4 (⬜ Low) | NA | PRIORITY LOW | Affects Web App, Community Report, rank:C-low-value-low-cost |
 | [175](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/175) | drop the excel column called "Area of block group in geodatabase" and … | 0 (🟢 Very Low) | 4 (⬜ Low) | NA | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
 | [458](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458) | in-app report header for a 1-site analysis should say Community Report… | 1 (🟢 Very Low) | 4 (⬜ Low) | v4 | PRIORITY LOW | Affects Web App, Community Report |
+| [159](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/159) | integrate file-naming function and header-creating functions | 3 (🔵 Low) | 4 (⬜ Low) | NA | PRIORITY LOW | refactor, Affects Web App, Community Report, rank:C-low-value-low-cost |
+| [24](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/24) | map popups in make.popups.api() and other functions are too cluttered,… | 3 (🔵 Low) | 4 (⬜ Low) | NA | PRIORITY LOW | map-popups-related, rank:C-low-value-low-cost |
 | [179](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/179) | in ejam2excel() rename parameter fname to filename for consistency w o… | 0 (🟢 Very Low) | 3 (⬜ Low) | NA | PRIORITY LOW | refactor, Affects R users only - NOT web app users, rank:C-low-value-low-cost |
 | [174](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/174) | round to only 1 digit the area in square miles in header of summary re… | 0 (🟢 Very Low) | 3 (⬜ Low) | NA | PRIORITY LOW | Affects Web App, Community Report, rank:C-low-value-low-cost |
 | [464](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/464) | Investigate and solve high cost on AWS Fargate | 2 (🔵 Low) | 3 (⬜ Low) | NA | — | Affects Web App |
 | [181](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/181) | add other ejam2xyz functions to basics.Rmd as examples | 1 (🟢 Very Low) | 2 (⬜ Low) | NA | PRIORITY LOW | documentation, refactor, Affects R users only - NOT web app users, rank:C-low-value-low-cost |
 | [93](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/93) | make Demog. section of summary report table more visually prominent | 2 (🔵 Low) | 2 (⬜ Low) | NA | PRIORITY LOW | Community Report, rank:C-low-value-low-cost |
 | [59](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/59) | Improve MACT-related  lat lon data | 2 (🔵 Low) | 2 (⬜ Low) | NA | PRIORITY LOW | rank:C-low-value-low-cost |
+| [184](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/184) | trim the extremely long unit test names | 3 (🔵 Low) | 2 (⬜ Low) | NA | PRIORITY LOW | documentation, refactor, Affects R users only - NOT web app users, rank:C-low-value-low-cost |
+| [43](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/43) | Enable fast site selection map during category scrolling | 3 (🔵 Low) | 2 (⬜ Low) | NA | PRIORITY LOW | maps-related, rank:C-low-value-low-cost |
+| [41](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/41) | Include indicator formulas in Community Report | 3 (🔵 Low) | 2 (⬜ Low) | NA | PRIORITY LOW | Community Report, rank:C-low-value-low-cost |
+| [39](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/39) | Review/revise/expand unit testing for SIC functions | 3 (🔵 Low) | 2 (⬜ Low) | NA | PRIORITY LOW | test, rank:C-low-value-low-cost |
 | [482](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/482) | Feature: zipcode analysis — accept zipcode parameter in ejamit() and k… | 2 (🔵 Low) | 1 (⬜ Very Low) | v4 | PRIORITY LOW |  |
 | [183](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/183) | use more standardized format in NEWS / changelog? | 0 (🟢 Very Low) | 0 (⬜ Very Low) | NA | PRIORITY LOW | documentation, refactor, Affects R users only - NOT web app users, rank:C-low-value-low-cost |
 | [343](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/343) | check/loosen/drop minimum required version of each package specified i… | 1 (🟢 Very Low) | 0 (⬜ Very Low) | NA | — | rank:C-low-value-low-cost |
 | [42](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/42) | Remove unused report template files | 1 (🟢 Very Low) | 0 (⬜ Very Low) | NA | PRIORITY LOW | Community Report, rank:C-low-value-low-cost |
+| [60](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60) | Rename community report functions with common convention | 3 (🔵 Low) | 0 (⬜ Very Low) | NA | PRIORITY LOW | documentation, refactor, server, Community Report |
 
 ---
 
 ## Quadrant D — WORST CANDIDATES — High Cost, Low Benefit
 *Expensive to fix, limited payoff. Defer or deprioritize unless circumstances change.*
 
-**32 issues**
+**23 issues**
 
-- [#242](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/242) — Report should show ratios to avg for special indicators like % of residents who are in CEJST disadvantaged or air nonattainment areas
-- [#159](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/159) — integrate file-naming function and header-creating functions
-- [#24](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/24) — map popups in make.popups.api() and other functions are too cluttered, move most info to separate popup (see example in comment)
-- [#184](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/184) — trim the extremely long unit test names
-- [#43](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/43) — Enable fast site selection map during category scrolling
-- [#41](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/41) — Include indicator formulas in Community Report
-- [#39](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/39) — Review/revise/expand unit testing for SIC functions
-- [#60](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60) — Rename community report functions with common convention
 - [#508](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/508) — ECR lifecycle policy: prune accumulating dev images (without touching prod)
 - [#507](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/507) — deploy-dev: encode the deployed EJAM version in the dev ECR image tag
-- [#465](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/465) — EJAM app crashes on EJScreen token handoff (Send to EJAM) for FIPS/polygon/bufferless selections
 - [#182](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/182) — consider refactoring url_xyz functions
 - [#89](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/89) — clarify what "N places" really means & report on the selection type (in summary report etc.)
 - [#35](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/35) — Review/revise/expand unit testing for URL functions
@@ -311,17 +306,8 @@
 
 | # | Issue | Cost | Benefit | Milestone | Priority | Labels (key) |
 |---|-------|------|---------|-----------|----------|--------------|
-| [242](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/242) | Report should show ratios to avg for special indicators like % of resi… | 3 (🔵 Low) | 4 (⬜ Low) | NA | PRIORITY MEDIUM | Community Report, rank:C-low-value-low-cost |
-| [159](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/159) | integrate file-naming function and header-creating functions | 3 (🔵 Low) | 4 (⬜ Low) | NA | PRIORITY LOW | refactor, Affects Web App, Community Report, rank:C-low-value-low-cost |
-| [24](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/24) | map popups in make.popups.api() and other functions are too cluttered,… | 3 (🔵 Low) | 4 (⬜ Low) | NA | PRIORITY LOW | map-popups-related, rank:C-low-value-low-cost |
-| [184](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/184) | trim the extremely long unit test names | 3 (🔵 Low) | 2 (⬜ Low) | NA | PRIORITY LOW | documentation, refactor, Affects R users only - NOT web app users, rank:C-low-value-low-cost |
-| [43](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/43) | Enable fast site selection map during category scrolling | 3 (🔵 Low) | 2 (⬜ Low) | NA | PRIORITY LOW | maps-related, rank:C-low-value-low-cost |
-| [41](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/41) | Include indicator formulas in Community Report | 3 (🔵 Low) | 2 (⬜ Low) | NA | PRIORITY LOW | Community Report, rank:C-low-value-low-cost |
-| [39](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/39) | Review/revise/expand unit testing for SIC functions | 3 (🔵 Low) | 2 (⬜ Low) | NA | PRIORITY LOW | test, rank:C-low-value-low-cost |
-| [60](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60) | Rename community report functions with common convention | 3 (🔵 Low) | 0 (⬜ Very Low) | NA | PRIORITY LOW | documentation, refactor, server, Community Report |
 | [508](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/508) | ECR lifecycle policy: prune accumulating dev images (without touching … | 4 (🟡 Medium) | 4 (⬜ Low) | NA | PRIORITY MEDIUM |  |
 | [507](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/507) | deploy-dev: encode the deployed EJAM version in the dev ECR image tag | 4 (🟡 Medium) | 4 (⬜ Low) | NA | PRIORITY MEDIUM |  |
-| [465](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/465) | EJAM app crashes on EJScreen token handoff (Send to EJAM) for FIPS/pol… | 4 (🟡 Medium) | 4 (⬜ Low) | NA | — |  |
 | [182](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/182) | consider refactoring url_xyz functions | 4 (🟡 Medium) | 4 (⬜ Low) | NA | PRIORITY LOW | refactor, Affects R users only - NOT web app users, rank:D-defer |
 | [89](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/89) | clarify what "N places" really means & report on the selection type (i… | 4 (🟡 Medium) | 4 (⬜ Low) | NA | PRIORITY LOW | still relevant?, Affects Web App, rank:D-defer |
 | [35](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/35) | Review/revise/expand unit testing for URL functions | 4 (🟡 Medium) | 2 (⬜ Low) | NA | PRIORITY LOW | test, URL-related, rank:D-defer |
@@ -346,26 +332,25 @@
 
 ---
 
-## Full Table — All 137 Issues
+## Full Table — All 130 Issues
 
 Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 
 | Quad | Issue # | Cost | Benefit | Milestone | Priority | Title |
 |------|---------|------|---------|-----------|----------|-------|
-| A | [156](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/156) | 0 | 17 | NA | PRIORITY HIGH-ish but not a bug | in app - add view of   ejam2areafeatures(out)  (info on % of pop with ce… |
+| A | [504](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504) | 3 | 17 | v4 | PRIORITY MEDIUM | Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate task … |
 | A | [152](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/152) | 0 | 15 | NA | PRIORITY HIGH-ish but not a bug | build_community_report() needs unit tests, table_signif_round_x100() or … |
-| A | [385](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/385) | 1 | 15 | v4 | PRIORITY MEDIUM | ejam2report() fails to save a file when the filename parameter is used |
-| A | [348](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/348) | 2 | 15 | v3.2022.2 | PRIORITY MEDIUM | API report links from multisite results label every per-site report as s… |
 | A | [274](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/274) | 2 | 15 | NA | PRIORITY HIGH-ish but not a bug | Add the features not yet restored from the pre-2025 EPA version of the C… |
-| A | [205](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/205) | 2 | 15 | NA | PRIORITY HIGH-ish but not a bug | adjust summary report fonts and row heights/line spacing to make text mo… |
+| A | [342](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342) | 3 | 15 | NA | PRIORITY HIGH-ish but not a bug | use renv package to create lock state for what versions of what packages… |
+| A | [341](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341) | 3 | 15 | NA | PRIORITY HIGH-ish but not a bug | Align map_headernames and/or generated avg/pctile/ratio metadata with co… |
 | A | [16](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16) | 2 | 14 | v4 | PRIORITY HIGH | need new/updated "User Guide" ("Help" in header at right) since UI has c… |
-| A | [144](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/144) | 0 | 13 | v3.2022.2 | PRIORITY MEDIUM | use or remove or explain the sitenumber parameter in ejam2map() for fips… |
-| A | [127](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/127) | 0 | 13 | v3.2022.2 | PRIORITY MEDIUM | web app details tab with table of all sites is too sluggish as it appear… |
-| A | [344](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344) | 2 | 12 | NA | PRIORITY HIGH-ish but not a bug | Show an example of a community report - e.g., in or linked from "basics"… |
+| A | [400](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400) | 3 | 13 | NA | PRIORITY HIGH | improve how webapp users can find info on data vintage (in EJAM web app … |
+| A | [344](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344) | 2 | 12 | v4 | PRIORITY HIGH-ish but not a bug | Show an example of a community report - e.g., in or linked from "basics"… |
 | A | [249](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/249) | 2 | 12 | v3.2022.2 | PRIORITY LOW | ejam2report() fails if filename is specified without path, or with "./xy… |
-| A | [410](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/410) | 1 | 11 | v3.2022.2 | PRIORITY MEDIUM | "FEATURES AND LOCATION INFORMATION" on report need explanation and less … |
 | A | [137](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/137) | 1 | 11 | v4 | PRIORITY MEDIUM | fix bug in popshare_at_top_x_pct() - results sometimes not quite right. … |
-| A | [109](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/109) | 1 | 10 | NA | PRIORITY LOW | Update & correct the article "Defaults and Custom Settings for the Web A… |
+| A | [268](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/268) | 2 | 11 | NA | — | Uploading a file was failing intermittently when live app hosted using A… |
+| A | [109](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/109) | 1 | 10 | v4 | PRIORITY LOW | Update & correct the article "Defaults and Custom Settings for the Web A… |
+| A | [73](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73) | 3 | 10 | NA | PRIORITY MEDIUM | in web app, add ways to analyze multiple radii at once or even continuou… |
 | A | [354](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/354) | 2 | 9 | NA | PRIORITY MEDIUM | consider if downloaded report map and/or excel can use polygons in map t… |
 | A | [166](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/166) | 2 | 9 | NA | PRIORITY MEDIUM | could simplify polygons before mapping, saving - check if useful and the… |
 | A | [223](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/223) | 2 | 8 | NA | PRIORITY LOW | app_title parameter is not working in ejamapp() |
@@ -376,42 +361,42 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | A | [490](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490) | 1 | 7 | v4 | PRIORITY MEDIUM | swap us and state ratio columns |
 | A | [361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) | 1 | 7 | NA | PRIORITY MEDIUM | Add date and time of last updated to help with deploys |
 | A | [163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) | 1 | 7 | NA | PRIORITY MEDIUM | put certain columns last in table of results (bg count, block count, rad… |
-| A | [162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) | 1 | 7 | NA | PRIORITY MEDIUM | rename "in_how_many_states"   column  in table of results |
-| A | [136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | 1 | 7 | NA | PRIORITY LOW | in web app, fix console  error msg when uploading a shapefile |
-| A | [288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) | 2 | 7 | NA | PRIORITY MEDIUM | ratio of 1.0 should not be yellow on community report |
+| A | [162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) | 1 | 7 | v4 | PRIORITY MEDIUM | rename "in_how_many_states"   column  in table of results |
+| A | [136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | 1 | 7 | v4 | PRIORITY LOW | in web app, fix console  error msg when uploading a shapefile |
+| A | [288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) | 2 | 7 | v3.2022.2 | PRIORITY MEDIUM | ratio of 1.0 should not be yellow on community report |
 | A | [70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) | 2 | 7 | NA | PRIORITY MEDIUM | set up alerts that monitor and alert staff when the app goes down - ensu… |
+| A | [484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) | 3 | 7 | v4 | PRIORITY MEDIUM | in overall table, change EJAM Report link for 1-site analysis |
 | A | [486](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486) | 1 | 6 | v4 | PRIORITY LOW | allow zip code analysis in EJAM shiny web app |
+| A | [284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) | 3 | 6 | NA | PRIORITY LOW | resolve warning about datum, in logs/console, when web app tries to uplo… |
 | A | [102](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102) | 0 | 5 | NA | PRIORITY LOW | Remove NA console messages from `doaggregate` |
 | A | [455](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/455) | 1 | 5 | v4 | PRIORITY LOW | fix radius slider behavior after deep link passes a radius and then user… |
 | A | [403](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403) | 1 | 5 | NA | PRIORITY MEDIUM | Add explanation of what "average in state" or "percentile in state" mean… |
 | A | [350](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350) | 2 | 5 | NA | PRIORITY LOW | Add report regression tests for FIPS, shapefile, sitenumber, NAICS, and … |
 | A | [96](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/96) | 2 | 5 | NA | PRIORITY LOW | Detailed Table UI Filtering improvements |
 | A | [92](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92) | 2 | 5 | NA | PRIORITY LOW | Excel's new tab with upload needs cap on size |
-| A | [69](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/69) | 2 | 5 | NA | PRIORITY MEDIUM | enable other units like kilometers for entry of radius |
 | A | [58](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58) | 2 | 5 | NA | PRIORITY MEDIUM | joining FIPS upload data to preview table |
-| B | [467](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/467) | 4 | 20 | v3.2022.2 | PRIORITY HIGH | ejam2report() fails for zero-population or otherwise analysis-invalid si… |
+| A | [454](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454) | 3 | 5 | v4 | PRIORITY LOW | fix when should radius slider reset to 0 vs 1 mile (a method-specific de… |
+| A | [224](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224) | 3 | 5 | NA | PRIORITY LOW | report correct population for a single block (if block is analyzed via b… |
+| A | [40](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40) | 3 | 5 | NA | PRIORITY MEDIUM | Allow abort site selection processing when selections are changed |
 | B | [293](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/293) | 5 | 19 | v4 | PRIORITY HIGH-ish but not a bug | API takes too long to create a community report from when user clicks |
-| B | [504](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504) | 3 | 17 | v4 | PRIORITY MEDIUM | Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate task … |
+| B | [513](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/513) | 6 | 17 | v4 | PRIORITY HIGH | need better ETA estimates (predicted seconds to completion are too high) |
 | B | [52](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/52) | 8 | 17 | NA | PRIORITY HIGH-ish but not a bug | Create density score /proximity score/ count-nearby functions, then prov… |
 | B | [44](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/44) | 18 | 17 | NA | PRIORITY HIGH-ish but not a bug | Investigate options for asynchronous processing in R Shiny (espec for sp… |
 | B | [226](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/226) | 7 | 16 | NA | PRIORITY HIGH-ish but not a bug | NOTES on SPEEDING UP app & functions (incl load testing) |
-| B | [342](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342) | 3 | 15 | NA | PRIORITY HIGH-ish but not a bug | use renv package to create lock state for what versions of what packages… |
-| B | [341](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341) | 3 | 15 | NA | PRIORITY HIGH-ish but not a bug | Align map_headernames and/or generated avg/pctile/ratio metadata with co… |
 | B | [349](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/349) | 4 | 15 | v4 | PRIORITY MEDIUM | Polygon report links recompute API reports from simplified GeoJSON |
 | B | [153](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/153) | 4 | 15 | NA | PRIORITY HIGH-ish but not a bug | revisit work in progress on this list of .R files |
 | B | [193](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/193) | 5 | 15 | NA | PRIORITY HIGH-ish but not a bug | Create Executive Summary helper functions - summarizer / Methods for Ide… |
-| B | [400](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400) | 3 | 13 | NA | PRIORITY HIGH | improve how webapp users can find info on data vintage (in EJAM web app … |
 | B | [68](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/68) | 4 | 13 | NA | PRIORITY HIGH-ish but not a bug | allow user to type in radius not only use slider |
 | B | [46](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46) | 8 | 13 | NA | PRIORITY HIGH-ish but not a bug | Long Report text needed |
 | B | [126](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126) | 4 | 11 | NA | PRIORITY MEDIUM | enable 1-site report on Polygons / Shapefile, via links/buttons in shiny… |
-| B | [73](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73) | 3 | 10 | NA | PRIORITY MEDIUM | in web app, add ways to analyze multiple radii at once or even continuou… |
 | B | [279](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279) | 5 | 10 | NA | PRIORITY MEDIUM | Prepare the package to submit to CRAN (and get it accepted for hosting o… |
 | B | [87](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/87) | 6 | 10 | NA | PRIORITY MEDIUM | Enable shiny.telemetry log file that is not just a text file on server |
 | B | [31](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31) | 4 | 9 | NA | PRIORITY MEDIUM | fix distance_avg in doaggregate()$results_bybg_people |
 | B | [56](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/56) | 6 | 9 | NA | PRIORITY MEDIUM | check/ fix Distance and Site Count summary stats, in doaggregate() |
 | B | [135](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135) | 4 | 8 | NA | PRIORITY LOW | finish work in progress on default_ss_choose_method  vs input$ ? |
 | B | [19](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/19) | 6 | 8 | Data Updates | PRIORITY MEDIUM | FIPS missing/problems (mostly in Connecticut) |
-| B | [484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) | 3 | 7 | v4 | PRIORITY MEDIUM | in overall table, change EJAM Report link for 1-site analysis |
+| B | [511](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/511) | 4 | 7 | NA | PRIORITY MEDIUM | CI runs only on PRs into main: development and deploy PRs get no checks … |
+| B | [510](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/510) | 4 | 7 | NA | PRIORITY MEDIUM | Smoke-test PDF generation in the built image and after deploy (prod PDF … |
 | B | [172](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/172) | 4 | 7 | NA | PRIORITY MEDIUM | create "sites_from_anything" func to allow any types of inputs specifyin… |
 | B | [82](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/82) | 4 | 7 | NA | PRIORITY MEDIUM | confusing UI: a user names the analysis #1, then forgets to change title… |
 | B | [81](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/81) | 4 | 7 | NA | PRIORITY MEDIUM | confusion in UI: if user tries a second analysis by uploading new stuff,… |
@@ -423,13 +408,9 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | B | [168](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/168) | 8 | 7 | NA | PRIORITY MEDIUM | refactor/reconcile "report_logo" vs "logo_path" (parameters and/or globa… |
 | B | [256](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/256) | 9 | 7 | NA | PRIORITY MEDIUM | speed up some functions by using .arrow not .rda version of each large d… |
 | B | [169](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/169) | 9 | 7 | NA | PRIORITY MEDIUM | harmonize/refactor functions that create or sanitize filenames, paths |
-| B | [284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) | 3 | 6 | NA | PRIORITY LOW | resolve warning about datum, in logs/console, when web app tries to uplo… |
 | B | [194](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194) | 5 | 6 | NA | PRIORITY MEDIUM | Create visualizations of overall results in app  - engaging & insightful |
 | B | [54](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/54) | 9 | 6 | NA | PRIORITY LOW | correctly handle cases where the adjusted distance (via block_radius_mil… |
 | B | [66](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66) | 10 | 6 | v4 | PRIORITY LOW | EJAM & EJScreen report on avg PERSON generally but State Average or US A… |
-| B | [454](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454) | 3 | 5 | v4 | PRIORITY LOW | fix when should radius slider reset to 0 vs 1 mile (a method-specific de… |
-| B | [224](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224) | 3 | 5 | NA | PRIORITY LOW | report correct population for a single block (if block is analyzed via b… |
-| B | [40](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40) | 3 | 5 | NA | PRIORITY MEDIUM | Allow abort site selection processing when selections are changed |
 | B | [83](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/83) | 4 | 5 | NA | PRIORITY LOW | enable selecting a folder as way to upload shapefile(s) |
 | B | [74](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/74) | 4 | 5 | NA | PRIORITY MEDIUM | Develop options for defining the Reference Zone or Ref. Group - avg pers… |
 | B | [72](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/72) | 4 | 5 | NA | PRIORITY MEDIUM | find a way to map more polygons (than just 159 cap) |
@@ -447,27 +428,25 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | C | [176](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/176) | 0 | 4 | NA | PRIORITY LOW | popups reports in county case are not normal/ignore reports settings? |
 | C | [175](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/175) | 0 | 4 | NA | PRIORITY LOW | drop the excel column called "Area of block group in geodatabase" and ot… |
 | C | [458](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458) | 1 | 4 | v4 | PRIORITY LOW | in-app report header for a 1-site analysis should say Community Report n… |
+| C | [159](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/159) | 3 | 4 | NA | PRIORITY LOW | integrate file-naming function and header-creating functions |
+| C | [24](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/24) | 3 | 4 | NA | PRIORITY LOW | map popups in make.popups.api() and other functions are too cluttered, m… |
 | C | [179](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/179) | 0 | 3 | NA | PRIORITY LOW | in ejam2excel() rename parameter fname to filename for consistency w oth… |
 | C | [174](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/174) | 0 | 3 | NA | PRIORITY LOW | round to only 1 digit the area in square miles in header of summary repo… |
 | C | [464](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/464) | 2 | 3 | NA | — | Investigate and solve high cost on AWS Fargate |
 | C | [181](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/181) | 1 | 2 | NA | PRIORITY LOW | add other ejam2xyz functions to basics.Rmd as examples |
 | C | [93](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/93) | 2 | 2 | NA | PRIORITY LOW | make Demog. section of summary report table more visually prominent |
 | C | [59](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/59) | 2 | 2 | NA | PRIORITY LOW | Improve MACT-related  lat lon data |
+| C | [184](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/184) | 3 | 2 | NA | PRIORITY LOW | trim the extremely long unit test names |
+| C | [43](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/43) | 3 | 2 | NA | PRIORITY LOW | Enable fast site selection map during category scrolling |
+| C | [41](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/41) | 3 | 2 | NA | PRIORITY LOW | Include indicator formulas in Community Report |
+| C | [39](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/39) | 3 | 2 | NA | PRIORITY LOW | Review/revise/expand unit testing for SIC functions |
 | C | [482](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/482) | 2 | 1 | v4 | PRIORITY LOW | Feature: zipcode analysis — accept zipcode parameter in ejamit() and key… |
 | C | [183](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/183) | 0 | 0 | NA | PRIORITY LOW | use more standardized format in NEWS / changelog? |
 | C | [343](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/343) | 1 | 0 | NA | — | check/loosen/drop minimum required version of each package specified in … |
 | C | [42](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/42) | 1 | 0 | NA | PRIORITY LOW | Remove unused report template files |
-| D | [242](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/242) | 3 | 4 | NA | PRIORITY MEDIUM | Report should show ratios to avg for special indicators like % of reside… |
-| D | [159](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/159) | 3 | 4 | NA | PRIORITY LOW | integrate file-naming function and header-creating functions |
-| D | [24](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/24) | 3 | 4 | NA | PRIORITY LOW | map popups in make.popups.api() and other functions are too cluttered, m… |
-| D | [184](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/184) | 3 | 2 | NA | PRIORITY LOW | trim the extremely long unit test names |
-| D | [43](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/43) | 3 | 2 | NA | PRIORITY LOW | Enable fast site selection map during category scrolling |
-| D | [41](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/41) | 3 | 2 | NA | PRIORITY LOW | Include indicator formulas in Community Report |
-| D | [39](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/39) | 3 | 2 | NA | PRIORITY LOW | Review/revise/expand unit testing for SIC functions |
-| D | [60](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60) | 3 | 0 | NA | PRIORITY LOW | Rename community report functions with common convention |
+| C | [60](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60) | 3 | 0 | NA | PRIORITY LOW | Rename community report functions with common convention |
 | D | [508](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/508) | 4 | 4 | NA | PRIORITY MEDIUM | ECR lifecycle policy: prune accumulating dev images (without touching pr… |
 | D | [507](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/507) | 4 | 4 | NA | PRIORITY MEDIUM | deploy-dev: encode the deployed EJAM version in the dev ECR image tag |
-| D | [465](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/465) | 4 | 4 | NA | — | EJAM app crashes on EJScreen token handoff (Send to EJAM) for FIPS/polyg… |
 | D | [182](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/182) | 4 | 4 | NA | PRIORITY LOW | consider refactoring url_xyz functions |
 | D | [89](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/89) | 4 | 4 | NA | PRIORITY LOW | clarify what "N places" really means & report on the selection type (in … |
 | D | [35](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/35) | 4 | 2 | NA | PRIORITY LOW | Review/revise/expand unit testing for URL functions |
@@ -497,9 +476,9 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | Milestone | Issue count |
 |-----------|------------:|
 | Data Updates | 1 |
-| v3.2022.2 | 6 |
-| v4 | 14 |
-| NA | 116 |
+| v3.2022.2 | 2 |
+| v4 | 18 |
+| NA | 109 |
 
 ---
 
@@ -516,8 +495,8 @@ Each issue is scored independently on two dimensions:
 
 | Dimension | Range | Median (split threshold) |
 |-----------|-------|--------------------------|
-| Cost    | 0 – 18    | 3 |
-| Benefit | 0 – 20 | 5 |
+| Cost    | 0 – 18    | 4 |
+| Benefit | 0 – 19 | 5 |
 
 Issues at or above the median are **High**; below are **Low** for that dimension.
 

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.MD
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.MD
@@ -1,6 +1,6 @@
 # EJAM Open Issues — Scored by Cost & Benefit
 
-**Total open issues:** 130  |  **Generated:** 2026-07-25  |  **Source:** Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)
+**Total open issues:** 131  |  **Generated:** 2026-07-26  |  **Source:** Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)
 
 **Score payload:** `inst/issues/ejam_issues_scored_by_risk_and_value.json`
 
@@ -12,10 +12,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Previous run | 2026-07-24 |
-| Issues opened since previous run | 4 |
-| Issues closed since previous run | 11 |
-| Issues whose quadrant changed | 17 |
+| Previous run | 2026-07-25 |
+| Issues opened since previous run | 2 |
+| Issues closed since previous run | 1 |
+| Issues whose quadrant changed | 0 |
 
 ---
 
@@ -23,28 +23,27 @@
 
 | Cost / Benefit | **LOW Benefit**<br>value < median | **HIGH Benefit**<br>value ≥ median |
 |---|---|---|
-| **LOW Cost**<br>cost < median | **C — Might As Well**<br>21 issues | **A — BEST CANDIDATES**<br>40 issues |
-| **HIGH Cost**<br>cost ≥ median | **D — WORST CANDIDATES**<br>23 issues | **B — OK Candidates**<br>46 issues |
+| **LOW Cost**<br>cost < median | **C — Might As Well**<br>22 issues | **A — BEST CANDIDATES**<br>39 issues |
+| **HIGH Cost**<br>cost ≥ median | **D — WORST CANDIDATES**<br>23 issues | **B — OK Candidates**<br>47 issues |
 
 ---
 
 ## Quadrant A — BEST CANDIDATES — Low Cost, High Benefit
 *Easy fixes with clear high value. Prioritize these above all others.*
 
-**40 issues**
+**39 issues**
 
+- [#16](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16) — need new/updated "User Guide" ("Help" in header at right) since UI has changed a lot, etc.
 - [#504](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504) — Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate task during blockgroup join
 - [#152](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/152) — build_community_report() needs unit tests, table_signif_round_x100() or table_round() too
 - [#274](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/274) — Add the features not yet restored from the pre-2025 EPA version of the Community Report
 - [#342](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342) — use renv package to create lock state for what versions of what packages are used
 - [#341](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341) — Align map_headernames and/or generated avg/pctile/ratio metadata with columns doaggregate() can produce for the report
-- [#16](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16) — need new/updated "User Guide" ("Help" in header at right) since UI has changed a lot, etc.
 - [#400](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400) — improve how webapp users can find info on data vintage (in EJAM web app UI, from community report, and from EJScreen UI)
 - [#344](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344) — Show an example of a community report - e.g., in or linked from "basics" vignette
 - [#249](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/249) — ejam2report() fails if filename is specified without path, or with "./xyz.html"
 - [#137](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/137) — fix bug in popshare_at_top_x_pct() - results sometimes not quite right. seems to interpolate badly.
 - [#268](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/268) — Uploading a file was failing intermittently when live app hosted using AWS with load balancing
-- [#109](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/109) — Update & correct the article "Defaults and Custom Settings for the Web App"
 - [#73](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73) — in web app, add ways to analyze multiple radii at once or even continuous radius
 - [#354](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/354) — consider if downloaded report map and/or excel can use polygons in map to do POST API request for 1-site report
 - [#166](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/166) — could simplify polygons before mapping, saving - check if useful and then implement
@@ -76,18 +75,17 @@
 
 | # | Issue | Cost | Benefit | Milestone | Priority | Labels (key) |
 |---|-------|------|---------|-----------|----------|--------------|
+| [16](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16) | need new/updated "User Guide" ("Help" in header at right) since UI has… | 2 (🔵 Low) | 17 (🟩🟩 Very High) | v4 | PRIORITY HIGH | BUG, documentation, help wanted, good first issue |
 | [504](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504) | Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate tas… | 3 (🔵 Low) | 17 (🟩🟩 Very High) | v4 | PRIORITY MEDIUM | BUG, Affects Web App |
 | [152](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/152) | build_community_report() needs unit tests, table_signif_round_x100() o… | 0 (🟢 Very Low) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | test, Affects Web App, Community Report, rank:A-high-value-low-cost |
 | [274](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/274) | Add the features not yet restored from the pre-2025 EPA version of the… | 2 (🔵 Low) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | Affects Web App, Community Report, rank:A-high-value-low-cost |
 | [342](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342) | use renv package to create lock state for what versions of what packag… | 3 (🔵 Low) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | help wanted, Affects Web App, rank:A-high-value-low-cost |
 | [341](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341) | Align map_headernames and/or generated avg/pctile/ratio metadata with … | 3 (🔵 Low) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | Affects Web App, Community Report, rank:A-high-value-low-cost |
-| [16](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16) | need new/updated "User Guide" ("Help" in header at right) since UI has… | 2 (🔵 Low) | 14 (🟩🟩 Very High) | v4 | PRIORITY HIGH | BUG, documentation, help wanted, good first issue |
 | [400](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400) | improve how webapp users can find info on data vintage (in EJAM web ap… | 3 (🔵 Low) | 13 (🟩🟩 Very High) | NA | PRIORITY HIGH | Affects Web App, rank:A-high-value-low-cost |
 | [344](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344) | Show an example of a community report - e.g., in or linked from "basic… | 2 (🔵 Low) | 12 (🟩🟦 High) | v4 | PRIORITY HIGH-ish but not a bug | documentation, help wanted, good first issue, rank:A-high-value-low-cost |
 | [249](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/249) | ejam2report() fails if filename is specified without path, or with "./… | 2 (🔵 Low) | 12 (🟩🟦 High) | v3.2022.2 | PRIORITY LOW | BUG, Affects R users only - NOT web app users, rank:A-high-value-low-cost |
 | [137](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/137) | fix bug in popshare_at_top_x_pct() - results sometimes not quite right… | 1 (🟢 Very Low) | 11 (🟩🟦 High) | v4 | PRIORITY MEDIUM | BUG, Affects Web App, rank:A-high-value-low-cost |
 | [268](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/268) | Uploading a file was failing intermittently when live app hosted using… | 2 (🔵 Low) | 11 (🟩🟦 High) | NA | — | BUG, Affects Web App |
-| [109](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/109) | Update & correct the article "Defaults and Custom Settings for the Web… | 1 (🟢 Very Low) | 10 (🟩🟦 High) | v4 | PRIORITY LOW | BUG, documentation, Affects R users only - NOT web app users, rank:A-high-value-low-cost |
 | [73](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73) | in web app, add ways to analyze multiple radii at once or even continu… | 3 (🔵 Low) | 10 (🟩🟦 High) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
 | [354](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/354) | consider if downloaded report map and/or excel can use polygons in map… | 2 (🔵 Low) | 9 (🟩🟦 High) | NA | PRIORITY MEDIUM | Affects Web App, Community Report, rank:A-high-value-low-cost |
 | [166](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/166) | could simplify polygons before mapping, saving - check if useful and t… | 2 (🔵 Low) | 9 (🟩🟦 High) | NA | PRIORITY MEDIUM | Affects Web App, API, rank:A-high-value-low-cost |
@@ -122,7 +120,7 @@
 ## Quadrant B — OK Candidates — High Cost, High Benefit
 *Worth doing but require more effort or expertise. Plan carefully before starting.*
 
-**46 issues**
+**47 issues**
 
 - [#293](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/293) — API takes too long to create a community report from when user clicks
 - [#513](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/513) — need better ETA estimates (predicted seconds to completion are too high)
@@ -134,6 +132,7 @@
 - [#193](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/193) — Create Executive Summary helper functions - summarizer / Methods for Identifying and Focusing on Key Findings
 - [#68](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/68) — allow user to type in radius not only use slider
 - [#46](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46) — Long Report text needed
+- [#527](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/527) — shapes_from_fips() errors offline even when the county boundary is built into the package
 - [#126](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126) — enable 1-site report on Polygons / Shapefile, via links/buttons in shiny map popups and table of sites (but NOT outside shiny like in URL-based/link in Excel table)
 - [#279](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279) — Prepare the package to submit to CRAN (and get it accepted for hosting on CRAN)
 - [#87](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/87) — Enable shiny.telemetry log file that is not just a text file on server
@@ -183,6 +182,7 @@
 | [193](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/193) | Create Executive Summary helper functions - summarizer / Methods for I… | 5 (🟡 Medium) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | LongReport_output, Affects Web App, future plan list, rank:B-high-value-high-cost |
 | [68](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/68) | allow user to type in radius not only use slider | 4 (🟡 Medium) | 13 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | rank:B-high-value-high-cost |
 | [46](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46) | Long Report text needed | 8 (🟠 High) | 13 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | LongReport_output, future plan list, rank:B-high-value-high-cost |
+| [527](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/527) | shapes_from_fips() errors offline even when the county boundary is bui… | 4 (🟡 Medium) | 11 (🟩🟦 High) | v4 | PRIORITY MEDIUM | BUG, test, Affects R users only - NOT web app users |
 | [126](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126) | enable 1-site report on Polygons / Shapefile, via links/buttons in shi… | 4 (🟡 Medium) | 11 (🟩🟦 High) | NA | PRIORITY MEDIUM | Affects Web App, API, rank:B-high-value-high-cost |
 | [279](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279) | Prepare the package to submit to CRAN (and get it accepted for hosting… | 5 (🟡 Medium) | 10 (🟩🟦 High) | NA | PRIORITY MEDIUM | help wanted, Affects R users only - NOT web app users, rank:B-high-value-high-cost |
 | [87](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/87) | Enable shiny.telemetry log file that is not just a text file on server | 6 (🟡 Medium) | 10 (🟩🟦 High) | NA | PRIORITY MEDIUM | datasets-related, Affects Web App, rank:B-high-value-high-cost |
@@ -225,7 +225,7 @@
 ## Quadrant C — Might As Well — Low Cost, Low Benefit
 *Cheap to do; low urgency. Pick these up when bandwidth allows or combine with nearby work.*
 
-**21 issues**
+**22 issues**
 
 - [#177](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/177) — pick which approach is faster among functions like sf_nearest_points() and related
 - [#176](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/176) — popups reports in county case are not normal/ignore reports settings?
@@ -236,6 +236,7 @@
 - [#179](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/179) — in ejam2excel() rename parameter fname to filename for consistency w other functions
 - [#174](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/174) — round to only 1 digit the area in square miles in header of summary report
 - [#464](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/464) — Investigate and solve high cost on AWS Fargate
+- [#535](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/535) — Consolidate app-settings vignette: EJScreen deep links + cross-vignette overlap
 - [#181](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/181) — add other ejam2xyz functions to basics.Rmd as examples
 - [#93](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/93) — make Demog. section of summary report table more visually prominent
 - [#59](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/59) — Improve MACT-related  lat lon data
@@ -260,6 +261,7 @@
 | [179](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/179) | in ejam2excel() rename parameter fname to filename for consistency w o… | 0 (🟢 Very Low) | 3 (⬜ Low) | NA | PRIORITY LOW | refactor, Affects R users only - NOT web app users, rank:C-low-value-low-cost |
 | [174](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/174) | round to only 1 digit the area in square miles in header of summary re… | 0 (🟢 Very Low) | 3 (⬜ Low) | NA | PRIORITY LOW | Affects Web App, Community Report, rank:C-low-value-low-cost |
 | [464](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/464) | Investigate and solve high cost on AWS Fargate | 2 (🔵 Low) | 3 (⬜ Low) | NA | — | Affects Web App |
+| [535](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/535) | Consolidate app-settings vignette: EJScreen deep links + cross-vignett… | 1 (🟢 Very Low) | 2 (⬜ Low) | v4 | PRIORITY LOW | documentation, Affects R users only - NOT web app users |
 | [181](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/181) | add other ejam2xyz functions to basics.Rmd as examples | 1 (🟢 Very Low) | 2 (⬜ Low) | NA | PRIORITY LOW | documentation, refactor, Affects R users only - NOT web app users, rank:C-low-value-low-cost |
 | [93](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/93) | make Demog. section of summary report table more visually prominent | 2 (🔵 Low) | 2 (⬜ Low) | NA | PRIORITY LOW | Community Report, rank:C-low-value-low-cost |
 | [59](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/59) | Improve MACT-related  lat lon data | 2 (🔵 Low) | 2 (⬜ Low) | NA | PRIORITY LOW | rank:C-low-value-low-cost |
@@ -332,24 +334,23 @@
 
 ---
 
-## Full Table — All 130 Issues
+## Full Table — All 131 Issues
 
 Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 
 | Quad | Issue # | Cost | Benefit | Milestone | Priority | Title |
 |------|---------|------|---------|-----------|----------|-------|
+| A | [16](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16) | 2 | 17 | v4 | PRIORITY HIGH | need new/updated "User Guide" ("Help" in header at right) since UI has c… |
 | A | [504](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504) | 3 | 17 | v4 | PRIORITY MEDIUM | Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate task … |
 | A | [152](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/152) | 0 | 15 | NA | PRIORITY HIGH-ish but not a bug | build_community_report() needs unit tests, table_signif_round_x100() or … |
 | A | [274](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/274) | 2 | 15 | NA | PRIORITY HIGH-ish but not a bug | Add the features not yet restored from the pre-2025 EPA version of the C… |
 | A | [342](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342) | 3 | 15 | NA | PRIORITY HIGH-ish but not a bug | use renv package to create lock state for what versions of what packages… |
 | A | [341](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341) | 3 | 15 | NA | PRIORITY HIGH-ish but not a bug | Align map_headernames and/or generated avg/pctile/ratio metadata with co… |
-| A | [16](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16) | 2 | 14 | v4 | PRIORITY HIGH | need new/updated "User Guide" ("Help" in header at right) since UI has c… |
 | A | [400](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400) | 3 | 13 | NA | PRIORITY HIGH | improve how webapp users can find info on data vintage (in EJAM web app … |
 | A | [344](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344) | 2 | 12 | v4 | PRIORITY HIGH-ish but not a bug | Show an example of a community report - e.g., in or linked from "basics"… |
 | A | [249](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/249) | 2 | 12 | v3.2022.2 | PRIORITY LOW | ejam2report() fails if filename is specified without path, or with "./xy… |
 | A | [137](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/137) | 1 | 11 | v4 | PRIORITY MEDIUM | fix bug in popshare_at_top_x_pct() - results sometimes not quite right. … |
 | A | [268](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/268) | 2 | 11 | NA | — | Uploading a file was failing intermittently when live app hosted using A… |
-| A | [109](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/109) | 1 | 10 | v4 | PRIORITY LOW | Update & correct the article "Defaults and Custom Settings for the Web A… |
 | A | [73](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73) | 3 | 10 | NA | PRIORITY MEDIUM | in web app, add ways to analyze multiple radii at once or even continuou… |
 | A | [354](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/354) | 2 | 9 | NA | PRIORITY MEDIUM | consider if downloaded report map and/or excel can use polygons in map t… |
 | A | [166](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/166) | 2 | 9 | NA | PRIORITY MEDIUM | could simplify polygons before mapping, saving - check if useful and the… |
@@ -388,6 +389,7 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | B | [193](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/193) | 5 | 15 | NA | PRIORITY HIGH-ish but not a bug | Create Executive Summary helper functions - summarizer / Methods for Ide… |
 | B | [68](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/68) | 4 | 13 | NA | PRIORITY HIGH-ish but not a bug | allow user to type in radius not only use slider |
 | B | [46](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46) | 8 | 13 | NA | PRIORITY HIGH-ish but not a bug | Long Report text needed |
+| B | [527](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/527) | 4 | 11 | v4 | PRIORITY MEDIUM | shapes_from_fips() errors offline even when the county boundary is built… |
 | B | [126](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126) | 4 | 11 | NA | PRIORITY MEDIUM | enable 1-site report on Polygons / Shapefile, via links/buttons in shiny… |
 | B | [279](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279) | 5 | 10 | NA | PRIORITY MEDIUM | Prepare the package to submit to CRAN (and get it accepted for hosting o… |
 | B | [87](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/87) | 6 | 10 | NA | PRIORITY MEDIUM | Enable shiny.telemetry log file that is not just a text file on server |
@@ -433,6 +435,7 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | C | [179](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/179) | 0 | 3 | NA | PRIORITY LOW | in ejam2excel() rename parameter fname to filename for consistency w oth… |
 | C | [174](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/174) | 0 | 3 | NA | PRIORITY LOW | round to only 1 digit the area in square miles in header of summary repo… |
 | C | [464](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/464) | 2 | 3 | NA | — | Investigate and solve high cost on AWS Fargate |
+| C | [535](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/535) | 1 | 2 | v4 | PRIORITY LOW | Consolidate app-settings vignette: EJScreen deep links + cross-vignette … |
 | C | [181](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/181) | 1 | 2 | NA | PRIORITY LOW | add other ejam2xyz functions to basics.Rmd as examples |
 | C | [93](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/93) | 2 | 2 | NA | PRIORITY LOW | make Demog. section of summary report table more visually prominent |
 | C | [59](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/59) | 2 | 2 | NA | PRIORITY LOW | Improve MACT-related  lat lon data |
@@ -477,7 +480,7 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 |-----------|------------:|
 | Data Updates | 1 |
 | v3.2022.2 | 2 |
-| v4 | 18 |
+| v4 | 19 |
 | NA | 109 |
 
 ---

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.MD
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.MD
@@ -1,6 +1,6 @@
 # EJAM Open Issues — Scored by Cost & Benefit
 
-**Total open issues:** 131  |  **Generated:** 2026-07-26  |  **Source:** Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)
+**Total open issues:** 132  |  **Generated:** 2026-07-27  |  **Source:** Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)
 
 **Score payload:** `inst/issues/ejam_issues_scored_by_risk_and_value.json`
 
@@ -12,10 +12,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Previous run | 2026-07-25 |
-| Issues opened since previous run | 2 |
-| Issues closed since previous run | 1 |
-| Issues whose quadrant changed | 0 |
+| Previous run | 2026-07-26 |
+| Issues opened since previous run | 1 |
+| Issues closed since previous run | 0 |
+| Issues whose quadrant changed | 19 |
 
 ---
 
@@ -23,15 +23,15 @@
 
 | Cost / Benefit | **LOW Benefit**<br>value < median | **HIGH Benefit**<br>value ≥ median |
 |---|---|---|
-| **LOW Cost**<br>cost < median | **C — Might As Well**<br>22 issues | **A — BEST CANDIDATES**<br>39 issues |
-| **HIGH Cost**<br>cost ≥ median | **D — WORST CANDIDATES**<br>23 issues | **B — OK Candidates**<br>47 issues |
+| **LOW Cost**<br>cost < median | **C — Other Low-Cost Work**<br>41 issues | **A — Focus Shortlist (max 20)**<br>20 issues |
+| **HIGH Cost**<br>cost ≥ median | **D — WORST CANDIDATES**<br>24 issues | **B — OK Candidates**<br>47 issues |
 
 ---
 
-## Quadrant A — BEST CANDIDATES — Low Cost, High Benefit
-*Easy fixes with clear high value. Prioritize these above all others.*
+## Quadrant A — FOCUS SHORTLIST — Low Cost, High Benefit
+*The top 20 low-cost, high-benefit candidates at most, ordered by benefit then cost. Prioritize these above all others.*
 
-**39 issues**
+**20 issues**
 
 - [#16](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16) — need new/updated "User Guide" ("Help" in header at right) since UI has changed a lot, etc.
 - [#504](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504) — Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate task during blockgroup join
@@ -52,26 +52,7 @@
 - [#119](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/119) — some code assumes RStudio user is in root folder of source package - check & warn/document, or fix
 - [#91](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/91) — Excel needs new tab with uploaded places or facilities found
 - [#161](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161) — ejamapp() should be able to handle mix of fips types
-- [#490](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490) — swap us and state ratio columns
-- [#361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) — Add date and time of last updated to help with deploys
-- [#163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) — put certain columns last in table of results (bg count, block count, radius)
-- [#162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) — rename "in_how_many_states"   column  in table of results
 - [#136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) — in web app, fix console  error msg when uploading a shapefile
-- [#288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) — ratio of 1.0 should not be yellow on community report
-- [#70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) — set up alerts that monitor and alert staff when the app goes down - ensure available
-- [#484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) — in overall table, change EJAM Report link for 1-site analysis
-- [#486](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486) — allow zip code analysis in EJAM shiny web app
-- [#284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) — resolve warning about datum, in logs/console, when web app tries to upload/read some shapefiles
-- [#102](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102) — Remove NA console messages from `doaggregate`
-- [#455](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/455) — fix radius slider behavior after deep link passes a radius and then user changes it
-- [#403](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403) — Add explanation of what "average in state" or "percentile in state" means for a multisite report
-- [#350](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350) — Add report regression tests for FIPS, shapefile, sitenumber, NAICS, and PDF-unavailable paths
-- [#96](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/96) — Detailed Table UI Filtering improvements
-- [#92](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92) — Excel's new tab with upload needs cap on size
-- [#58](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58) — joining FIPS upload data to preview table
-- [#454](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454) — fix when should radius slider reset to 0 vs 1 mile (a method-specific default) if radio button used to switch between points and polygon/fips type sites
-- [#224](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224) — report correct population for a single block (if block is analyzed via block fips code)
-- [#40](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40) — Allow abort site selection processing when selections are changed
 
 | # | Issue | Cost | Benefit | Milestone | Priority | Labels (key) |
 |---|-------|------|---------|-----------|----------|--------------|
@@ -94,26 +75,7 @@
 | [119](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/119) | some code assumes RStudio user is in root folder of source package - c… | 2 (🔵 Low) | 8 (🟦 Medium) | NA | PRIORITY LOW | BUG, Affects R users only - NOT web app users, rank:A-high-value-low-cost |
 | [91](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/91) | Excel needs new tab with uploaded places or facilities found | 2 (🔵 Low) | 8 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
 | [161](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161) | ejamapp() should be able to handle mix of fips types | 0 (🟢 Very Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
-| [490](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490) | swap us and state ratio columns | 1 (🟢 Very Low) | 7 (🟦 Medium) | v4 | PRIORITY MEDIUM | Affects Web App, Community Report |
-| [361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) | Add date and time of last updated to help with deploys | 1 (🟢 Very Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
-| [163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) | put certain columns last in table of results (bg count, block count, r… | 1 (🟢 Very Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
-| [162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) | rename "in_how_many_states"   column  in table of results | 1 (🟢 Very Low) | 7 (🟦 Medium) | v4 | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
 | [136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | in web app, fix console  error msg when uploading a shapefile | 1 (🟢 Very Low) | 7 (🟦 Medium) | v4 | PRIORITY LOW | BUG, rank:A-high-value-low-cost |
-| [288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) | ratio of 1.0 should not be yellow on community report | 2 (🔵 Low) | 7 (🟦 Medium) | v3.2022.2 | PRIORITY MEDIUM | Affects Web App, Community Report, rank:A-high-value-low-cost |
-| [70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) | set up alerts that monitor and alert staff when the app goes down - en… | 2 (🔵 Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | rank:A-high-value-low-cost |
-| [484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) | in overall table, change EJAM Report link for 1-site analysis | 3 (🔵 Low) | 7 (🟦 Medium) | v4 | PRIORITY MEDIUM | Affects Web App |
-| [486](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486) | allow zip code analysis in EJAM shiny web app | 1 (🟢 Very Low) | 6 (🟦 Medium) | v4 | PRIORITY LOW | Affects Web App |
-| [284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) | resolve warning about datum, in logs/console, when web app tries to up… | 3 (🔵 Low) | 6 (🟦 Medium) | NA | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
-| [102](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102) | Remove NA console messages from `doaggregate` | 0 (🟢 Very Low) | 5 (🟦 Medium) | NA | PRIORITY LOW | Affects R users only - NOT web app users, rank:C-low-value-low-cost |
-| [455](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/455) | fix radius slider behavior after deep link passes a radius and then us… | 1 (🟢 Very Low) | 5 (🟦 Medium) | v4 | PRIORITY LOW | BUG |
-| [403](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403) | Add explanation of what "average in state" or "percentile in state" me… | 1 (🟢 Very Low) | 5 (🟦 Medium) | NA | PRIORITY MEDIUM | documentation, Affects Web App, rank:C-low-value-low-cost |
-| [350](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350) | Add report regression tests for FIPS, shapefile, sitenumber, NAICS, an… | 2 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY LOW | BUG, test, Community Report, rank:C-low-value-low-cost |
-| [96](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/96) | Detailed Table UI Filtering improvements | 2 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
-| [92](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92) | Excel's new tab with upload needs cap on size | 2 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
-| [58](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58) | joining FIPS upload data to preview table | 2 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY MEDIUM | rank:C-low-value-low-cost |
-| [454](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454) | fix when should radius slider reset to 0 vs 1 mile (a method-specific … | 3 (🔵 Low) | 5 (🟦 Medium) | v4 | PRIORITY LOW | BUG |
-| [224](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224) | report correct population for a single block (if block is analyzed via… | 3 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY LOW | BUG, rank:C-low-value-low-cost |
-| [40](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40) | Allow abort site selection processing when selections are changed | 3 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY MEDIUM | rank:C-low-value-low-cost |
 
 ---
 
@@ -222,11 +184,30 @@
 
 ---
 
-## Quadrant C — Might As Well — Low Cost, Low Benefit
-*Cheap to do; low urgency. Pick these up when bandwidth allows or combine with nearby work.*
+## Quadrant C — OTHER LOW-COST WORK
+*Cheap to do but not in the current focus shortlist. Pick these up when bandwidth allows or combine them with nearby work.*
 
-**22 issues**
+**41 issues**
 
+- [#490](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490) — swap us and state ratio columns
+- [#361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) — Add date and time of last updated to help with deploys
+- [#163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) — put certain columns last in table of results (bg count, block count, radius)
+- [#162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) — rename "in_how_many_states"   column  in table of results
+- [#288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) — ratio of 1.0 should not be yellow on community report
+- [#70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) — set up alerts that monitor and alert staff when the app goes down - ensure available
+- [#484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) — in overall table, change EJAM Report link for 1-site analysis
+- [#486](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486) — allow zip code analysis in EJAM shiny web app
+- [#284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) — resolve warning about datum, in logs/console, when web app tries to upload/read some shapefiles
+- [#102](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102) — Remove NA console messages from `doaggregate`
+- [#455](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/455) — fix radius slider behavior after deep link passes a radius and then user changes it
+- [#403](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403) — Add explanation of what "average in state" or "percentile in state" means for a multisite report
+- [#350](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350) — Add report regression tests for FIPS, shapefile, sitenumber, NAICS, and PDF-unavailable paths
+- [#96](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/96) — Detailed Table UI Filtering improvements
+- [#92](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92) — Excel's new tab with upload needs cap on size
+- [#58](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58) — joining FIPS upload data to preview table
+- [#454](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454) — fix when should radius slider reset to 0 vs 1 mile (a method-specific default) if radio button used to switch between points and polygon/fips type sites
+- [#224](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224) — report correct population for a single block (if block is analyzed via block fips code)
+- [#40](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40) — Allow abort site selection processing when selections are changed
 - [#177](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/177) — pick which approach is faster among functions like sf_nearest_points() and related
 - [#176](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/176) — popups reports in county case are not normal/ignore reports settings?
 - [#175](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/175) — drop the excel column called "Area of block group in geodatabase" and others
@@ -252,6 +233,25 @@
 
 | # | Issue | Cost | Benefit | Milestone | Priority | Labels (key) |
 |---|-------|------|---------|-----------|----------|--------------|
+| [490](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490) | swap us and state ratio columns | 1 (🟢 Very Low) | 7 (🟦 Medium) | v4 | PRIORITY MEDIUM | Affects Web App, Community Report |
+| [361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) | Add date and time of last updated to help with deploys | 1 (🟢 Very Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
+| [163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) | put certain columns last in table of results (bg count, block count, r… | 1 (🟢 Very Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
+| [162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) | rename "in_how_many_states"   column  in table of results | 1 (🟢 Very Low) | 7 (🟦 Medium) | v4 | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
+| [288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) | ratio of 1.0 should not be yellow on community report | 2 (🔵 Low) | 7 (🟦 Medium) | v3.2022.2 | PRIORITY MEDIUM | Affects Web App, Community Report, rank:A-high-value-low-cost |
+| [70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) | set up alerts that monitor and alert staff when the app goes down - en… | 2 (🔵 Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | rank:A-high-value-low-cost |
+| [484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) | in overall table, change EJAM Report link for 1-site analysis | 3 (🔵 Low) | 7 (🟦 Medium) | v4 | PRIORITY MEDIUM | Affects Web App |
+| [486](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486) | allow zip code analysis in EJAM shiny web app | 1 (🟢 Very Low) | 6 (🟦 Medium) | v4 | PRIORITY LOW | Affects Web App |
+| [284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) | resolve warning about datum, in logs/console, when web app tries to up… | 3 (🔵 Low) | 6 (🟦 Medium) | NA | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
+| [102](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102) | Remove NA console messages from `doaggregate` | 0 (🟢 Very Low) | 5 (🟦 Medium) | NA | PRIORITY LOW | Affects R users only - NOT web app users, rank:C-low-value-low-cost |
+| [455](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/455) | fix radius slider behavior after deep link passes a radius and then us… | 1 (🟢 Very Low) | 5 (🟦 Medium) | v4 | PRIORITY LOW | BUG |
+| [403](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403) | Add explanation of what "average in state" or "percentile in state" me… | 1 (🟢 Very Low) | 5 (🟦 Medium) | NA | PRIORITY MEDIUM | documentation, Affects Web App, rank:C-low-value-low-cost |
+| [350](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350) | Add report regression tests for FIPS, shapefile, sitenumber, NAICS, an… | 2 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY LOW | BUG, test, Community Report, rank:C-low-value-low-cost |
+| [96](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/96) | Detailed Table UI Filtering improvements | 2 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
+| [92](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92) | Excel's new tab with upload needs cap on size | 2 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
+| [58](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58) | joining FIPS upload data to preview table | 2 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY MEDIUM | rank:C-low-value-low-cost |
+| [454](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454) | fix when should radius slider reset to 0 vs 1 mile (a method-specific … | 3 (🔵 Low) | 5 (🟦 Medium) | v4 | PRIORITY LOW | BUG |
+| [224](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224) | report correct population for a single block (if block is analyzed via… | 3 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY LOW | BUG, rank:C-low-value-low-cost |
+| [40](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40) | Allow abort site selection processing when selections are changed | 3 (🔵 Low) | 5 (🟦 Medium) | NA | PRIORITY MEDIUM | rank:C-low-value-low-cost |
 | [177](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/177) | pick which approach is faster among functions like sf_nearest_points()… | 0 (🟢 Very Low) | 4 (⬜ Low) | NA | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
 | [176](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/176) | popups reports in county case are not normal/ignore reports settings? | 0 (🟢 Very Low) | 4 (⬜ Low) | NA | PRIORITY LOW | Affects Web App, Community Report, rank:C-low-value-low-cost |
 | [175](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/175) | drop the excel column called "Area of block group in geodatabase" and … | 0 (🟢 Very Low) | 4 (⬜ Low) | NA | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
@@ -280,12 +280,13 @@
 ## Quadrant D — WORST CANDIDATES — High Cost, Low Benefit
 *Expensive to fix, limited payoff. Defer or deprioritize unless circumstances change.*
 
-**23 issues**
+**24 issues**
 
 - [#508](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/508) — ECR lifecycle policy: prune accumulating dev images (without touching prod)
 - [#507](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/507) — deploy-dev: encode the deployed EJAM version in the dev ECR image tag
 - [#182](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/182) — consider refactoring url_xyz functions
 - [#89](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/89) — clarify what "N places" really means & report on the selection type (in summary report etc.)
+- [#536](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/536) — redo list of URLs in url_package() documentation
 - [#35](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/35) — Review/revise/expand unit testing for URL functions
 - [#62](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/62) — Enable download of 'Plot of Average Scores' and 'Plot Full Range of Scores' plots
 - [#61](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/61) — downloading excel output with plots for 1000-2000 points takes 10-15 seconds
@@ -312,6 +313,7 @@
 | [507](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/507) | deploy-dev: encode the deployed EJAM version in the dev ECR image tag | 4 (🟡 Medium) | 4 (⬜ Low) | NA | PRIORITY MEDIUM |  |
 | [182](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/182) | consider refactoring url_xyz functions | 4 (🟡 Medium) | 4 (⬜ Low) | NA | PRIORITY LOW | refactor, Affects R users only - NOT web app users, rank:D-defer |
 | [89](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/89) | clarify what "N places" really means & report on the selection type (i… | 4 (🟡 Medium) | 4 (⬜ Low) | NA | PRIORITY LOW | still relevant?, Affects Web App, rank:D-defer |
+| [536](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/536) | redo list of URLs in url_package() documentation | 4 (🟡 Medium) | 2 (⬜ Low) | NA | PRIORITY LOW | documentation, refactor, Affects R users only - NOT web app users |
 | [35](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/35) | Review/revise/expand unit testing for URL functions | 4 (🟡 Medium) | 2 (⬜ Low) | NA | PRIORITY LOW | test, URL-related, rank:D-defer |
 | [62](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/62) | Enable download of 'Plot of Average Scores' and 'Plot Full Range of Sc… | 4 (🟡 Medium) | 1 (⬜ Very Low) | NA | PRIORITY LOW | still relevant?, plots-graphs-related, rank:D-defer |
 | [61](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/61) | downloading excel output with plots for 1000-2000 points takes 10-15 s… | 4 (🟡 Medium) | 1 (⬜ Very Low) | NA | PRIORITY LOW | still relevant?, rank:D-defer |
@@ -334,7 +336,7 @@
 
 ---
 
-## Full Table — All 131 Issues
+## Full Table — All 132 Issues
 
 Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 
@@ -359,26 +361,7 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | A | [119](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/119) | 2 | 8 | NA | PRIORITY LOW | some code assumes RStudio user is in root folder of source package - che… |
 | A | [91](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/91) | 2 | 8 | NA | PRIORITY MEDIUM | Excel needs new tab with uploaded places or facilities found |
 | A | [161](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161) | 0 | 7 | NA | PRIORITY MEDIUM | ejamapp() should be able to handle mix of fips types |
-| A | [490](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490) | 1 | 7 | v4 | PRIORITY MEDIUM | swap us and state ratio columns |
-| A | [361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) | 1 | 7 | NA | PRIORITY MEDIUM | Add date and time of last updated to help with deploys |
-| A | [163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) | 1 | 7 | NA | PRIORITY MEDIUM | put certain columns last in table of results (bg count, block count, rad… |
-| A | [162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) | 1 | 7 | v4 | PRIORITY MEDIUM | rename "in_how_many_states"   column  in table of results |
 | A | [136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | 1 | 7 | v4 | PRIORITY LOW | in web app, fix console  error msg when uploading a shapefile |
-| A | [288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) | 2 | 7 | v3.2022.2 | PRIORITY MEDIUM | ratio of 1.0 should not be yellow on community report |
-| A | [70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) | 2 | 7 | NA | PRIORITY MEDIUM | set up alerts that monitor and alert staff when the app goes down - ensu… |
-| A | [484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) | 3 | 7 | v4 | PRIORITY MEDIUM | in overall table, change EJAM Report link for 1-site analysis |
-| A | [486](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486) | 1 | 6 | v4 | PRIORITY LOW | allow zip code analysis in EJAM shiny web app |
-| A | [284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) | 3 | 6 | NA | PRIORITY LOW | resolve warning about datum, in logs/console, when web app tries to uplo… |
-| A | [102](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102) | 0 | 5 | NA | PRIORITY LOW | Remove NA console messages from `doaggregate` |
-| A | [455](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/455) | 1 | 5 | v4 | PRIORITY LOW | fix radius slider behavior after deep link passes a radius and then user… |
-| A | [403](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403) | 1 | 5 | NA | PRIORITY MEDIUM | Add explanation of what "average in state" or "percentile in state" mean… |
-| A | [350](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350) | 2 | 5 | NA | PRIORITY LOW | Add report regression tests for FIPS, shapefile, sitenumber, NAICS, and … |
-| A | [96](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/96) | 2 | 5 | NA | PRIORITY LOW | Detailed Table UI Filtering improvements |
-| A | [92](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92) | 2 | 5 | NA | PRIORITY LOW | Excel's new tab with upload needs cap on size |
-| A | [58](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58) | 2 | 5 | NA | PRIORITY MEDIUM | joining FIPS upload data to preview table |
-| A | [454](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454) | 3 | 5 | v4 | PRIORITY LOW | fix when should radius slider reset to 0 vs 1 mile (a method-specific de… |
-| A | [224](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224) | 3 | 5 | NA | PRIORITY LOW | report correct population for a single block (if block is analyzed via b… |
-| A | [40](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40) | 3 | 5 | NA | PRIORITY MEDIUM | Allow abort site selection processing when selections are changed |
 | B | [293](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/293) | 5 | 19 | v4 | PRIORITY HIGH-ish but not a bug | API takes too long to create a community report from when user clicks |
 | B | [513](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/513) | 6 | 17 | v4 | PRIORITY HIGH | need better ETA estimates (predicted seconds to completion are too high) |
 | B | [52](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/52) | 8 | 17 | NA | PRIORITY HIGH-ish but not a bug | Create density score /proximity score/ count-nearby functions, then prov… |
@@ -426,6 +409,25 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | B | [50](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/50) | 8 | 5 | NA | PRIORITY MEDIUM | plotting functions all need review/ consolidation/ improvement/ renaming… |
 | B | [32](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/32) | 11 | 5 | NA | PRIORITY MEDIUM | *** MOVE CODE OUT OF SERVER and app_ui |
 | B | [85](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/85) | 12 | 5 | NA | PRIORITY LOW | Enable higher resolution analysis than getblocksnearby() does, via Dasym… |
+| C | [490](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490) | 1 | 7 | v4 | PRIORITY MEDIUM | swap us and state ratio columns |
+| C | [361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) | 1 | 7 | NA | PRIORITY MEDIUM | Add date and time of last updated to help with deploys |
+| C | [163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) | 1 | 7 | NA | PRIORITY MEDIUM | put certain columns last in table of results (bg count, block count, rad… |
+| C | [162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) | 1 | 7 | v4 | PRIORITY MEDIUM | rename "in_how_many_states"   column  in table of results |
+| C | [288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) | 2 | 7 | v3.2022.2 | PRIORITY MEDIUM | ratio of 1.0 should not be yellow on community report |
+| C | [70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) | 2 | 7 | NA | PRIORITY MEDIUM | set up alerts that monitor and alert staff when the app goes down - ensu… |
+| C | [484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) | 3 | 7 | v4 | PRIORITY MEDIUM | in overall table, change EJAM Report link for 1-site analysis |
+| C | [486](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486) | 1 | 6 | v4 | PRIORITY LOW | allow zip code analysis in EJAM shiny web app |
+| C | [284](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284) | 3 | 6 | NA | PRIORITY LOW | resolve warning about datum, in logs/console, when web app tries to uplo… |
+| C | [102](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102) | 0 | 5 | NA | PRIORITY LOW | Remove NA console messages from `doaggregate` |
+| C | [455](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/455) | 1 | 5 | v4 | PRIORITY LOW | fix radius slider behavior after deep link passes a radius and then user… |
+| C | [403](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403) | 1 | 5 | NA | PRIORITY MEDIUM | Add explanation of what "average in state" or "percentile in state" mean… |
+| C | [350](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350) | 2 | 5 | NA | PRIORITY LOW | Add report regression tests for FIPS, shapefile, sitenumber, NAICS, and … |
+| C | [96](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/96) | 2 | 5 | NA | PRIORITY LOW | Detailed Table UI Filtering improvements |
+| C | [92](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92) | 2 | 5 | NA | PRIORITY LOW | Excel's new tab with upload needs cap on size |
+| C | [58](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58) | 2 | 5 | NA | PRIORITY MEDIUM | joining FIPS upload data to preview table |
+| C | [454](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454) | 3 | 5 | v4 | PRIORITY LOW | fix when should radius slider reset to 0 vs 1 mile (a method-specific de… |
+| C | [224](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224) | 3 | 5 | NA | PRIORITY LOW | report correct population for a single block (if block is analyzed via b… |
+| C | [40](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40) | 3 | 5 | NA | PRIORITY MEDIUM | Allow abort site selection processing when selections are changed |
 | C | [177](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/177) | 0 | 4 | NA | PRIORITY LOW | pick which approach is faster among functions like sf_nearest_points() a… |
 | C | [176](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/176) | 0 | 4 | NA | PRIORITY LOW | popups reports in county case are not normal/ignore reports settings? |
 | C | [175](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/175) | 0 | 4 | NA | PRIORITY LOW | drop the excel column called "Area of block group in geodatabase" and ot… |
@@ -452,6 +454,7 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | D | [507](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/507) | 4 | 4 | NA | PRIORITY MEDIUM | deploy-dev: encode the deployed EJAM version in the dev ECR image tag |
 | D | [182](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/182) | 4 | 4 | NA | PRIORITY LOW | consider refactoring url_xyz functions |
 | D | [89](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/89) | 4 | 4 | NA | PRIORITY LOW | clarify what "N places" really means & report on the selection type (in … |
+| D | [536](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/536) | 4 | 2 | NA | PRIORITY LOW | redo list of URLs in url_package() documentation |
 | D | [35](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/35) | 4 | 2 | NA | PRIORITY LOW | Review/revise/expand unit testing for URL functions |
 | D | [62](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/62) | 4 | 1 | NA | PRIORITY LOW | Enable download of 'Plot of Average Scores' and 'Plot Full Range of Scor… |
 | D | [61](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/61) | 4 | 1 | NA | PRIORITY LOW | downloading excel output with plots for 1000-2000 points takes 10-15 sec… |
@@ -481,7 +484,7 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | Data Updates | 1 |
 | v3.2022.2 | 2 |
 | v4 | 19 |
-| NA | 109 |
+| NA | 110 |
 
 ---
 
@@ -502,6 +505,10 @@ Each issue is scored independently on two dimensions:
 | Benefit | 0 – 19 | 5 |
 
 Issues at or above the median are **High**; below are **Low** for that dimension.
+
+### Focus shortlist rule
+
+Quadrant A is capped at **20 issues**. After the median split, eligible low-cost, high-benefit issues are ordered by benefit descending, cost ascending, then issue number. Any remaining eligible issues are placed in C as other low-cost work.
 
 ### GitHub rank labels for a later update task
 

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.MD
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.MD
@@ -1,6 +1,6 @@
 # EJAM Open Issues — Scored by Cost & Benefit
 
-**Total open issues:** 132  |  **Generated:** 2026-07-27  |  **Source:** Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)
+**Total open issues:** 132  |  **Generated:** 2026-08-02  |  **Source:** Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)
 
 **Score payload:** `inst/issues/ejam_issues_scored_by_risk_and_value.json`
 
@@ -12,10 +12,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Previous run | 2026-07-26 |
-| Issues opened since previous run | 1 |
+| Previous run | 2026-07-27 |
+| Issues opened since previous run | 0 |
 | Issues closed since previous run | 0 |
-| Issues whose quadrant changed | 19 |
+| Issues whose quadrant changed | 2 |
 
 ---
 
@@ -35,6 +35,7 @@
 
 - [#16](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16) — need new/updated "User Guide" ("Help" in header at right) since UI has changed a lot, etc.
 - [#504](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504) — Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate task during blockgroup join
+- [#458](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458) — Share one report-header rule across in-app, download, and API paths (1-site vs multisite, FIPS place name)
 - [#152](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/152) — build_community_report() needs unit tests, table_signif_round_x100() or table_round() too
 - [#274](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/274) — Add the features not yet restored from the pre-2025 EPA version of the Community Report
 - [#342](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342) — use renv package to create lock state for what versions of what packages are used
@@ -52,12 +53,12 @@
 - [#119](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/119) — some code assumes RStudio user is in root folder of source package - check & warn/document, or fix
 - [#91](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/91) — Excel needs new tab with uploaded places or facilities found
 - [#161](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161) — ejamapp() should be able to handle mix of fips types
-- [#136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) — in web app, fix console  error msg when uploading a shapefile
 
 | # | Issue | Cost | Benefit | Milestone | Priority | Labels (key) |
 |---|-------|------|---------|-----------|----------|--------------|
 | [16](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16) | need new/updated "User Guide" ("Help" in header at right) since UI has… | 2 (🔵 Low) | 17 (🟩🟩 Very High) | v4 | PRIORITY HIGH | BUG, documentation, help wanted, good first issue |
 | [504](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504) | Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate tas… | 3 (🔵 Low) | 17 (🟩🟩 Very High) | v4 | PRIORITY MEDIUM | BUG, Affects Web App |
+| [458](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458) | Share one report-header rule across in-app, download, and API paths (1… | 3 (🔵 Low) | 17 (🟩🟩 Very High) | v4 | PRIORITY HIGH-ish but not a bug | Affects Web App, Community Report |
 | [152](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/152) | build_community_report() needs unit tests, table_signif_round_x100() o… | 0 (🟢 Very Low) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | test, Affects Web App, Community Report, rank:A-high-value-low-cost |
 | [274](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/274) | Add the features not yet restored from the pre-2025 EPA version of the… | 2 (🔵 Low) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | Affects Web App, Community Report, rank:A-high-value-low-cost |
 | [342](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342) | use renv package to create lock state for what versions of what packag… | 3 (🔵 Low) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | help wanted, Affects Web App, rank:A-high-value-low-cost |
@@ -75,7 +76,6 @@
 | [119](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/119) | some code assumes RStudio user is in root folder of source package - c… | 2 (🔵 Low) | 8 (🟦 Medium) | NA | PRIORITY LOW | BUG, Affects R users only - NOT web app users, rank:A-high-value-low-cost |
 | [91](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/91) | Excel needs new tab with uploaded places or facilities found | 2 (🔵 Low) | 8 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
 | [161](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161) | ejamapp() should be able to handle mix of fips types | 0 (🟢 Very Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
-| [136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | in web app, fix console  error msg when uploading a shapefile | 1 (🟢 Very Low) | 7 (🟦 Medium) | v4 | PRIORITY LOW | BUG, rank:A-high-value-low-cost |
 
 ---
 
@@ -193,6 +193,7 @@
 - [#361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) — Add date and time of last updated to help with deploys
 - [#163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) — put certain columns last in table of results (bg count, block count, radius)
 - [#162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) — rename "in_how_many_states"   column  in table of results
+- [#136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) — in web app, fix console  error msg when uploading a shapefile
 - [#288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) — ratio of 1.0 should not be yellow on community report
 - [#70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) — set up alerts that monitor and alert staff when the app goes down - ensure available
 - [#484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) — in overall table, change EJAM Report link for 1-site analysis
@@ -211,7 +212,6 @@
 - [#177](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/177) — pick which approach is faster among functions like sf_nearest_points() and related
 - [#176](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/176) — popups reports in county case are not normal/ignore reports settings?
 - [#175](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/175) — drop the excel column called "Area of block group in geodatabase" and others
-- [#458](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458) — in-app report header for a 1-site analysis should say Community Report not Multisite Summary
 - [#159](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/159) — integrate file-naming function and header-creating functions
 - [#24](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/24) — map popups in make.popups.api() and other functions are too cluttered, move most info to separate popup (see example in comment)
 - [#179](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/179) — in ejam2excel() rename parameter fname to filename for consistency w other functions
@@ -237,6 +237,7 @@
 | [361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) | Add date and time of last updated to help with deploys | 1 (🟢 Very Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
 | [163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) | put certain columns last in table of results (bg count, block count, r… | 1 (🟢 Very Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
 | [162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) | rename "in_how_many_states"   column  in table of results | 1 (🟢 Very Low) | 7 (🟦 Medium) | v4 | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
+| [136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | in web app, fix console  error msg when uploading a shapefile | 1 (🟢 Very Low) | 7 (🟦 Medium) | v4 | PRIORITY LOW | BUG, rank:A-high-value-low-cost |
 | [288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) | ratio of 1.0 should not be yellow on community report | 2 (🔵 Low) | 7 (🟦 Medium) | v3.2022.2 | PRIORITY MEDIUM | Affects Web App, Community Report, rank:A-high-value-low-cost |
 | [70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) | set up alerts that monitor and alert staff when the app goes down - en… | 2 (🔵 Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | rank:A-high-value-low-cost |
 | [484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) | in overall table, change EJAM Report link for 1-site analysis | 3 (🔵 Low) | 7 (🟦 Medium) | v4 | PRIORITY MEDIUM | Affects Web App |
@@ -255,7 +256,6 @@
 | [177](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/177) | pick which approach is faster among functions like sf_nearest_points()… | 0 (🟢 Very Low) | 4 (⬜ Low) | NA | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
 | [176](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/176) | popups reports in county case are not normal/ignore reports settings? | 0 (🟢 Very Low) | 4 (⬜ Low) | NA | PRIORITY LOW | Affects Web App, Community Report, rank:C-low-value-low-cost |
 | [175](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/175) | drop the excel column called "Area of block group in geodatabase" and … | 0 (🟢 Very Low) | 4 (⬜ Low) | NA | PRIORITY LOW | Affects Web App, rank:C-low-value-low-cost |
-| [458](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458) | in-app report header for a 1-site analysis should say Community Report… | 1 (🟢 Very Low) | 4 (⬜ Low) | v4 | PRIORITY LOW | Affects Web App, Community Report |
 | [159](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/159) | integrate file-naming function and header-creating functions | 3 (🔵 Low) | 4 (⬜ Low) | NA | PRIORITY LOW | refactor, Affects Web App, Community Report, rank:C-low-value-low-cost |
 | [24](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/24) | map popups in make.popups.api() and other functions are too cluttered,… | 3 (🔵 Low) | 4 (⬜ Low) | NA | PRIORITY LOW | map-popups-related, rank:C-low-value-low-cost |
 | [179](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/179) | in ejam2excel() rename parameter fname to filename for consistency w o… | 0 (🟢 Very Low) | 3 (⬜ Low) | NA | PRIORITY LOW | refactor, Affects R users only - NOT web app users, rank:C-low-value-low-cost |
@@ -344,6 +344,7 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 |------|---------|------|---------|-----------|----------|-------|
 | A | [16](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16) | 2 | 17 | v4 | PRIORITY HIGH | need new/updated "User Guide" ("Help" in header at right) since UI has c… |
 | A | [504](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504) | 3 | 17 | v4 | PRIORITY MEDIUM | Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate task … |
+| A | [458](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458) | 3 | 17 | v4 | PRIORITY HIGH-ish but not a bug | Share one report-header rule across in-app, download, and API paths (1-s… |
 | A | [152](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/152) | 0 | 15 | NA | PRIORITY HIGH-ish but not a bug | build_community_report() needs unit tests, table_signif_round_x100() or … |
 | A | [274](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/274) | 2 | 15 | NA | PRIORITY HIGH-ish but not a bug | Add the features not yet restored from the pre-2025 EPA version of the C… |
 | A | [342](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342) | 3 | 15 | NA | PRIORITY HIGH-ish but not a bug | use renv package to create lock state for what versions of what packages… |
@@ -361,7 +362,6 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | A | [119](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/119) | 2 | 8 | NA | PRIORITY LOW | some code assumes RStudio user is in root folder of source package - che… |
 | A | [91](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/91) | 2 | 8 | NA | PRIORITY MEDIUM | Excel needs new tab with uploaded places or facilities found |
 | A | [161](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161) | 0 | 7 | NA | PRIORITY MEDIUM | ejamapp() should be able to handle mix of fips types |
-| A | [136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | 1 | 7 | v4 | PRIORITY LOW | in web app, fix console  error msg when uploading a shapefile |
 | B | [293](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/293) | 5 | 19 | v4 | PRIORITY HIGH-ish but not a bug | API takes too long to create a community report from when user clicks |
 | B | [513](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/513) | 6 | 17 | v4 | PRIORITY HIGH | need better ETA estimates (predicted seconds to completion are too high) |
 | B | [52](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/52) | 8 | 17 | NA | PRIORITY HIGH-ish but not a bug | Create density score /proximity score/ count-nearby functions, then prov… |
@@ -413,6 +413,7 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | C | [361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) | 1 | 7 | NA | PRIORITY MEDIUM | Add date and time of last updated to help with deploys |
 | C | [163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) | 1 | 7 | NA | PRIORITY MEDIUM | put certain columns last in table of results (bg count, block count, rad… |
 | C | [162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) | 1 | 7 | v4 | PRIORITY MEDIUM | rename "in_how_many_states"   column  in table of results |
+| C | [136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | 1 | 7 | v4 | PRIORITY LOW | in web app, fix console  error msg when uploading a shapefile |
 | C | [288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) | 2 | 7 | v3.2022.2 | PRIORITY MEDIUM | ratio of 1.0 should not be yellow on community report |
 | C | [70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) | 2 | 7 | NA | PRIORITY MEDIUM | set up alerts that monitor and alert staff when the app goes down - ensu… |
 | C | [484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) | 3 | 7 | v4 | PRIORITY MEDIUM | in overall table, change EJAM Report link for 1-site analysis |
@@ -431,7 +432,6 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | C | [177](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/177) | 0 | 4 | NA | PRIORITY LOW | pick which approach is faster among functions like sf_nearest_points() a… |
 | C | [176](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/176) | 0 | 4 | NA | PRIORITY LOW | popups reports in county case are not normal/ignore reports settings? |
 | C | [175](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/175) | 0 | 4 | NA | PRIORITY LOW | drop the excel column called "Area of block group in geodatabase" and ot… |
-| C | [458](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458) | 1 | 4 | v4 | PRIORITY LOW | in-app report header for a 1-site analysis should say Community Report n… |
 | C | [159](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/159) | 3 | 4 | NA | PRIORITY LOW | integrate file-naming function and header-creating functions |
 | C | [24](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/24) | 3 | 4 | NA | PRIORITY LOW | map popups in make.popups.api() and other functions are too cluttered, m… |
 | C | [179](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/179) | 0 | 3 | NA | PRIORITY LOW | in ejam2excel() rename parameter fname to filename for consistency w oth… |

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.html
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.html
@@ -207,8 +207,8 @@
 <body>
 <h1 id="ejam-open-issues-scored-by-cost-benefit">EJAM Open Issues —
 Scored by Cost &amp; Benefit</h1>
-<p><strong>Total open issues:</strong> 137 | <strong>Generated:</strong>
-2026-07-24 | <strong>Source:</strong> Live GitHub REST API open issues
+<p><strong>Total open issues:</strong> 130 | <strong>Generated:</strong>
+2026-07-25 | <strong>Source:</strong> Live GitHub REST API open issues
 (Public-Environmental-Data-Partners/EJAM)</p>
 <p><strong>Score payload:</strong>
 <code>inst/issues/ejam_issues_scored_by_risk_and_value.json</code></p>
@@ -229,15 +229,15 @@ Scored by Cost &amp; Benefit</h1>
 </tr>
 <tr>
 <td>Issues opened since previous run</td>
-<td>0</td>
+<td>4</td>
 </tr>
 <tr>
 <td>Issues closed since previous run</td>
-<td>0</td>
+<td>11</td>
 </tr>
 <tr>
 <td>Issues whose quadrant changed</td>
-<td>0</td>
+<td>17</td>
 </tr>
 </tbody>
 </table>
@@ -259,13 +259,13 @@ Scored by Cost &amp; Benefit</h1>
 <tbody>
 <tr>
 <td><strong>LOW Cost</strong><br>cost &lt; median</td>
-<td><strong>C — Might As Well</strong><br>14 issues</td>
-<td><strong>A — BEST CANDIDATES</strong><br>37 issues</td>
+<td><strong>C — Might As Well</strong><br>21 issues</td>
+<td><strong>A — BEST CANDIDATES</strong><br>40 issues</td>
 </tr>
 <tr>
 <td><strong>HIGH Cost</strong><br>cost ≥ median</td>
-<td><strong>D — WORST CANDIDATES</strong><br>32 issues</td>
-<td><strong>B — OK Candidates</strong><br>54 issues</td>
+<td><strong>D — WORST CANDIDATES</strong><br>23 issues</td>
+<td><strong>B — OK Candidates</strong><br>46 issues</td>
 </tr>
 </tbody>
 </table>
@@ -274,44 +274,36 @@ Scored by Cost &amp; Benefit</h1>
 BEST CANDIDATES — Low Cost, High Benefit</h2>
 <p><em>Easy fixes with clear high value. Prioritize these above all
 others.</em></p>
-<p><strong>37 issues</strong></p>
+<p><strong>40 issues</strong></p>
 <ul>
 <li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/156">#156</a>
-— in app - add view of ejam2areafeatures(out) (info on % of pop with
-certain things nearby)</li>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504">#504</a>
+— Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate
+task during blockgroup join</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/152">#152</a>
 — build_community_report() needs unit tests, table_signif_round_x100()
 or table_round() too</li>
 <li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/385">#385</a>
-— ejam2report() fails to save a file when the filename parameter is
-used</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/348">#348</a>
-— API report links from multisite results label every per-site report as
-site 1</li>
-<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/274">#274</a>
 — Add the features not yet restored from the pre-2025 EPA version of the
 Community Report</li>
 <li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/205">#205</a>
-— adjust summary report fonts and row heights/line spacing to make text
-more legible</li>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342">#342</a>
+— use renv package to create lock state for what versions of what
+packages are used</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341">#341</a>
+— Align map_headernames and/or generated avg/pctile/ratio metadata with
+columns doaggregate() can produce for the report</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16">#16</a>
 — need new/updated “User Guide” (“Help” in header at right) since UI has
 changed a lot, etc.</li>
 <li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/144">#144</a>
-— use or remove or explain the sitenumber parameter in ejam2map() for
-fips case</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/127">#127</a>
-— web app details tab with table of all sites is too sluggish as it
-appears after clicking to view that tab</li>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400">#400</a>
+— improve how webapp users can find info on data vintage (in EJAM web
+app UI, from community report, and from EJScreen UI)</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344">#344</a>
 — Show an example of a community report - e.g., in or linked from
@@ -321,17 +313,21 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/249">#24
 — ejam2report() fails if filename is specified without path, or with
 “./xyz.html”</li>
 <li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/410">#410</a>
-— “FEATURES AND LOCATION INFORMATION” on report need explanation and
-less rounding</li>
-<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/137">#137</a>
 — fix bug in popshare_at_top_x_pct() - results sometimes not quite
 right. seems to interpolate badly.</li>
 <li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/268">#268</a>
+— Uploading a file was failing intermittently when live app hosted using
+AWS with load balancing</li>
+<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/109">#109</a>
 — Update &amp; correct the article “Defaults and Custom Settings for the
 Web App”</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73">#73</a>
+— in web app, add ways to analyze multiple radii at once or even
+continuous radius</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/354">#354</a>
 — consider if downloaded report map and/or excel can use polygons in map
@@ -381,8 +377,15 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70">#70<
 — set up alerts that monitor and alert staff when the app goes down -
 ensure available</li>
 <li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484">#484</a>
+— in overall table, change EJAM Report link for 1-site analysis</li>
+<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486">#486</a>
 — allow zip code analysis in EJAM shiny web app</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">#284</a>
+— resolve warning about datum, in logs/console, when web app tries to
+upload/read some shapefiles</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102">#102</a>
 — Remove NA console messages from <code>doaggregate</code></li>
@@ -405,11 +408,20 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/96">#96<
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92">#92</a>
 — Excel’s new tab with upload needs cap on size</li>
 <li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/69">#69</a>
-— enable other units like kilometers for entry of radius</li>
-<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58">#58</a>
 — joining FIPS upload data to preview table</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454">#454</a>
+— fix when should radius slider reset to 0 vs 1 mile (a method-specific
+default) if radio button used to switch between points and polygon/fips
+type sites</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224">#224</a>
+— report correct population for a single block (if block is analyzed via
+block fips code)</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40">#40</a>
+— Allow abort site selection processing when selections are changed</li>
 </ul>
 <table class="issue-details">
 <colgroup>
@@ -435,14 +447,14 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58">#58<
 <tbody>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/156">156</a></td>
-<td>in app - add view of ejam2areafeatures(out) (info on % of pop with
-…</td>
-<td>0 (🟢 Very Low)</td>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504">504</a></td>
+<td>Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate
+tas…</td>
+<td>3 (🔵 Low)</td>
 <td>17 (🟩🟩 Very High)</td>
-<td>NA</td>
-<td>PRIORITY HIGH-ish but not a bug</td>
-<td>test, Affects Web App, rank:A-high-value-low-cost</td>
+<td>v4</td>
+<td>PRIORITY MEDIUM</td>
+<td>BUG, Affects Web App</td>
 </tr>
 <tr>
 <td><a
@@ -458,29 +470,6 @@ rank:A-high-value-low-cost</td>
 </tr>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/385">385</a></td>
-<td>ejam2report() fails to save a file when the filename parameter is
-used</td>
-<td>1 (🟢 Very Low)</td>
-<td>15 (🟩🟩 Very High)</td>
-<td>v4</td>
-<td>PRIORITY MEDIUM</td>
-<td>BUG, Affects R users only - NOT web app users, Community Report,
-rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/348">348</a></td>
-<td>API report links from multisite results label every per-site report
-as…</td>
-<td>2 (🔵 Low)</td>
-<td>15 (🟩🟩 Very High)</td>
-<td>v3.2022.2</td>
-<td>PRIORITY MEDIUM</td>
-<td>BUG, URL-related, Affects Web App, API</td>
-</tr>
-<tr>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/274">274</a></td>
 <td>Add the features not yet restored from the pre-2025 EPA version of
 the…</td>
@@ -492,15 +481,25 @@ the…</td>
 </tr>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/205">205</a></td>
-<td>adjust summary report fonts and row heights/line spacing to make
-text …</td>
-<td>2 (🔵 Low)</td>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342">342</a></td>
+<td>use renv package to create lock state for what versions of what
+packag…</td>
+<td>3 (🔵 Low)</td>
 <td>15 (🟩🟩 Very High)</td>
 <td>NA</td>
 <td>PRIORITY HIGH-ish but not a bug</td>
-<td>help wanted, Affects Web App, Community Report,
-rank:A-high-value-low-cost</td>
+<td>help wanted, Affects Web App, rank:A-high-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341">341</a></td>
+<td>Align map_headernames and/or generated avg/pctile/ratio metadata
+with …</td>
+<td>3 (🔵 Low)</td>
+<td>15 (🟩🟩 Very High)</td>
+<td>NA</td>
+<td>PRIORITY HIGH-ish but not a bug</td>
+<td>Affects Web App, Community Report, rank:A-high-value-low-cost</td>
 </tr>
 <tr>
 <td><a
@@ -515,25 +514,14 @@ has…</td>
 </tr>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/144">144</a></td>
-<td>use or remove or explain the sitenumber parameter in ejam2map() for
-fi…</td>
-<td>0 (🟢 Very Low)</td>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400">400</a></td>
+<td>improve how webapp users can find info on data vintage (in EJAM web
+ap…</td>
+<td>3 (🔵 Low)</td>
 <td>13 (🟩🟩 Very High)</td>
-<td>v3.2022.2</td>
-<td>PRIORITY MEDIUM</td>
-<td>BUG, Affects Web App, API, rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/127">127</a></td>
-<td>web app details tab with table of all sites is too sluggish as it
-appe…</td>
-<td>0 (🟢 Very Low)</td>
-<td>13 (🟩🟩 Very High)</td>
-<td>v3.2022.2</td>
-<td>PRIORITY MEDIUM</td>
-<td>BUG, Affects Web App, rank:A-high-value-low-cost</td>
+<td>NA</td>
+<td>PRIORITY HIGH</td>
+<td>Affects Web App, rank:A-high-value-low-cost</td>
 </tr>
 <tr>
 <td><a
@@ -542,7 +530,7 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344">344
 “basic…</td>
 <td>2 (🔵 Low)</td>
 <td>12 (🟩🟦 High)</td>
-<td>NA</td>
+<td>v4</td>
 <td>PRIORITY HIGH-ish but not a bug</td>
 <td>documentation, help wanted, good first issue,
 rank:A-high-value-low-cost</td>
@@ -561,18 +549,6 @@ rank:A-high-value-low-cost</td>
 </tr>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/410">410</a></td>
-<td>“FEATURES AND LOCATION INFORMATION” on report need explanation and
-les…</td>
-<td>1 (🟢 Very Low)</td>
-<td>11 (🟩🟦 High)</td>
-<td>v3.2022.2</td>
-<td>PRIORITY MEDIUM</td>
-<td>BUG, Affects Web App, Community Report,
-rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/137">137</a></td>
 <td>fix bug in popshare_at_top_x_pct() - results sometimes not quite
 right…</td>
@@ -584,15 +560,37 @@ right…</td>
 </tr>
 <tr>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/268">268</a></td>
+<td>Uploading a file was failing intermittently when live app hosted
+using…</td>
+<td>2 (🔵 Low)</td>
+<td>11 (🟩🟦 High)</td>
+<td>NA</td>
+<td>—</td>
+<td>BUG, Affects Web App</td>
+</tr>
+<tr>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/109">109</a></td>
 <td>Update &amp; correct the article “Defaults and Custom Settings for
 the Web…</td>
 <td>1 (🟢 Very Low)</td>
 <td>10 (🟩🟦 High)</td>
-<td>NA</td>
+<td>v4</td>
 <td>PRIORITY LOW</td>
 <td>BUG, documentation, Affects R users only - NOT web app users,
 rank:A-high-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73">73</a></td>
+<td>in web app, add ways to analyze multiple radii at once or even
+continu…</td>
+<td>3 (🔵 Low)</td>
+<td>10 (🟩🟦 High)</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>Affects Web App, rank:A-high-value-low-cost</td>
 </tr>
 <tr>
 <td><a
@@ -706,7 +704,7 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">162
 <td>rename “in_how_many_states” column in table of results</td>
 <td>1 (🟢 Very Low)</td>
 <td>7 (🟦 Medium)</td>
-<td>NA</td>
+<td>v4</td>
 <td>PRIORITY MEDIUM</td>
 <td>Affects Web App, rank:A-high-value-low-cost</td>
 </tr>
@@ -716,7 +714,7 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">136
 <td>in web app, fix console error msg when uploading a shapefile</td>
 <td>1 (🟢 Very Low)</td>
 <td>7 (🟦 Medium)</td>
-<td>NA</td>
+<td>v4</td>
 <td>PRIORITY LOW</td>
 <td>BUG, rank:A-high-value-low-cost</td>
 </tr>
@@ -726,7 +724,7 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288">288
 <td>ratio of 1.0 should not be yellow on community report</td>
 <td>2 (🔵 Low)</td>
 <td>7 (🟦 Medium)</td>
-<td>NA</td>
+<td>v3.2022.2</td>
 <td>PRIORITY MEDIUM</td>
 <td>Affects Web App, Community Report, rank:A-high-value-low-cost</td>
 </tr>
@@ -743,6 +741,16 @@ en…</td>
 </tr>
 <tr>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484">484</a></td>
+<td>in overall table, change EJAM Report link for 1-site analysis</td>
+<td>3 (🔵 Low)</td>
+<td>7 (🟦 Medium)</td>
+<td>v4</td>
+<td>PRIORITY MEDIUM</td>
+<td>Affects Web App</td>
+</tr>
+<tr>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486">486</a></td>
 <td>allow zip code analysis in EJAM shiny web app</td>
 <td>1 (🟢 Very Low)</td>
@@ -750,6 +758,17 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486">486
 <td>v4</td>
 <td>PRIORITY LOW</td>
 <td>Affects Web App</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">284</a></td>
+<td>resolve warning about datum, in logs/console, when web app tries to
+up…</td>
+<td>3 (🔵 Low)</td>
+<td>6 (🟦 Medium)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>Affects Web App, rank:C-low-value-low-cost</td>
 </tr>
 <tr>
 <td><a
@@ -817,8 +836,8 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92">92</
 </tr>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/69">69</a></td>
-<td>enable other units like kilometers for entry of radius</td>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58">58</a></td>
+<td>joining FIPS upload data to preview table</td>
 <td>2 (🔵 Low)</td>
 <td>5 (🟦 Medium)</td>
 <td>NA</td>
@@ -827,9 +846,32 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/69">69</
 </tr>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58">58</a></td>
-<td>joining FIPS upload data to preview table</td>
-<td>2 (🔵 Low)</td>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454">454</a></td>
+<td>fix when should radius slider reset to 0 vs 1 mile (a
+method-specific …</td>
+<td>3 (🔵 Low)</td>
+<td>5 (🟦 Medium)</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>BUG</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224">224</a></td>
+<td>report correct population for a single block (if block is analyzed
+via…</td>
+<td>3 (🔵 Low)</td>
+<td>5 (🟦 Medium)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>BUG, rank:C-low-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40">40</a></td>
+<td>Allow abort site selection processing when selections are
+changed</td>
+<td>3 (🔵 Low)</td>
 <td>5 (🟦 Medium)</td>
 <td>NA</td>
 <td>PRIORITY MEDIUM</td>
@@ -842,20 +884,16 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58">58</
 Candidates — High Cost, High Benefit</h2>
 <p><em>Worth doing but require more effort or expertise. Plan carefully
 before starting.</em></p>
-<p><strong>54 issues</strong></p>
+<p><strong>46 issues</strong></p>
 <ul>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/467">#467</a>
-— ejam2report() fails for zero-population or otherwise analysis-invalid
-sites</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/293">#293</a>
 — API takes too long to create a community report from when user
 clicks</li>
 <li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504">#504</a>
-— Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate
-task during blockgroup join</li>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/513">#513</a>
+— need better ETA estimates (predicted seconds to completion are too
+high)</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/52">#52</a>
 — Create density score /proximity score/ count-nearby functions, then
@@ -868,14 +906,6 @@ speed / performance at launch)</li>
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/226">#226</a>
 — NOTES on SPEEDING UP app &amp; functions (incl load testing)</li>
 <li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342">#342</a>
-— use renv package to create lock state for what versions of what
-packages are used</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341">#341</a>
-— Align map_headernames and/or generated avg/pctile/ratio metadata with
-columns doaggregate() can produce for the report</li>
-<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/349">#349</a>
 — Polygon report links recompute API reports from simplified
 GeoJSON</li>
@@ -887,10 +917,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/193">#19
 — Create Executive Summary helper functions - summarizer / Methods for
 Identifying and Focusing on Key Findings</li>
 <li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400">#400</a>
-— improve how webapp users can find info on data vintage (in EJAM web
-app UI, from community report, and from EJScreen UI)</li>
-<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/68">#68</a>
 — allow user to type in radius not only use slider</li>
 <li><a
@@ -901,10 +927,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126">#12
 — enable 1-site report on Polygons / Shapefile, via links/buttons in
 shiny map popups and table of sites (but NOT outside shiny like in
 URL-based/link in Excel table)</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73">#73</a>
-— in web app, add ways to analyze multiple radii at once or even
-continuous radius</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279">#279</a>
 — Prepare the package to submit to CRAN (and get it accepted for hosting
@@ -927,8 +949,13 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135">#13
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/19">#19</a>
 — FIPS missing/problems (mostly in Connecticut)</li>
 <li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484">#484</a>
-— in overall table, change EJAM Report link for 1-site analysis</li>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/511">#511</a>
+— CI runs only on PRs into main: development and deploy PRs get no
+checks at all</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/510">#510</a>
+— Smoke-test PDF generation in the built image and after deploy (prod
+PDF broke undetected)</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/172">#172</a>
 — create “sites_from_anything” func to allow any types of inputs
@@ -972,10 +999,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/169">#16
 — harmonize/refactor functions that create or sanitize filenames,
 paths</li>
 <li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">#284</a>
-— resolve warning about datum, in logs/console, when web app tries to
-upload/read some shapefiles</li>
-<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194">#194</a>
 — Create visualizations of overall results in app - engaging &amp;
 insightful</li>
@@ -987,18 +1010,6 @@ block_radius_miles) is &gt; radius the user specified</li>
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66">#66</a>
 — EJAM &amp; EJScreen report on avg PERSON generally but State Average
 or US Avg shown is avg BLOCK GROUP ! Decide how to reconcile this.</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454">#454</a>
-— fix when should radius slider reset to 0 vs 1 mile (a method-specific
-default) if radio button used to switch between points and polygon/fips
-type sites</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224">#224</a>
-— report correct population for a single block (if block is analyzed via
-block fips code)</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40">#40</a>
-— Allow abort site selection processing when selections are changed</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/83">#83</a>
 — enable selecting a folder as way to upload shapefile(s)</li>
@@ -1073,17 +1084,6 @@ Dasymetric mapping</li>
 <tbody>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/467">467</a></td>
-<td>ejam2report() fails for zero-population or otherwise
-analysis-invalid …</td>
-<td>4 (🟡 Medium)</td>
-<td>20 (🟩🟩 Very High)</td>
-<td>v3.2022.2</td>
-<td>PRIORITY HIGH</td>
-<td>BUG, API, Community Report</td>
-</tr>
-<tr>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/293">293</a></td>
 <td>API takes too long to create a community report from when user
 clicks</td>
@@ -1096,14 +1096,14 @@ rank:B-high-value-high-cost</td>
 </tr>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504">504</a></td>
-<td>Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate
-tas…</td>
-<td>3 (🔵 Low)</td>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/513">513</a></td>
+<td>need better ETA estimates (predicted seconds to completion are too
+hig…</td>
+<td>6 (🟡 Medium)</td>
 <td>17 (🟩🟩 Very High)</td>
 <td>v4</td>
-<td>PRIORITY MEDIUM</td>
-<td>BUG, Affects Web App</td>
+<td>PRIORITY HIGH</td>
+<td>BUG, speed / performance (see #226), Affects Web App</td>
 </tr>
 <tr>
 <td><a
@@ -1141,28 +1141,6 @@ rank:B-high-value-high-cost</td>
 </tr>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342">342</a></td>
-<td>use renv package to create lock state for what versions of what
-packag…</td>
-<td>3 (🔵 Low)</td>
-<td>15 (🟩🟩 Very High)</td>
-<td>NA</td>
-<td>PRIORITY HIGH-ish but not a bug</td>
-<td>help wanted, Affects Web App, rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341">341</a></td>
-<td>Align map_headernames and/or generated avg/pctile/ratio metadata
-with …</td>
-<td>3 (🔵 Low)</td>
-<td>15 (🟩🟩 Very High)</td>
-<td>NA</td>
-<td>PRIORITY HIGH-ish but not a bug</td>
-<td>Affects Web App, Community Report, rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/349">349</a></td>
 <td>Polygon report links recompute API reports from simplified
 GeoJSON</td>
@@ -1196,17 +1174,6 @@ rank:B-high-value-high-cost</td>
 </tr>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400">400</a></td>
-<td>improve how webapp users can find info on data vintage (in EJAM web
-ap…</td>
-<td>3 (🔵 Low)</td>
-<td>13 (🟩🟩 Very High)</td>
-<td>NA</td>
-<td>PRIORITY HIGH</td>
-<td>Affects Web App, rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/68">68</a></td>
 <td>allow user to type in radius not only use slider</td>
 <td>4 (🟡 Medium)</td>
@@ -1236,17 +1203,6 @@ shi…</td>
 <td>NA</td>
 <td>PRIORITY MEDIUM</td>
 <td>Affects Web App, API, rank:B-high-value-high-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73">73</a></td>
-<td>in web app, add ways to analyze multiple radii at once or even
-continu…</td>
-<td>3 (🔵 Low)</td>
-<td>10 (🟩🟦 High)</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>Affects Web App, rank:A-high-value-low-cost</td>
 </tr>
 <tr>
 <td><a
@@ -1296,13 +1252,25 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/19">19</
 </tr>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484">484</a></td>
-<td>in overall table, change EJAM Report link for 1-site analysis</td>
-<td>3 (🔵 Low)</td>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/511">511</a></td>
+<td>CI runs only on PRs into main: development and deploy PRs get no
+check…</td>
+<td>4 (🟡 Medium)</td>
 <td>7 (🟦 Medium)</td>
-<td>v4</td>
+<td>NA</td>
 <td>PRIORITY MEDIUM</td>
-<td>Affects Web App</td>
+<td>test, Affects Web App</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/510">510</a></td>
+<td>Smoke-test PDF generation in the built image and after deploy (prod
+PD…</td>
+<td>4 (🟡 Medium)</td>
+<td>7 (🟦 Medium)</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>test, Affects Web App</td>
 </tr>
 <tr>
 <td><a
@@ -1431,17 +1399,6 @@ rank:B-high-value-high-cost</td>
 </tr>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">284</a></td>
-<td>resolve warning about datum, in logs/console, when web app tries to
-up…</td>
-<td>3 (🔵 Low)</td>
-<td>6 (🟦 Medium)</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>Affects Web App, rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194">194</a></td>
 <td>Create visualizations of overall results in app - engaging &amp;
 insightf…</td>
@@ -1474,39 +1431,6 @@ or US…</td>
 <td>PRIORITY LOW</td>
 <td>BUG, calculate/validate to EJScreen, Community Report,
 rank:D-defer</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454">454</a></td>
-<td>fix when should radius slider reset to 0 vs 1 mile (a
-method-specific …</td>
-<td>3 (🔵 Low)</td>
-<td>5 (🟦 Medium)</td>
-<td>v4</td>
-<td>PRIORITY LOW</td>
-<td>BUG</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224">224</a></td>
-<td>report correct population for a single block (if block is analyzed
-via…</td>
-<td>3 (🔵 Low)</td>
-<td>5 (🟦 Medium)</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>BUG, rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40">40</a></td>
-<td>Allow abort site selection processing when selections are
-changed</td>
-<td>3 (🔵 Low)</td>
-<td>5 (🟦 Medium)</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>rank:C-low-value-low-cost</td>
 </tr>
 <tr>
 <td><a
@@ -1657,7 +1581,7 @@ list</td>
 Might As Well — Low Cost, Low Benefit</h2>
 <p><em>Cheap to do; low urgency. Pick these up when bandwidth allows or
 combine with nearby work.</em></p>
-<p><strong>14 issues</strong></p>
+<p><strong>21 issues</strong></p>
 <ul>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/177">#177</a>
@@ -1675,6 +1599,13 @@ others</li>
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458">#458</a>
 — in-app report header for a 1-site analysis should say Community Report
 not Multisite Summary</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/159">#159</a>
+— integrate file-naming function and header-creating functions</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/24">#24</a>
+— map popups in make.popups.api() and other functions are too cluttered,
+move most info to separate popup (see example in comment)</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/179">#179</a>
 — in ejam2excel() rename parameter fname to filename for consistency w
@@ -1697,6 +1628,18 @@ prominent</li>
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/59">#59</a>
 — Improve MACT-related lat lon data</li>
 <li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/184">#184</a>
+— trim the extremely long unit test names</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/43">#43</a>
+— Enable fast site selection map during category scrolling</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/41">#41</a>
+— Include indicator formulas in Community Report</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/39">#39</a>
+— Review/revise/expand unit testing for SIC functions</li>
+<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/482">#482</a>
 — Feature: zipcode analysis — accept zipcode parameter in ejamit() and
 key functions</li>
@@ -1710,6 +1653,9 @@ in DESCRIPTION file</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/42">#42</a>
 — Remove unused report template files</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60">#60</a>
+— Rename community report functions with common convention</li>
 </ul>
 <table class="issue-details">
 <colgroup>
@@ -1779,6 +1725,28 @@ Report…</td>
 </tr>
 <tr>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/159">159</a></td>
+<td>integrate file-naming function and header-creating functions</td>
+<td>3 (🔵 Low)</td>
+<td>4 (⬜ Low)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>refactor, Affects Web App, Community Report,
+rank:C-low-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/24">24</a></td>
+<td>map popups in make.popups.api() and other functions are too
+cluttered,…</td>
+<td>3 (🔵 Low)</td>
+<td>4 (⬜ Low)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>map-popups-related, rank:C-low-value-low-cost</td>
+</tr>
+<tr>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/179">179</a></td>
 <td>in ejam2excel() rename parameter fname to filename for consistency w
 o…</td>
@@ -1844,6 +1812,47 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/59">59</
 </tr>
 <tr>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/184">184</a></td>
+<td>trim the extremely long unit test names</td>
+<td>3 (🔵 Low)</td>
+<td>2 (⬜ Low)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>documentation, refactor, Affects R users only - NOT web app users,
+rank:C-low-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/43">43</a></td>
+<td>Enable fast site selection map during category scrolling</td>
+<td>3 (🔵 Low)</td>
+<td>2 (⬜ Low)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>maps-related, rank:C-low-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/41">41</a></td>
+<td>Include indicator formulas in Community Report</td>
+<td>3 (🔵 Low)</td>
+<td>2 (⬜ Low)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>Community Report, rank:C-low-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/39">39</a></td>
+<td>Review/revise/expand unit testing for SIC functions</td>
+<td>3 (🔵 Low)</td>
+<td>2 (⬜ Low)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>test, rank:C-low-value-low-cost</td>
+</tr>
+<tr>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/482">482</a></td>
 <td>Feature: zipcode analysis — accept zipcode parameter in ejamit() and
 k…</td>
@@ -1885,6 +1894,16 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/42">42</
 <td>PRIORITY LOW</td>
 <td>Community Report, rank:C-low-value-low-cost</td>
 </tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60">60</a></td>
+<td>Rename community report functions with common convention</td>
+<td>3 (🔵 Low)</td>
+<td>0 (⬜ Very Low)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>documentation, refactor, server, Community Report</td>
+</tr>
 </tbody>
 </table>
 <hr />
@@ -1892,34 +1911,8 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/42">42</
 WORST CANDIDATES — High Cost, Low Benefit</h2>
 <p><em>Expensive to fix, limited payoff. Defer or deprioritize unless
 circumstances change.</em></p>
-<p><strong>32 issues</strong></p>
+<p><strong>23 issues</strong></p>
 <ul>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/242">#242</a>
-— Report should show ratios to avg for special indicators like % of
-residents who are in CEJST disadvantaged or air nonattainment areas</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/159">#159</a>
-— integrate file-naming function and header-creating functions</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/24">#24</a>
-— map popups in make.popups.api() and other functions are too cluttered,
-move most info to separate popup (see example in comment)</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/184">#184</a>
-— trim the extremely long unit test names</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/43">#43</a>
-— Enable fast site selection map during category scrolling</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/41">#41</a>
-— Include indicator formulas in Community Report</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/39">#39</a>
-— Review/revise/expand unit testing for SIC functions</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60">#60</a>
-— Rename community report functions with common convention</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/508">#508</a>
 — ECR lifecycle policy: prune accumulating dev images (without touching
@@ -1928,10 +1921,6 @@ prod)</li>
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/507">#507</a>
 — deploy-dev: encode the deployed EJAM version in the dev ECR image
 tag</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/465">#465</a>
-— EJAM app crashes on EJScreen token handoff (Send to EJAM) for
-FIPS/polygon/bufferless selections</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/182">#182</a>
 — consider refactoring url_xyz functions</li>
@@ -2036,90 +2025,6 @@ code</li>
 <tbody>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/242">242</a></td>
-<td>Report should show ratios to avg for special indicators like % of
-resi…</td>
-<td>3 (🔵 Low)</td>
-<td>4 (⬜ Low)</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>Community Report, rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/159">159</a></td>
-<td>integrate file-naming function and header-creating functions</td>
-<td>3 (🔵 Low)</td>
-<td>4 (⬜ Low)</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>refactor, Affects Web App, Community Report,
-rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/24">24</a></td>
-<td>map popups in make.popups.api() and other functions are too
-cluttered,…</td>
-<td>3 (🔵 Low)</td>
-<td>4 (⬜ Low)</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>map-popups-related, rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/184">184</a></td>
-<td>trim the extremely long unit test names</td>
-<td>3 (🔵 Low)</td>
-<td>2 (⬜ Low)</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>documentation, refactor, Affects R users only - NOT web app users,
-rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/43">43</a></td>
-<td>Enable fast site selection map during category scrolling</td>
-<td>3 (🔵 Low)</td>
-<td>2 (⬜ Low)</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>maps-related, rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/41">41</a></td>
-<td>Include indicator formulas in Community Report</td>
-<td>3 (🔵 Low)</td>
-<td>2 (⬜ Low)</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>Community Report, rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/39">39</a></td>
-<td>Review/revise/expand unit testing for SIC functions</td>
-<td>3 (🔵 Low)</td>
-<td>2 (⬜ Low)</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>test, rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60">60</a></td>
-<td>Rename community report functions with common convention</td>
-<td>3 (🔵 Low)</td>
-<td>0 (⬜ Very Low)</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>documentation, refactor, server, Community Report</td>
-</tr>
-<tr>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/508">508</a></td>
 <td>ECR lifecycle policy: prune accumulating dev images (without
 touching …</td>
@@ -2138,17 +2043,6 @@ tag</td>
 <td>4 (⬜ Low)</td>
 <td>NA</td>
 <td>PRIORITY MEDIUM</td>
-<td></td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/465">465</a></td>
-<td>EJAM app crashes on EJScreen token handoff (Send to EJAM) for
-FIPS/pol…</td>
-<td>4 (🟡 Medium)</td>
-<td>4 (⬜ Low)</td>
-<td>NA</td>
-<td>—</td>
 <td></td>
 </tr>
 <tr>
@@ -2384,7 +2278,7 @@ code</td>
 </tbody>
 </table>
 <hr />
-<h2 id="full-table-all-137-issues">Full Table — All 137 Issues</h2>
+<h2 id="full-table-all-130-issues">Full Table — All 130 Issues</h2>
 <p>Sorted: A first (best), then B, C, D; within each group by benefit
 DESC.</p>
 <table>
@@ -2412,13 +2306,13 @@ DESC.</p>
 <tr>
 <td>A</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/156">156</a></td>
-<td>0</td>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504">504</a></td>
+<td>3</td>
 <td>17</td>
-<td>NA</td>
-<td>PRIORITY HIGH-ish but not a bug</td>
-<td>in app - add view of ejam2areafeatures(out) (info on % of pop with
-ce…</td>
+<td>v4</td>
+<td>PRIORITY MEDIUM</td>
+<td>Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate
+task …</td>
 </tr>
 <tr>
 <td>A</td>
@@ -2434,28 +2328,6 @@ or …</td>
 <tr>
 <td>A</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/385">385</a></td>
-<td>1</td>
-<td>15</td>
-<td>v4</td>
-<td>PRIORITY MEDIUM</td>
-<td>ejam2report() fails to save a file when the filename parameter is
-used</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/348">348</a></td>
-<td>2</td>
-<td>15</td>
-<td>v3.2022.2</td>
-<td>PRIORITY MEDIUM</td>
-<td>API report links from multisite results label every per-site report
-as s…</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/274">274</a></td>
 <td>2</td>
 <td>15</td>
@@ -2467,13 +2339,24 @@ the C…</td>
 <tr>
 <td>A</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/205">205</a></td>
-<td>2</td>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342">342</a></td>
+<td>3</td>
 <td>15</td>
 <td>NA</td>
 <td>PRIORITY HIGH-ish but not a bug</td>
-<td>adjust summary report fonts and row heights/line spacing to make
-text mo…</td>
+<td>use renv package to create lock state for what versions of what
+packages…</td>
+</tr>
+<tr>
+<td>A</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341">341</a></td>
+<td>3</td>
+<td>15</td>
+<td>NA</td>
+<td>PRIORITY HIGH-ish but not a bug</td>
+<td>Align map_headernames and/or generated avg/pctile/ratio metadata
+with co…</td>
 </tr>
 <tr>
 <td>A</td>
@@ -2489,24 +2372,13 @@ has c…</td>
 <tr>
 <td>A</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/144">144</a></td>
-<td>0</td>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400">400</a></td>
+<td>3</td>
 <td>13</td>
-<td>v3.2022.2</td>
-<td>PRIORITY MEDIUM</td>
-<td>use or remove or explain the sitenumber parameter in ejam2map() for
-fips…</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/127">127</a></td>
-<td>0</td>
-<td>13</td>
-<td>v3.2022.2</td>
-<td>PRIORITY MEDIUM</td>
-<td>web app details tab with table of all sites is too sluggish as it
-appear…</td>
+<td>NA</td>
+<td>PRIORITY HIGH</td>
+<td>improve how webapp users can find info on data vintage (in EJAM web
+app …</td>
 </tr>
 <tr>
 <td>A</td>
@@ -2514,7 +2386,7 @@ appear…</td>
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344">344</a></td>
 <td>2</td>
 <td>12</td>
-<td>NA</td>
+<td>v4</td>
 <td>PRIORITY HIGH-ish but not a bug</td>
 <td>Show an example of a community report - e.g., in or linked from
 “basics”…</td>
@@ -2533,17 +2405,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/249">249
 <tr>
 <td>A</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/410">410</a></td>
-<td>1</td>
-<td>11</td>
-<td>v3.2022.2</td>
-<td>PRIORITY MEDIUM</td>
-<td>“FEATURES AND LOCATION INFORMATION” on report need explanation and
-less …</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/137">137</a></td>
 <td>1</td>
 <td>11</td>
@@ -2555,13 +2416,35 @@ right. …</td>
 <tr>
 <td>A</td>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/268">268</a></td>
+<td>2</td>
+<td>11</td>
+<td>NA</td>
+<td>—</td>
+<td>Uploading a file was failing intermittently when live app hosted
+using A…</td>
+</tr>
+<tr>
+<td>A</td>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/109">109</a></td>
 <td>1</td>
 <td>10</td>
-<td>NA</td>
+<td>v4</td>
 <td>PRIORITY LOW</td>
 <td>Update &amp; correct the article “Defaults and Custom Settings for
 the Web A…</td>
+</tr>
+<tr>
+<td>A</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73">73</a></td>
+<td>3</td>
+<td>10</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>in web app, add ways to analyze multiple radii at once or even
+continuou…</td>
 </tr>
 <tr>
 <td>A</td>
@@ -2674,7 +2557,7 @@ rad…</td>
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">162</a></td>
 <td>1</td>
 <td>7</td>
-<td>NA</td>
+<td>v4</td>
 <td>PRIORITY MEDIUM</td>
 <td>rename “in_how_many_states” column in table of results</td>
 </tr>
@@ -2684,7 +2567,7 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">162
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">136</a></td>
 <td>1</td>
 <td>7</td>
-<td>NA</td>
+<td>v4</td>
 <td>PRIORITY LOW</td>
 <td>in web app, fix console error msg when uploading a shapefile</td>
 </tr>
@@ -2694,7 +2577,7 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">136
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288">288</a></td>
 <td>2</td>
 <td>7</td>
-<td>NA</td>
+<td>v3.2022.2</td>
 <td>PRIORITY MEDIUM</td>
 <td>ratio of 1.0 should not be yellow on community report</td>
 </tr>
@@ -2712,12 +2595,33 @@ ensu…</td>
 <tr>
 <td>A</td>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484">484</a></td>
+<td>3</td>
+<td>7</td>
+<td>v4</td>
+<td>PRIORITY MEDIUM</td>
+<td>in overall table, change EJAM Report link for 1-site analysis</td>
+</tr>
+<tr>
+<td>A</td>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486">486</a></td>
 <td>1</td>
 <td>6</td>
 <td>v4</td>
 <td>PRIORITY LOW</td>
 <td>allow zip code analysis in EJAM shiny web app</td>
+</tr>
+<tr>
+<td>A</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">284</a></td>
+<td>3</td>
+<td>6</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>resolve warning about datum, in logs/console, when web app tries to
+uplo…</td>
 </tr>
 <tr>
 <td>A</td>
@@ -2785,16 +2689,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92">92</
 <tr>
 <td>A</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/69">69</a></td>
-<td>2</td>
-<td>5</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>enable other units like kilometers for entry of radius</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58">58</a></td>
 <td>2</td>
 <td>5</td>
@@ -2803,15 +2697,37 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58">58</
 <td>joining FIPS upload data to preview table</td>
 </tr>
 <tr>
-<td>B</td>
+<td>A</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/467">467</a></td>
-<td>4</td>
-<td>20</td>
-<td>v3.2022.2</td>
-<td>PRIORITY HIGH</td>
-<td>ejam2report() fails for zero-population or otherwise
-analysis-invalid si…</td>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454">454</a></td>
+<td>3</td>
+<td>5</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>fix when should radius slider reset to 0 vs 1 mile (a
+method-specific de…</td>
+</tr>
+<tr>
+<td>A</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224">224</a></td>
+<td>3</td>
+<td>5</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>report correct population for a single block (if block is analyzed
+via b…</td>
+</tr>
+<tr>
+<td>A</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40">40</a></td>
+<td>3</td>
+<td>5</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>Allow abort site selection processing when selections are
+changed</td>
 </tr>
 <tr>
 <td>B</td>
@@ -2827,13 +2743,13 @@ clicks</td>
 <tr>
 <td>B</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504">504</a></td>
-<td>3</td>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/513">513</a></td>
+<td>6</td>
 <td>17</td>
 <td>v4</td>
-<td>PRIORITY MEDIUM</td>
-<td>Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate
-task …</td>
+<td>PRIORITY HIGH</td>
+<td>need better ETA estimates (predicted seconds to completion are too
+high)</td>
 </tr>
 <tr>
 <td>B</td>
@@ -2870,28 +2786,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/226">226
 <tr>
 <td>B</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342">342</a></td>
-<td>3</td>
-<td>15</td>
-<td>NA</td>
-<td>PRIORITY HIGH-ish but not a bug</td>
-<td>use renv package to create lock state for what versions of what
-packages…</td>
-</tr>
-<tr>
-<td>B</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341">341</a></td>
-<td>3</td>
-<td>15</td>
-<td>NA</td>
-<td>PRIORITY HIGH-ish but not a bug</td>
-<td>Align map_headernames and/or generated avg/pctile/ratio metadata
-with co…</td>
-</tr>
-<tr>
-<td>B</td>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/349">349</a></td>
 <td>4</td>
 <td>15</td>
@@ -2924,17 +2818,6 @@ Ide…</td>
 <tr>
 <td>B</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400">400</a></td>
-<td>3</td>
-<td>13</td>
-<td>NA</td>
-<td>PRIORITY HIGH</td>
-<td>improve how webapp users can find info on data vintage (in EJAM web
-app …</td>
-</tr>
-<tr>
-<td>B</td>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/68">68</a></td>
 <td>4</td>
 <td>13</td>
@@ -2962,17 +2845,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126">126
 <td>PRIORITY MEDIUM</td>
 <td>enable 1-site report on Polygons / Shapefile, via links/buttons in
 shiny…</td>
-</tr>
-<tr>
-<td>B</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73">73</a></td>
-<td>3</td>
-<td>10</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>in web app, add ways to analyze multiple radii at once or even
-continuou…</td>
 </tr>
 <tr>
 <td>B</td>
@@ -3021,12 +2893,24 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/19">19</
 <tr>
 <td>B</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484">484</a></td>
-<td>3</td>
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/511">511</a></td>
+<td>4</td>
 <td>7</td>
-<td>v4</td>
+<td>NA</td>
 <td>PRIORITY MEDIUM</td>
-<td>in overall table, change EJAM Report link for 1-site analysis</td>
+<td>CI runs only on PRs into main: development and deploy PRs get no
+checks …</td>
+</tr>
+<tr>
+<td>B</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/510">510</a></td>
+<td>4</td>
+<td>7</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>Smoke-test PDF generation in the built image and after deploy (prod
+PDF …</td>
 </tr>
 <tr>
 <td>B</td>
@@ -3150,17 +3034,6 @@ paths</td>
 <tr>
 <td>B</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">284</a></td>
-<td>3</td>
-<td>6</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>resolve warning about datum, in logs/console, when web app tries to
-uplo…</td>
-</tr>
-<tr>
-<td>B</td>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/194">194</a></td>
 <td>5</td>
 <td>6</td>
@@ -3190,39 +3063,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/66">66</
 <td>PRIORITY LOW</td>
 <td>EJAM &amp; EJScreen report on avg PERSON generally but State Average
 or US A…</td>
-</tr>
-<tr>
-<td>B</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454">454</a></td>
-<td>3</td>
-<td>5</td>
-<td>v4</td>
-<td>PRIORITY LOW</td>
-<td>fix when should radius slider reset to 0 vs 1 mile (a
-method-specific de…</td>
-</tr>
-<tr>
-<td>B</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224">224</a></td>
-<td>3</td>
-<td>5</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>report correct population for a single block (if block is analyzed
-via b…</td>
-</tr>
-<tr>
-<td>B</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40">40</a></td>
-<td>3</td>
-<td>5</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>Allow abort site selection processing when selections are
-changed</td>
 </tr>
 <tr>
 <td>B</td>
@@ -3410,6 +3250,27 @@ Report n…</td>
 <tr>
 <td>C</td>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/159">159</a></td>
+<td>3</td>
+<td>4</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>integrate file-naming function and header-creating functions</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/24">24</a></td>
+<td>3</td>
+<td>4</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>map popups in make.popups.api() and other functions are too
+cluttered, m…</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/179">179</a></td>
 <td>0</td>
 <td>3</td>
@@ -3473,6 +3334,46 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/59">59</
 <tr>
 <td>C</td>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/184">184</a></td>
+<td>3</td>
+<td>2</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>trim the extremely long unit test names</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/43">43</a></td>
+<td>3</td>
+<td>2</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>Enable fast site selection map during category scrolling</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/41">41</a></td>
+<td>3</td>
+<td>2</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>Include indicator formulas in Community Report</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/39">39</a></td>
+<td>3</td>
+<td>2</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>Review/revise/expand unit testing for SIC functions</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/482">482</a></td>
 <td>2</td>
 <td>1</td>
@@ -3513,79 +3414,7 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/42">42</
 <td>Remove unused report template files</td>
 </tr>
 <tr>
-<td>D</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/242">242</a></td>
-<td>3</td>
-<td>4</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>Report should show ratios to avg for special indicators like % of
-reside…</td>
-</tr>
-<tr>
-<td>D</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/159">159</a></td>
-<td>3</td>
-<td>4</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>integrate file-naming function and header-creating functions</td>
-</tr>
-<tr>
-<td>D</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/24">24</a></td>
-<td>3</td>
-<td>4</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>map popups in make.popups.api() and other functions are too
-cluttered, m…</td>
-</tr>
-<tr>
-<td>D</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/184">184</a></td>
-<td>3</td>
-<td>2</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>trim the extremely long unit test names</td>
-</tr>
-<tr>
-<td>D</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/43">43</a></td>
-<td>3</td>
-<td>2</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>Enable fast site selection map during category scrolling</td>
-</tr>
-<tr>
-<td>D</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/41">41</a></td>
-<td>3</td>
-<td>2</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>Include indicator formulas in Community Report</td>
-</tr>
-<tr>
-<td>D</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/39">39</a></td>
-<td>3</td>
-<td>2</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>Review/revise/expand unit testing for SIC functions</td>
-</tr>
-<tr>
-<td>D</td>
+<td>C</td>
 <td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60">60</a></td>
 <td>3</td>
@@ -3615,17 +3444,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/507">507
 <td>PRIORITY MEDIUM</td>
 <td>deploy-dev: encode the deployed EJAM version in the dev ECR image
 tag</td>
-</tr>
-<tr>
-<td>D</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/465">465</a></td>
-<td>4</td>
-<td>4</td>
-<td>NA</td>
-<td>—</td>
-<td>EJAM app crashes on EJScreen token handoff (Send to EJAM) for
-FIPS/polyg…</td>
 </tr>
 <tr>
 <td>D</td>
@@ -3870,15 +3688,15 @@ code</td>
 </tr>
 <tr>
 <td>v3.2022.2</td>
-<td style="text-align: right;">6</td>
+<td style="text-align: right;">2</td>
 </tr>
 <tr>
 <td>v4</td>
-<td style="text-align: right;">14</td>
+<td style="text-align: right;">18</td>
 </tr>
 <tr>
 <td>NA</td>
-<td style="text-align: right;">116</td>
+<td style="text-align: right;">109</td>
 </tr>
 </tbody>
 </table>
@@ -3926,11 +3744,11 @@ crash/wrong-calculation signals, CRAN visibility</td>
 <tr>
 <td>Cost</td>
 <td>0 – 18</td>
-<td>3</td>
+<td>4</td>
 </tr>
 <tr>
 <td>Benefit</td>
-<td>0 – 20</td>
+<td>0 – 19</td>
 <td>5</td>
 </tr>
 </tbody>

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.html
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.html
@@ -207,8 +207,8 @@
 <body>
 <h1 id="ejam-open-issues-scored-by-cost-benefit">EJAM Open Issues —
 Scored by Cost &amp; Benefit</h1>
-<p><strong>Total open issues:</strong> 131 | <strong>Generated:</strong>
-2026-07-26 | <strong>Source:</strong> Live GitHub REST API open issues
+<p><strong>Total open issues:</strong> 132 | <strong>Generated:</strong>
+2026-07-27 | <strong>Source:</strong> Live GitHub REST API open issues
 (Public-Environmental-Data-Partners/EJAM)</p>
 <p><strong>Score payload:</strong>
 <code>inst/issues/ejam_issues_scored_by_risk_and_value.json</code></p>
@@ -225,19 +225,19 @@ Scored by Cost &amp; Benefit</h1>
 <tbody>
 <tr>
 <td>Previous run</td>
-<td>2026-07-25</td>
+<td>2026-07-26</td>
 </tr>
 <tr>
 <td>Issues opened since previous run</td>
-<td>2</td>
-</tr>
-<tr>
-<td>Issues closed since previous run</td>
 <td>1</td>
 </tr>
 <tr>
-<td>Issues whose quadrant changed</td>
+<td>Issues closed since previous run</td>
 <td>0</td>
+</tr>
+<tr>
+<td>Issues whose quadrant changed</td>
+<td>19</td>
 </tr>
 </tbody>
 </table>
@@ -259,22 +259,22 @@ Scored by Cost &amp; Benefit</h1>
 <tbody>
 <tr>
 <td><strong>LOW Cost</strong><br>cost &lt; median</td>
-<td><strong>C — Might As Well</strong><br>22 issues</td>
-<td><strong>A — BEST CANDIDATES</strong><br>39 issues</td>
+<td><strong>C — Other Low-Cost Work</strong><br>41 issues</td>
+<td><strong>A — Focus Shortlist (max 20)</strong><br>20 issues</td>
 </tr>
 <tr>
 <td><strong>HIGH Cost</strong><br>cost ≥ median</td>
-<td><strong>D — WORST CANDIDATES</strong><br>23 issues</td>
+<td><strong>D — WORST CANDIDATES</strong><br>24 issues</td>
 <td><strong>B — OK Candidates</strong><br>47 issues</td>
 </tr>
 </tbody>
 </table>
 <hr />
-<h2 id="quadrant-a-best-candidates-low-cost-high-benefit">Quadrant A —
-BEST CANDIDATES — Low Cost, High Benefit</h2>
-<p><em>Easy fixes with clear high value. Prioritize these above all
-others.</em></p>
-<p><strong>39 issues</strong></p>
+<h2 id="quadrant-a-focus-shortlist-low-cost-high-benefit">Quadrant A —
+FOCUS SHORTLIST — Low Cost, High Benefit</h2>
+<p><em>The top 20 low-cost, high-benefit candidates at most, ordered by
+benefit then cost. Prioritize these above all others.</em></p>
+<p><strong>20 issues</strong></p>
 <ul>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16">#16</a>
@@ -350,74 +350,8 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/91">#91<
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161">#161</a>
 — ejamapp() should be able to handle mix of fips types</li>
 <li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490">#490</a>
-— swap us and state ratio columns</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361">#361</a>
-— Add date and time of last updated to help with deploys</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163">#163</a>
-— put certain columns last in table of results (bg count, block count,
-radius)</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">#162</a>
-— rename “in_how_many_states” column in table of results</li>
-<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">#136</a>
 — in web app, fix console error msg when uploading a shapefile</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288">#288</a>
-— ratio of 1.0 should not be yellow on community report</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70">#70</a>
-— set up alerts that monitor and alert staff when the app goes down -
-ensure available</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484">#484</a>
-— in overall table, change EJAM Report link for 1-site analysis</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486">#486</a>
-— allow zip code analysis in EJAM shiny web app</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">#284</a>
-— resolve warning about datum, in logs/console, when web app tries to
-upload/read some shapefiles</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102">#102</a>
-— Remove NA console messages from <code>doaggregate</code></li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/455">#455</a>
-— fix radius slider behavior after deep link passes a radius and then
-user changes it</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403">#403</a>
-— Add explanation of what “average in state” or “percentile in state”
-means for a multisite report</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350">#350</a>
-— Add report regression tests for FIPS, shapefile, sitenumber, NAICS,
-and PDF-unavailable paths</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/96">#96</a>
-— Detailed Table UI Filtering improvements</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92">#92</a>
-— Excel’s new tab with upload needs cap on size</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58">#58</a>
-— joining FIPS upload data to preview table</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454">#454</a>
-— fix when should radius slider reset to 0 vs 1 mile (a method-specific
-default) if radio button used to switch between points and polygon/fips
-type sites</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224">#224</a>
-— report correct population for a single block (if block is analyzed via
-block fips code)</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40">#40</a>
-— Allow abort site selection processing when selections are changed</li>
 </ul>
 <table class="issue-details">
 <colgroup>
@@ -653,47 +587,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161">161
 </tr>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490">490</a></td>
-<td>swap us and state ratio columns</td>
-<td>1 (🟢 Very Low)</td>
-<td>7 (🟦 Medium)</td>
-<td>v4</td>
-<td>PRIORITY MEDIUM</td>
-<td>Affects Web App, Community Report</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361">361</a></td>
-<td>Add date and time of last updated to help with deploys</td>
-<td>1 (🟢 Very Low)</td>
-<td>7 (🟦 Medium)</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>Affects Web App, rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163">163</a></td>
-<td>put certain columns last in table of results (bg count, block count,
-r…</td>
-<td>1 (🟢 Very Low)</td>
-<td>7 (🟦 Medium)</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>Affects Web App, rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">162</a></td>
-<td>rename “in_how_many_states” column in table of results</td>
-<td>1 (🟢 Very Low)</td>
-<td>7 (🟦 Medium)</td>
-<td>v4</td>
-<td>PRIORITY MEDIUM</td>
-<td>Affects Web App, rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">136</a></td>
 <td>in web app, fix console error msg when uploading a shapefile</td>
 <td>1 (🟢 Very Low)</td>
@@ -701,165 +594,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">136
 <td>v4</td>
 <td>PRIORITY LOW</td>
 <td>BUG, rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288">288</a></td>
-<td>ratio of 1.0 should not be yellow on community report</td>
-<td>2 (🔵 Low)</td>
-<td>7 (🟦 Medium)</td>
-<td>v3.2022.2</td>
-<td>PRIORITY MEDIUM</td>
-<td>Affects Web App, Community Report, rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70">70</a></td>
-<td>set up alerts that monitor and alert staff when the app goes down -
-en…</td>
-<td>2 (🔵 Low)</td>
-<td>7 (🟦 Medium)</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484">484</a></td>
-<td>in overall table, change EJAM Report link for 1-site analysis</td>
-<td>3 (🔵 Low)</td>
-<td>7 (🟦 Medium)</td>
-<td>v4</td>
-<td>PRIORITY MEDIUM</td>
-<td>Affects Web App</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486">486</a></td>
-<td>allow zip code analysis in EJAM shiny web app</td>
-<td>1 (🟢 Very Low)</td>
-<td>6 (🟦 Medium)</td>
-<td>v4</td>
-<td>PRIORITY LOW</td>
-<td>Affects Web App</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">284</a></td>
-<td>resolve warning about datum, in logs/console, when web app tries to
-up…</td>
-<td>3 (🔵 Low)</td>
-<td>6 (🟦 Medium)</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>Affects Web App, rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102">102</a></td>
-<td>Remove NA console messages from <code>doaggregate</code></td>
-<td>0 (🟢 Very Low)</td>
-<td>5 (🟦 Medium)</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>Affects R users only - NOT web app users,
-rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/455">455</a></td>
-<td>fix radius slider behavior after deep link passes a radius and then
-us…</td>
-<td>1 (🟢 Very Low)</td>
-<td>5 (🟦 Medium)</td>
-<td>v4</td>
-<td>PRIORITY LOW</td>
-<td>BUG</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403">403</a></td>
-<td>Add explanation of what “average in state” or “percentile in state”
-me…</td>
-<td>1 (🟢 Very Low)</td>
-<td>5 (🟦 Medium)</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>documentation, Affects Web App, rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350">350</a></td>
-<td>Add report regression tests for FIPS, shapefile, sitenumber, NAICS,
-an…</td>
-<td>2 (🔵 Low)</td>
-<td>5 (🟦 Medium)</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>BUG, test, Community Report, rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/96">96</a></td>
-<td>Detailed Table UI Filtering improvements</td>
-<td>2 (🔵 Low)</td>
-<td>5 (🟦 Medium)</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>Affects Web App, rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92">92</a></td>
-<td>Excel’s new tab with upload needs cap on size</td>
-<td>2 (🔵 Low)</td>
-<td>5 (🟦 Medium)</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>Affects Web App, rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58">58</a></td>
-<td>joining FIPS upload data to preview table</td>
-<td>2 (🔵 Low)</td>
-<td>5 (🟦 Medium)</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454">454</a></td>
-<td>fix when should radius slider reset to 0 vs 1 mile (a
-method-specific …</td>
-<td>3 (🔵 Low)</td>
-<td>5 (🟦 Medium)</td>
-<td>v4</td>
-<td>PRIORITY LOW</td>
-<td>BUG</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224">224</a></td>
-<td>report correct population for a single block (if block is analyzed
-via…</td>
-<td>3 (🔵 Low)</td>
-<td>5 (🟦 Medium)</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>BUG, rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40">40</a></td>
-<td>Allow abort site selection processing when selections are
-changed</td>
-<td>3 (🔵 Low)</td>
-<td>5 (🟦 Medium)</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>rank:C-low-value-low-cost</td>
 </tr>
 </tbody>
 </table>
@@ -1576,12 +1310,78 @@ list</td>
 </tbody>
 </table>
 <hr />
-<h2 id="quadrant-c-might-as-well-low-cost-low-benefit">Quadrant C —
-Might As Well — Low Cost, Low Benefit</h2>
-<p><em>Cheap to do; low urgency. Pick these up when bandwidth allows or
-combine with nearby work.</em></p>
-<p><strong>22 issues</strong></p>
+<h2 id="quadrant-c-other-low-cost-work">Quadrant C — OTHER LOW-COST
+WORK</h2>
+<p><em>Cheap to do but not in the current focus shortlist. Pick these up
+when bandwidth allows or combine them with nearby work.</em></p>
+<p><strong>41 issues</strong></p>
 <ul>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490">#490</a>
+— swap us and state ratio columns</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361">#361</a>
+— Add date and time of last updated to help with deploys</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163">#163</a>
+— put certain columns last in table of results (bg count, block count,
+radius)</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">#162</a>
+— rename “in_how_many_states” column in table of results</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288">#288</a>
+— ratio of 1.0 should not be yellow on community report</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70">#70</a>
+— set up alerts that monitor and alert staff when the app goes down -
+ensure available</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484">#484</a>
+— in overall table, change EJAM Report link for 1-site analysis</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486">#486</a>
+— allow zip code analysis in EJAM shiny web app</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">#284</a>
+— resolve warning about datum, in logs/console, when web app tries to
+upload/read some shapefiles</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102">#102</a>
+— Remove NA console messages from <code>doaggregate</code></li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/455">#455</a>
+— fix radius slider behavior after deep link passes a radius and then
+user changes it</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403">#403</a>
+— Add explanation of what “average in state” or “percentile in state”
+means for a multisite report</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350">#350</a>
+— Add report regression tests for FIPS, shapefile, sitenumber, NAICS,
+and PDF-unavailable paths</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/96">#96</a>
+— Detailed Table UI Filtering improvements</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92">#92</a>
+— Excel’s new tab with upload needs cap on size</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58">#58</a>
+— joining FIPS upload data to preview table</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454">#454</a>
+— fix when should radius slider reset to 0 vs 1 mile (a method-specific
+default) if radio button used to switch between points and polygon/fips
+type sites</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224">#224</a>
+— report correct population for a single block (if block is analyzed via
+block fips code)</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40">#40</a>
+— Allow abort site selection processing when selections are changed</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/177">#177</a>
 — pick which approach is faster among functions like sf_nearest_points()
@@ -1682,6 +1482,206 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60">#60<
 </tr>
 </thead>
 <tbody>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490">490</a></td>
+<td>swap us and state ratio columns</td>
+<td>1 (🟢 Very Low)</td>
+<td>7 (🟦 Medium)</td>
+<td>v4</td>
+<td>PRIORITY MEDIUM</td>
+<td>Affects Web App, Community Report</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361">361</a></td>
+<td>Add date and time of last updated to help with deploys</td>
+<td>1 (🟢 Very Low)</td>
+<td>7 (🟦 Medium)</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>Affects Web App, rank:A-high-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163">163</a></td>
+<td>put certain columns last in table of results (bg count, block count,
+r…</td>
+<td>1 (🟢 Very Low)</td>
+<td>7 (🟦 Medium)</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>Affects Web App, rank:A-high-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">162</a></td>
+<td>rename “in_how_many_states” column in table of results</td>
+<td>1 (🟢 Very Low)</td>
+<td>7 (🟦 Medium)</td>
+<td>v4</td>
+<td>PRIORITY MEDIUM</td>
+<td>Affects Web App, rank:A-high-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288">288</a></td>
+<td>ratio of 1.0 should not be yellow on community report</td>
+<td>2 (🔵 Low)</td>
+<td>7 (🟦 Medium)</td>
+<td>v3.2022.2</td>
+<td>PRIORITY MEDIUM</td>
+<td>Affects Web App, Community Report, rank:A-high-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70">70</a></td>
+<td>set up alerts that monitor and alert staff when the app goes down -
+en…</td>
+<td>2 (🔵 Low)</td>
+<td>7 (🟦 Medium)</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>rank:A-high-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484">484</a></td>
+<td>in overall table, change EJAM Report link for 1-site analysis</td>
+<td>3 (🔵 Low)</td>
+<td>7 (🟦 Medium)</td>
+<td>v4</td>
+<td>PRIORITY MEDIUM</td>
+<td>Affects Web App</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486">486</a></td>
+<td>allow zip code analysis in EJAM shiny web app</td>
+<td>1 (🟢 Very Low)</td>
+<td>6 (🟦 Medium)</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>Affects Web App</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">284</a></td>
+<td>resolve warning about datum, in logs/console, when web app tries to
+up…</td>
+<td>3 (🔵 Low)</td>
+<td>6 (🟦 Medium)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>Affects Web App, rank:C-low-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102">102</a></td>
+<td>Remove NA console messages from <code>doaggregate</code></td>
+<td>0 (🟢 Very Low)</td>
+<td>5 (🟦 Medium)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>Affects R users only - NOT web app users,
+rank:C-low-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/455">455</a></td>
+<td>fix radius slider behavior after deep link passes a radius and then
+us…</td>
+<td>1 (🟢 Very Low)</td>
+<td>5 (🟦 Medium)</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>BUG</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403">403</a></td>
+<td>Add explanation of what “average in state” or “percentile in state”
+me…</td>
+<td>1 (🟢 Very Low)</td>
+<td>5 (🟦 Medium)</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>documentation, Affects Web App, rank:C-low-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350">350</a></td>
+<td>Add report regression tests for FIPS, shapefile, sitenumber, NAICS,
+an…</td>
+<td>2 (🔵 Low)</td>
+<td>5 (🟦 Medium)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>BUG, test, Community Report, rank:C-low-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/96">96</a></td>
+<td>Detailed Table UI Filtering improvements</td>
+<td>2 (🔵 Low)</td>
+<td>5 (🟦 Medium)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>Affects Web App, rank:C-low-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92">92</a></td>
+<td>Excel’s new tab with upload needs cap on size</td>
+<td>2 (🔵 Low)</td>
+<td>5 (🟦 Medium)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>Affects Web App, rank:C-low-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58">58</a></td>
+<td>joining FIPS upload data to preview table</td>
+<td>2 (🔵 Low)</td>
+<td>5 (🟦 Medium)</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>rank:C-low-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454">454</a></td>
+<td>fix when should radius slider reset to 0 vs 1 mile (a
+method-specific …</td>
+<td>3 (🔵 Low)</td>
+<td>5 (🟦 Medium)</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>BUG</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224">224</a></td>
+<td>report correct population for a single block (if block is analyzed
+via…</td>
+<td>3 (🔵 Low)</td>
+<td>5 (🟦 Medium)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>BUG, rank:C-low-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40">40</a></td>
+<td>Allow abort site selection processing when selections are
+changed</td>
+<td>3 (🔵 Low)</td>
+<td>5 (🟦 Medium)</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>rank:C-low-value-low-cost</td>
+</tr>
 <tr>
 <td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/177">177</a></td>
@@ -1925,7 +1925,7 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60">60</
 WORST CANDIDATES — High Cost, Low Benefit</h2>
 <p><em>Expensive to fix, limited payoff. Defer or deprioritize unless
 circumstances change.</em></p>
-<p><strong>23 issues</strong></p>
+<p><strong>24 issues</strong></p>
 <ul>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/508">#508</a>
@@ -1942,6 +1942,9 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/182">#18
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/89">#89</a>
 — clarify what “N places” really means &amp; report on the selection
 type (in summary report etc.)</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/536">#536</a>
+— redo list of URLs in url_package() documentation</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/35">#35</a>
 — Review/revise/expand unit testing for URL functions</li>
@@ -2080,6 +2083,17 @@ type (i…</td>
 <td>NA</td>
 <td>PRIORITY LOW</td>
 <td>still relevant?, Affects Web App, rank:D-defer</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/536">536</a></td>
+<td>redo list of URLs in url_package() documentation</td>
+<td>4 (🟡 Medium)</td>
+<td>2 (⬜ Low)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>documentation, refactor, Affects R users only - NOT web app
+users</td>
 </tr>
 <tr>
 <td><a
@@ -2292,7 +2306,7 @@ code</td>
 </tbody>
 </table>
 <hr />
-<h2 id="full-table-all-131-issues">Full Table — All 131 Issues</h2>
+<h2 id="full-table-all-132-issues">Full Table — All 132 Issues</h2>
 <p>Sorted: A first (best), then B, C, D; within each group by benefit
 DESC.</p>
 <table>
@@ -2526,211 +2540,12 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161">161
 <tr>
 <td>A</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490">490</a></td>
-<td>1</td>
-<td>7</td>
-<td>v4</td>
-<td>PRIORITY MEDIUM</td>
-<td>swap us and state ratio columns</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361">361</a></td>
-<td>1</td>
-<td>7</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>Add date and time of last updated to help with deploys</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163">163</a></td>
-<td>1</td>
-<td>7</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>put certain columns last in table of results (bg count, block count,
-rad…</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">162</a></td>
-<td>1</td>
-<td>7</td>
-<td>v4</td>
-<td>PRIORITY MEDIUM</td>
-<td>rename “in_how_many_states” column in table of results</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">136</a></td>
 <td>1</td>
 <td>7</td>
 <td>v4</td>
 <td>PRIORITY LOW</td>
 <td>in web app, fix console error msg when uploading a shapefile</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288">288</a></td>
-<td>2</td>
-<td>7</td>
-<td>v3.2022.2</td>
-<td>PRIORITY MEDIUM</td>
-<td>ratio of 1.0 should not be yellow on community report</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70">70</a></td>
-<td>2</td>
-<td>7</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>set up alerts that monitor and alert staff when the app goes down -
-ensu…</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484">484</a></td>
-<td>3</td>
-<td>7</td>
-<td>v4</td>
-<td>PRIORITY MEDIUM</td>
-<td>in overall table, change EJAM Report link for 1-site analysis</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486">486</a></td>
-<td>1</td>
-<td>6</td>
-<td>v4</td>
-<td>PRIORITY LOW</td>
-<td>allow zip code analysis in EJAM shiny web app</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">284</a></td>
-<td>3</td>
-<td>6</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>resolve warning about datum, in logs/console, when web app tries to
-uplo…</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102">102</a></td>
-<td>0</td>
-<td>5</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>Remove NA console messages from <code>doaggregate</code></td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/455">455</a></td>
-<td>1</td>
-<td>5</td>
-<td>v4</td>
-<td>PRIORITY LOW</td>
-<td>fix radius slider behavior after deep link passes a radius and then
-user…</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403">403</a></td>
-<td>1</td>
-<td>5</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>Add explanation of what “average in state” or “percentile in state”
-mean…</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350">350</a></td>
-<td>2</td>
-<td>5</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>Add report regression tests for FIPS, shapefile, sitenumber, NAICS,
-and …</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/96">96</a></td>
-<td>2</td>
-<td>5</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>Detailed Table UI Filtering improvements</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92">92</a></td>
-<td>2</td>
-<td>5</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>Excel’s new tab with upload needs cap on size</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58">58</a></td>
-<td>2</td>
-<td>5</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>joining FIPS upload data to preview table</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454">454</a></td>
-<td>3</td>
-<td>5</td>
-<td>v4</td>
-<td>PRIORITY LOW</td>
-<td>fix when should radius slider reset to 0 vs 1 mile (a
-method-specific de…</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224">224</a></td>
-<td>3</td>
-<td>5</td>
-<td>NA</td>
-<td>PRIORITY LOW</td>
-<td>report correct population for a single block (if block is analyzed
-via b…</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40">40</a></td>
-<td>3</td>
-<td>5</td>
-<td>NA</td>
-<td>PRIORITY MEDIUM</td>
-<td>Allow abort site selection processing when selections are
-changed</td>
 </tr>
 <tr>
 <td>B</td>
@@ -3220,6 +3035,205 @@ Dasym…</td>
 <tr>
 <td>C</td>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490">490</a></td>
+<td>1</td>
+<td>7</td>
+<td>v4</td>
+<td>PRIORITY MEDIUM</td>
+<td>swap us and state ratio columns</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361">361</a></td>
+<td>1</td>
+<td>7</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>Add date and time of last updated to help with deploys</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163">163</a></td>
+<td>1</td>
+<td>7</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>put certain columns last in table of results (bg count, block count,
+rad…</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">162</a></td>
+<td>1</td>
+<td>7</td>
+<td>v4</td>
+<td>PRIORITY MEDIUM</td>
+<td>rename “in_how_many_states” column in table of results</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288">288</a></td>
+<td>2</td>
+<td>7</td>
+<td>v3.2022.2</td>
+<td>PRIORITY MEDIUM</td>
+<td>ratio of 1.0 should not be yellow on community report</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70">70</a></td>
+<td>2</td>
+<td>7</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>set up alerts that monitor and alert staff when the app goes down -
+ensu…</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484">484</a></td>
+<td>3</td>
+<td>7</td>
+<td>v4</td>
+<td>PRIORITY MEDIUM</td>
+<td>in overall table, change EJAM Report link for 1-site analysis</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486">486</a></td>
+<td>1</td>
+<td>6</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>allow zip code analysis in EJAM shiny web app</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/284">284</a></td>
+<td>3</td>
+<td>6</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>resolve warning about datum, in logs/console, when web app tries to
+uplo…</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/102">102</a></td>
+<td>0</td>
+<td>5</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>Remove NA console messages from <code>doaggregate</code></td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/455">455</a></td>
+<td>1</td>
+<td>5</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>fix radius slider behavior after deep link passes a radius and then
+user…</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/403">403</a></td>
+<td>1</td>
+<td>5</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>Add explanation of what “average in state” or “percentile in state”
+mean…</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/350">350</a></td>
+<td>2</td>
+<td>5</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>Add report regression tests for FIPS, shapefile, sitenumber, NAICS,
+and …</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/96">96</a></td>
+<td>2</td>
+<td>5</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>Detailed Table UI Filtering improvements</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/92">92</a></td>
+<td>2</td>
+<td>5</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>Excel’s new tab with upload needs cap on size</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/58">58</a></td>
+<td>2</td>
+<td>5</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>joining FIPS upload data to preview table</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/454">454</a></td>
+<td>3</td>
+<td>5</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>fix when should radius slider reset to 0 vs 1 mile (a
+method-specific de…</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/224">224</a></td>
+<td>3</td>
+<td>5</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>report correct population for a single block (if block is analyzed
+via b…</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40">40</a></td>
+<td>3</td>
+<td>5</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>Allow abort site selection processing when selections are
+changed</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/177">177</a></td>
 <td>0</td>
 <td>4</td>
@@ -3494,6 +3508,16 @@ type (in …</td>
 <tr>
 <td>D</td>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/536">536</a></td>
+<td>4</td>
+<td>2</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>redo list of URLs in url_package() documentation</td>
+</tr>
+<tr>
+<td>D</td>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/35">35</a></td>
 <td>4</td>
 <td>2</td>
@@ -3721,7 +3745,7 @@ code</td>
 </tr>
 <tr>
 <td>NA</td>
-<td style="text-align: right;">109</td>
+<td style="text-align: right;">110</td>
 </tr>
 </tbody>
 </table>
@@ -3780,6 +3804,11 @@ crash/wrong-calculation signals, CRAN visibility</td>
 </table>
 <p>Issues at or above the median are <strong>High</strong>; below are
 <strong>Low</strong> for that dimension.</p>
+<h3 id="focus-shortlist-rule">Focus shortlist rule</h3>
+<p>Quadrant A is capped at <strong>20 issues</strong>. After the median
+split, eligible low-cost, high-benefit issues are ordered by benefit
+descending, cost ascending, then issue number. Any remaining eligible
+issues are placed in C as other low-cost work.</p>
 <h3 id="github-rank-labels-for-a-later-update-task">GitHub rank labels
 for a later update task</h3>
 <p>This scoring script writes the labels below into the JSON payload,

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.html
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.html
@@ -208,7 +208,7 @@
 <h1 id="ejam-open-issues-scored-by-cost-benefit">EJAM Open Issues —
 Scored by Cost &amp; Benefit</h1>
 <p><strong>Total open issues:</strong> 132 | <strong>Generated:</strong>
-2026-07-27 | <strong>Source:</strong> Live GitHub REST API open issues
+2026-08-02 | <strong>Source:</strong> Live GitHub REST API open issues
 (Public-Environmental-Data-Partners/EJAM)</p>
 <p><strong>Score payload:</strong>
 <code>inst/issues/ejam_issues_scored_by_risk_and_value.json</code></p>
@@ -225,11 +225,11 @@ Scored by Cost &amp; Benefit</h1>
 <tbody>
 <tr>
 <td>Previous run</td>
-<td>2026-07-26</td>
+<td>2026-07-27</td>
 </tr>
 <tr>
 <td>Issues opened since previous run</td>
-<td>1</td>
+<td>0</td>
 </tr>
 <tr>
 <td>Issues closed since previous run</td>
@@ -237,7 +237,7 @@ Scored by Cost &amp; Benefit</h1>
 </tr>
 <tr>
 <td>Issues whose quadrant changed</td>
-<td>19</td>
+<td>2</td>
 </tr>
 </tbody>
 </table>
@@ -284,6 +284,10 @@ changed a lot, etc.</li>
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504">#504</a>
 — Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate
 task during blockgroup join</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458">#458</a>
+— Share one report-header rule across in-app, download, and API paths
+(1-site vs multisite, FIPS place name)</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/152">#152</a>
 — build_community_report() needs unit tests, table_signif_round_x100()
@@ -349,9 +353,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/91">#91<
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161">#161</a>
 — ejamapp() should be able to handle mix of fips types</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">#136</a>
-— in web app, fix console error msg when uploading a shapefile</li>
 </ul>
 <table class="issue-details">
 <colgroup>
@@ -396,6 +397,17 @@ tas…</td>
 <td>v4</td>
 <td>PRIORITY MEDIUM</td>
 <td>BUG, Affects Web App</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458">458</a></td>
+<td>Share one report-header rule across in-app, download, and API paths
+(1…</td>
+<td>3 (🔵 Low)</td>
+<td>17 (🟩🟩 Very High)</td>
+<td>v4</td>
+<td>PRIORITY HIGH-ish but not a bug</td>
+<td>Affects Web App, Community Report</td>
 </tr>
 <tr>
 <td><a
@@ -584,16 +596,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161">161
 <td>NA</td>
 <td>PRIORITY MEDIUM</td>
 <td>Affects Web App, rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">136</a></td>
-<td>in web app, fix console error msg when uploading a shapefile</td>
-<td>1 (🟢 Very Low)</td>
-<td>7 (🟦 Medium)</td>
-<td>v4</td>
-<td>PRIORITY LOW</td>
-<td>BUG, rank:A-high-value-low-cost</td>
 </tr>
 </tbody>
 </table>
@@ -1330,6 +1332,9 @@ radius)</li>
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">#162</a>
 — rename “in_how_many_states” column in table of results</li>
 <li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">#136</a>
+— in web app, fix console error msg when uploading a shapefile</li>
+<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288">#288</a>
 — ratio of 1.0 should not be yellow on community report</li>
 <li><a
@@ -1394,10 +1399,6 @@ settings?</li>
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/175">#175</a>
 — drop the excel column called “Area of block group in geodatabase” and
 others</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458">#458</a>
-— in-app report header for a 1-site analysis should say Community Report
-not Multisite Summary</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/159">#159</a>
 — integrate file-naming function and header-creating functions</li>
@@ -1522,6 +1523,16 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">162
 <td>v4</td>
 <td>PRIORITY MEDIUM</td>
 <td>Affects Web App, rank:A-high-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">136</a></td>
+<td>in web app, fix console error msg when uploading a shapefile</td>
+<td>1 (🟢 Very Low)</td>
+<td>7 (🟦 Medium)</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>BUG, rank:A-high-value-low-cost</td>
 </tr>
 <tr>
 <td><a
@@ -1714,17 +1725,6 @@ and …</td>
 <td>NA</td>
 <td>PRIORITY LOW</td>
 <td>Affects Web App, rank:C-low-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458">458</a></td>
-<td>in-app report header for a 1-site analysis should say Community
-Report…</td>
-<td>1 (🟢 Very Low)</td>
-<td>4 (⬜ Low)</td>
-<td>v4</td>
-<td>PRIORITY LOW</td>
-<td>Affects Web App, Community Report</td>
 </tr>
 <tr>
 <td><a
@@ -2356,6 +2356,17 @@ task …</td>
 <tr>
 <td>A</td>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458">458</a></td>
+<td>3</td>
+<td>17</td>
+<td>v4</td>
+<td>PRIORITY HIGH-ish but not a bug</td>
+<td>Share one report-header rule across in-app, download, and API paths
+(1-s…</td>
+</tr>
+<tr>
+<td>A</td>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/152">152</a></td>
 <td>0</td>
 <td>15</td>
@@ -2536,16 +2547,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161">161
 <td>NA</td>
 <td>PRIORITY MEDIUM</td>
 <td>ejamapp() should be able to handle mix of fips types</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">136</a></td>
-<td>1</td>
-<td>7</td>
-<td>v4</td>
-<td>PRIORITY LOW</td>
-<td>in web app, fix console error msg when uploading a shapefile</td>
 </tr>
 <tr>
 <td>B</td>
@@ -3076,6 +3077,16 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">162
 <tr>
 <td>C</td>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">136</a></td>
+<td>1</td>
+<td>7</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>in web app, fix console error msg when uploading a shapefile</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288">288</a></td>
 <td>2</td>
 <td>7</td>
@@ -3263,17 +3274,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/175">175
 <td>PRIORITY LOW</td>
 <td>drop the excel column called “Area of block group in geodatabase”
 and ot…</td>
-</tr>
-<tr>
-<td>C</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458">458</a></td>
-<td>1</td>
-<td>4</td>
-<td>v4</td>
-<td>PRIORITY LOW</td>
-<td>in-app report header for a 1-site analysis should say Community
-Report n…</td>
 </tr>
 <tr>
 <td>C</td>

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.html
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.html
@@ -207,8 +207,8 @@
 <body>
 <h1 id="ejam-open-issues-scored-by-cost-benefit">EJAM Open Issues —
 Scored by Cost &amp; Benefit</h1>
-<p><strong>Total open issues:</strong> 130 | <strong>Generated:</strong>
-2026-07-25 | <strong>Source:</strong> Live GitHub REST API open issues
+<p><strong>Total open issues:</strong> 131 | <strong>Generated:</strong>
+2026-07-26 | <strong>Source:</strong> Live GitHub REST API open issues
 (Public-Environmental-Data-Partners/EJAM)</p>
 <p><strong>Score payload:</strong>
 <code>inst/issues/ejam_issues_scored_by_risk_and_value.json</code></p>
@@ -225,19 +225,19 @@ Scored by Cost &amp; Benefit</h1>
 <tbody>
 <tr>
 <td>Previous run</td>
-<td>2026-07-24</td>
+<td>2026-07-25</td>
 </tr>
 <tr>
 <td>Issues opened since previous run</td>
-<td>4</td>
+<td>2</td>
 </tr>
 <tr>
 <td>Issues closed since previous run</td>
-<td>11</td>
+<td>1</td>
 </tr>
 <tr>
 <td>Issues whose quadrant changed</td>
-<td>17</td>
+<td>0</td>
 </tr>
 </tbody>
 </table>
@@ -259,13 +259,13 @@ Scored by Cost &amp; Benefit</h1>
 <tbody>
 <tr>
 <td><strong>LOW Cost</strong><br>cost &lt; median</td>
-<td><strong>C — Might As Well</strong><br>21 issues</td>
-<td><strong>A — BEST CANDIDATES</strong><br>40 issues</td>
+<td><strong>C — Might As Well</strong><br>22 issues</td>
+<td><strong>A — BEST CANDIDATES</strong><br>39 issues</td>
 </tr>
 <tr>
 <td><strong>HIGH Cost</strong><br>cost ≥ median</td>
 <td><strong>D — WORST CANDIDATES</strong><br>23 issues</td>
-<td><strong>B — OK Candidates</strong><br>46 issues</td>
+<td><strong>B — OK Candidates</strong><br>47 issues</td>
 </tr>
 </tbody>
 </table>
@@ -274,8 +274,12 @@ Scored by Cost &amp; Benefit</h1>
 BEST CANDIDATES — Low Cost, High Benefit</h2>
 <p><em>Easy fixes with clear high value. Prioritize these above all
 others.</em></p>
-<p><strong>40 issues</strong></p>
+<p><strong>39 issues</strong></p>
 <ul>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16">#16</a>
+— need new/updated “User Guide” (“Help” in header at right) since UI has
+changed a lot, etc.</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504">#504</a>
 — Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate
@@ -297,10 +301,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341">#34
 — Align map_headernames and/or generated avg/pctile/ratio metadata with
 columns doaggregate() can produce for the report</li>
 <li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16">#16</a>
-— need new/updated “User Guide” (“Help” in header at right) since UI has
-changed a lot, etc.</li>
-<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400">#400</a>
 — improve how webapp users can find info on data vintage (in EJAM web
 app UI, from community report, and from EJScreen UI)</li>
@@ -320,10 +320,6 @@ right. seems to interpolate badly.</li>
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/268">#268</a>
 — Uploading a file was failing intermittently when live app hosted using
 AWS with load balancing</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/109">#109</a>
-— Update &amp; correct the article “Defaults and Custom Settings for the
-Web App”</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73">#73</a>
 — in web app, add ways to analyze multiple radii at once or even
@@ -447,6 +443,17 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/40">#40<
 <tbody>
 <tr>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16">16</a></td>
+<td>need new/updated “User Guide” (“Help” in header at right) since UI
+has…</td>
+<td>2 (🔵 Low)</td>
+<td>17 (🟩🟩 Very High)</td>
+<td>v4</td>
+<td>PRIORITY HIGH</td>
+<td>BUG, documentation, help wanted, good first issue</td>
+</tr>
+<tr>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/504">504</a></td>
 <td>Web app: 10,000-point analysis (3.1 mi) OOM-crashes on dev Fargate
 tas…</td>
@@ -500,17 +507,6 @@ with …</td>
 <td>NA</td>
 <td>PRIORITY HIGH-ish but not a bug</td>
 <td>Affects Web App, Community Report, rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16">16</a></td>
-<td>need new/updated “User Guide” (“Help” in header at right) since UI
-has…</td>
-<td>2 (🔵 Low)</td>
-<td>14 (🟩🟩 Very High)</td>
-<td>v4</td>
-<td>PRIORITY HIGH</td>
-<td>BUG, documentation, help wanted, good first issue</td>
 </tr>
 <tr>
 <td><a
@@ -568,18 +564,6 @@ using…</td>
 <td>NA</td>
 <td>—</td>
 <td>BUG, Affects Web App</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/109">109</a></td>
-<td>Update &amp; correct the article “Defaults and Custom Settings for
-the Web…</td>
-<td>1 (🟢 Very Low)</td>
-<td>10 (🟩🟦 High)</td>
-<td>v4</td>
-<td>PRIORITY LOW</td>
-<td>BUG, documentation, Affects R users only - NOT web app users,
-rank:A-high-value-low-cost</td>
 </tr>
 <tr>
 <td><a
@@ -884,7 +868,7 @@ changed</td>
 Candidates — High Cost, High Benefit</h2>
 <p><em>Worth doing but require more effort or expertise. Plan carefully
 before starting.</em></p>
-<p><strong>46 issues</strong></p>
+<p><strong>47 issues</strong></p>
 <ul>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/293">#293</a>
@@ -922,6 +906,10 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/68">#68<
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46">#46</a>
 — Long Report text needed</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/527">#527</a>
+— shapes_from_fips() errors offline even when the county boundary is
+built into the package</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126">#126</a>
 — enable 1-site report on Polygons / Shapefile, via links/buttons in
@@ -1192,6 +1180,17 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46">46</
 <td>PRIORITY HIGH-ish but not a bug</td>
 <td>LongReport_output, future plan list,
 rank:B-high-value-high-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/527">527</a></td>
+<td>shapes_from_fips() errors offline even when the county boundary is
+bui…</td>
+<td>4 (🟡 Medium)</td>
+<td>11 (🟩🟦 High)</td>
+<td>v4</td>
+<td>PRIORITY MEDIUM</td>
+<td>BUG, test, Affects R users only - NOT web app users</td>
 </tr>
 <tr>
 <td><a
@@ -1581,7 +1580,7 @@ list</td>
 Might As Well — Low Cost, Low Benefit</h2>
 <p><em>Cheap to do; low urgency. Pick these up when bandwidth allows or
 combine with nearby work.</em></p>
-<p><strong>21 issues</strong></p>
+<p><strong>22 issues</strong></p>
 <ul>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/177">#177</a>
@@ -1617,6 +1616,10 @@ report</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/464">#464</a>
 — Investigate and solve high cost on AWS Fargate</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/535">#535</a>
+— Consolidate app-settings vignette: EJScreen deep links +
+cross-vignette overlap</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/181">#181</a>
 — add other ejam2xyz functions to basics.Rmd as examples</li>
@@ -1777,6 +1780,17 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/464">464
 <td>NA</td>
 <td>—</td>
 <td>Affects Web App</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/535">535</a></td>
+<td>Consolidate app-settings vignette: EJScreen deep links +
+cross-vignett…</td>
+<td>1 (🟢 Very Low)</td>
+<td>2 (⬜ Low)</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>documentation, Affects R users only - NOT web app users</td>
 </tr>
 <tr>
 <td><a
@@ -2278,7 +2292,7 @@ code</td>
 </tbody>
 </table>
 <hr />
-<h2 id="full-table-all-130-issues">Full Table — All 130 Issues</h2>
+<h2 id="full-table-all-131-issues">Full Table — All 131 Issues</h2>
 <p>Sorted: A first (best), then B, C, D; within each group by benefit
 DESC.</p>
 <table>
@@ -2303,6 +2317,17 @@ DESC.</p>
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>A</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16">16</a></td>
+<td>2</td>
+<td>17</td>
+<td>v4</td>
+<td>PRIORITY HIGH</td>
+<td>need new/updated “User Guide” (“Help” in header at right) since UI
+has c…</td>
+</tr>
 <tr>
 <td>A</td>
 <td><a
@@ -2361,17 +2386,6 @@ with co…</td>
 <tr>
 <td>A</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/16">16</a></td>
-<td>2</td>
-<td>14</td>
-<td>v4</td>
-<td>PRIORITY HIGH</td>
-<td>need new/updated “User Guide” (“Help” in header at right) since UI
-has c…</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400">400</a></td>
 <td>3</td>
 <td>13</td>
@@ -2423,17 +2437,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/268">268
 <td>—</td>
 <td>Uploading a file was failing intermittently when live app hosted
 using A…</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/109">109</a></td>
-<td>1</td>
-<td>10</td>
-<td>v4</td>
-<td>PRIORITY LOW</td>
-<td>Update &amp; correct the article “Defaults and Custom Settings for
-the Web A…</td>
 </tr>
 <tr>
 <td>A</td>
@@ -2834,6 +2837,17 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46">46</
 <td>NA</td>
 <td>PRIORITY HIGH-ish but not a bug</td>
 <td>Long Report text needed</td>
+</tr>
+<tr>
+<td>B</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/527">527</a></td>
+<td>4</td>
+<td>11</td>
+<td>v4</td>
+<td>PRIORITY MEDIUM</td>
+<td>shapes_from_fips() errors offline even when the county boundary is
+built…</td>
 </tr>
 <tr>
 <td>B</td>
@@ -3303,6 +3317,17 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/464">464
 <tr>
 <td>C</td>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/535">535</a></td>
+<td>1</td>
+<td>2</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>Consolidate app-settings vignette: EJScreen deep links +
+cross-vignette …</td>
+</tr>
+<tr>
+<td>C</td>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/181">181</a></td>
 <td>1</td>
 <td>2</td>
@@ -3692,7 +3717,7 @@ code</td>
 </tr>
 <tr>
 <td>v4</td>
-<td style="text-align: right;">18</td>
+<td style="text-align: right;">19</td>
 </tr>
 <tr>
 <td>NA</td>

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.json
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.json
@@ -1,10 +1,10 @@
 {
   "metadata": {
-    "generated": "2026-07-24",
+    "generated": "2026-07-25",
     "source": "Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)",
     "repository": "Public-Environmental-Data-Partners/EJAM",
-    "open_issue_count": 137,
-    "cost_median": 3,
+    "open_issue_count": 130,
+    "cost_median": 4,
     "benefit_median": 5,
     "rank_labels": {
       "A": "rank:A-high-value-low-cost",
@@ -15,15 +15,116 @@
     "report_path": "inst/issues/ejam_issues_scored_by_risk_and_value.MD",
     "run_changes": {
       "previous_run": "2026-07-24",
-      "opened_count": 0,
-      "closed_count": 0,
-      "quadrant_changed_count": 0,
-      "opened_issue_numbers": [],
-      "closed_issue_numbers": [],
-      "quadrant_changed_issue_numbers": []
+      "opened_count": 4,
+      "closed_count": 11,
+      "quadrant_changed_count": 17,
+      "opened_issue_numbers": [
+        268,
+        510,
+        511,
+        513
+      ],
+      "closed_issue_numbers": [
+        69,
+        127,
+        144,
+        156,
+        205,
+        242,
+        348,
+        385,
+        410,
+        465,
+        467
+      ],
+      "quadrant_changed_issue_numbers": [
+        24,
+        39,
+        40,
+        41,
+        43,
+        60,
+        73,
+        159,
+        184,
+        224,
+        284,
+        341,
+        342,
+        400,
+        454,
+        484,
+        504
+      ]
     }
   },
   "issues": [
+    {
+      "number": 513,
+      "title": "need better ETA estimates (predicted seconds to completion are too high)",
+      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/513",
+      "existing_labels": [
+        "BUG",
+        "speed / performance (see #226)",
+        "PRIORITY HIGH",
+        "Affects Web App"
+      ],
+      "milestone": "v4",
+      "cost": 6,
+      "benefit": 17,
+      "quadrant": "B",
+      "rank_label": "rank:B-high-value-high-cost",
+      "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
+        "rank:C-low-value-low-cost",
+        "rank:D-defer"
+      ],
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+    },
+    {
+      "number": 511,
+      "title": "CI runs only on PRs into main: development and deploy PRs get no checks at all",
+      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/511",
+      "existing_labels": [
+        "enhancement",
+        "PRIORITY MEDIUM",
+        "test",
+        "Affects Web App"
+      ],
+      "milestone": "NA",
+      "cost": 4,
+      "benefit": 7,
+      "quadrant": "B",
+      "rank_label": "rank:B-high-value-high-cost",
+      "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
+        "rank:C-low-value-low-cost",
+        "rank:D-defer"
+      ],
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+    },
+    {
+      "number": 510,
+      "title": "Smoke-test PDF generation in the built image and after deploy (prod PDF broke undetected)",
+      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/510",
+      "existing_labels": [
+        "enhancement",
+        "PRIORITY MEDIUM",
+        "test",
+        "Affects Web App"
+      ],
+      "milestone": "NA",
+      "cost": 4,
+      "benefit": 7,
+      "quadrant": "B",
+      "rank_label": "rank:B-high-value-high-cost",
+      "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
+        "rank:C-low-value-low-cost",
+        "rank:D-defer"
+      ],
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+    },
     {
       "number": 508,
       "title": "ECR lifecycle policy: prune accumulating dev images (without touching prod)",
@@ -42,7 +143,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 507,
@@ -62,7 +163,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 504,
@@ -76,14 +177,14 @@
       "milestone": "v4",
       "cost": 3,
       "benefit": 17,
-      "quadrant": "B",
-      "rank_label": "rank:B-high-value-high-cost",
+      "quadrant": "A",
+      "rank_label": "rank:A-high-value-low-cost",
       "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 497,
@@ -105,7 +206,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 490,
@@ -127,7 +228,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 486,
@@ -148,7 +249,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 1\nBenefit score: 6\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 6\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 484,
@@ -162,14 +263,14 @@
       "milestone": "v4",
       "cost": 3,
       "benefit": 7,
-      "quadrant": "B",
-      "rank_label": "rank:B-high-value-high-cost",
+      "quadrant": "A",
+      "rank_label": "rank:A-high-value-low-cost",
       "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 482,
@@ -189,46 +290,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 1\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 467,
-      "title": "ejam2report() fails for zero-population or otherwise analysis-invalid sites",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/467",
-      "existing_labels": [
-        "BUG",
-        "PRIORITY HIGH",
-        "API",
-        "Community Report"
-      ],
-      "milestone": "v3.2022.2",
-      "cost": 4,
-      "benefit": 20,
-      "quadrant": "B",
-      "rank_label": "rank:B-high-value-high-cost",
-      "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
-        "rank:C-low-value-low-cost",
-        "rank:D-defer"
-      ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 20\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 465,
-      "title": "EJAM app crashes on EJScreen token handoff (Send to EJAM) for FIPS/polygon/bufferless selections",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/465",
-      "existing_labels": [],
-      "milestone": "NA",
-      "cost": 4,
-      "benefit": 4,
-      "quadrant": "D",
-      "rank_label": "rank:D-defer",
-      "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost"
-      ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 1\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 464,
@@ -247,7 +309,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 458,
@@ -269,7 +331,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 1\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 455,
@@ -289,7 +351,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 1\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 454,
@@ -302,14 +364,14 @@
       "milestone": "v4",
       "cost": 3,
       "benefit": 5,
-      "quadrant": "B",
-      "rank_label": "rank:B-high-value-high-cost",
+      "quadrant": "A",
+      "rank_label": "rank:A-high-value-low-cost",
       "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 446,
@@ -329,30 +391,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 7\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 410,
-      "title": "\"FEATURES AND LOCATION INFORMATION\" on report need explanation and less rounding",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/410",
-      "existing_labels": [
-        "BUG",
-        "PRIORITY MEDIUM",
-        "Affects Web App",
-        "Community Report",
-        "rank:A-high-value-low-cost"
-      ],
-      "milestone": "v3.2022.2",
-      "cost": 1,
-      "benefit": 11,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
-      "rank_labels_to_remove": [
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
-        "rank:D-defer"
-      ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 1\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 7\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 403,
@@ -375,7 +414,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 1\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 400,
@@ -390,14 +429,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 13,
-      "quadrant": "B",
-      "rank_label": "rank:B-high-value-high-cost",
+      "quadrant": "A",
+      "rank_label": "rank:A-high-value-low-cost",
       "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 399,
@@ -421,7 +460,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 11\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 11\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 387,
@@ -443,7 +482,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 8\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 386,
@@ -462,30 +501,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 8\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 385,
-      "title": "ejam2report() fails to save a file when the filename parameter is used",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/385",
-      "existing_labels": [
-        "BUG",
-        "PRIORITY MEDIUM",
-        "Affects R users only - NOT web app users",
-        "Community Report",
-        "rank:A-high-value-low-cost"
-      ],
-      "milestone": "v4",
-      "cost": 1,
-      "benefit": 15,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
-      "rank_labels_to_remove": [
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
-        "rank:D-defer"
-      ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 1\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 361,
@@ -507,7 +523,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 354,
@@ -530,7 +546,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 350,
@@ -553,7 +569,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 349,
@@ -579,32 +595,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 348,
-      "title": "API report links from multisite results label every per-site report as site 1",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/348",
-      "existing_labels": [
-        "BUG",
-        "PRIORITY MEDIUM",
-        "URL-related",
-        "Affects Web App",
-        "API",
-        "Community Report",
-        "rank:A-high-value-low-cost"
-      ],
-      "milestone": "v3.2022.2",
-      "cost": 2,
-      "benefit": 15,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
-      "rank_labels_to_remove": [
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
-        "rank:D-defer"
-      ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 344,
@@ -618,7 +609,7 @@
         "PRIORITY HIGH-ish but not a bug",
         "rank:A-high-value-low-cost"
       ],
-      "milestone": "NA",
+      "milestone": "v4",
       "cost": 2,
       "benefit": 12,
       "quadrant": "A",
@@ -628,7 +619,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 343,
@@ -647,7 +638,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 342,
@@ -663,14 +654,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 15,
-      "quadrant": "B",
-      "rank_label": "rank:B-high-value-high-cost",
+      "quadrant": "A",
+      "rank_label": "rank:A-high-value-low-cost",
       "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 341,
@@ -686,14 +677,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 15,
-      "quadrant": "B",
-      "rank_label": "rank:B-high-value-high-cost",
+      "quadrant": "A",
+      "rank_label": "rank:A-high-value-low-cost",
       "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 293,
@@ -717,7 +708,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 5\nBenefit score: 19\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 5\nBenefit score: 19\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 288,
@@ -730,7 +721,7 @@
         "Community Report",
         "rank:A-high-value-low-cost"
       ],
-      "milestone": "NA",
+      "milestone": "v3.2022.2",
       "cost": 2,
       "benefit": 7,
       "quadrant": "A",
@@ -740,7 +731,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 284,
@@ -755,14 +746,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 6,
-      "quadrant": "B",
-      "rank_label": "rank:B-high-value-high-cost",
+      "quadrant": "A",
+      "rank_label": "rank:A-high-value-low-cost",
       "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 6\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 279,
@@ -785,7 +776,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 5\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 5\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 274,
@@ -808,7 +799,27 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+    },
+    {
+      "number": 268,
+      "title": "Uploading a file was failing intermittently when live app hosted using AWS with load balancing",
+      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/268",
+      "existing_labels": [
+        "BUG",
+        "Affects Web App"
+      ],
+      "milestone": "NA",
+      "cost": 2,
+      "benefit": 11,
+      "quadrant": "A",
+      "rank_label": "rank:A-high-value-low-cost",
+      "rank_labels_to_remove": [
+        "rank:B-high-value-high-cost",
+        "rank:C-low-value-low-cost",
+        "rank:D-defer"
+      ],
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 256,
@@ -832,7 +843,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 249,
@@ -854,29 +865,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 242,
-      "title": "Report should show ratios to avg for special indicators like % of residents who are in CEJST disadvantaged or air nonattainment areas",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/242",
-      "existing_labels": [
-        "enhancement",
-        "PRIORITY MEDIUM",
-        "Community Report",
-        "rank:C-low-value-low-cost"
-      ],
-      "milestone": "NA",
-      "cost": 3,
-      "benefit": 4,
-      "quadrant": "D",
-      "rank_label": "rank:D-defer",
-      "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost"
-      ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 231,
@@ -898,7 +887,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 226,
@@ -922,7 +911,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 7\nBenefit score: 16\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 7\nBenefit score: 16\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 224,
@@ -936,14 +925,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 5,
-      "quadrant": "B",
-      "rank_label": "rank:B-high-value-high-cost",
+      "quadrant": "A",
+      "rank_label": "rank:A-high-value-low-cost",
       "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 223,
@@ -965,7 +954,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 208,
@@ -987,31 +976,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 205,
-      "title": "adjust summary report fonts and row heights/line spacing to make text more legible",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/205",
-      "existing_labels": [
-        "enhancement",
-        "help wanted",
-        "PRIORITY HIGH-ish but not a bug",
-        "Affects Web App",
-        "Community Report",
-        "rank:A-high-value-low-cost"
-      ],
-      "milestone": "NA",
-      "cost": 2,
-      "benefit": 15,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
-      "rank_labels_to_remove": [
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
-        "rank:D-defer"
-      ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 194,
@@ -1034,7 +999,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 5\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 5\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 193,
@@ -1058,7 +1023,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 5\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 5\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 192,
@@ -1081,7 +1046,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 184,
@@ -1098,14 +1063,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 2,
-      "quadrant": "D",
-      "rank_label": "rank:D-defer",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
         "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost"
+        "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 183,
@@ -1129,7 +1094,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 0\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 182,
@@ -1152,7 +1117,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 181,
@@ -1176,7 +1141,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 180,
@@ -1199,7 +1164,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 7\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 7\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 179,
@@ -1222,7 +1187,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 177,
@@ -1244,7 +1209,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 176,
@@ -1267,7 +1232,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 175,
@@ -1289,7 +1254,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 174,
@@ -1312,7 +1277,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 172,
@@ -1335,7 +1300,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 170,
@@ -1358,7 +1323,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 169,
@@ -1381,7 +1346,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 168,
@@ -1405,7 +1370,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 8\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 167,
@@ -1429,7 +1394,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 166,
@@ -1452,7 +1417,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 163,
@@ -1474,7 +1439,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 162,
@@ -1486,7 +1451,7 @@
         "Affects Web App",
         "rank:A-high-value-low-cost"
       ],
-      "milestone": "NA",
+      "milestone": "v4",
       "cost": 1,
       "benefit": 7,
       "quadrant": "A",
@@ -1496,7 +1461,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 161,
@@ -1518,7 +1483,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 0\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 159,
@@ -1535,37 +1500,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 4,
-      "quadrant": "D",
-      "rank_label": "rank:D-defer",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
         "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost"
-      ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 156,
-      "title": "in app - add view of   ejam2areafeatures(out)  (info on % of pop with certain things nearby)",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/156",
-      "existing_labels": [
-        "enhancement",
-        "test",
-        "PRIORITY HIGH-ish but not a bug",
-        "Affects Web App",
-        "rank:A-high-value-low-cost"
-      ],
-      "milestone": "NA",
-      "cost": 0,
-      "benefit": 17,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
-      "rank_labels_to_remove": [
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 0\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 153,
@@ -1588,7 +1530,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 152,
@@ -1612,30 +1554,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 0\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 144,
-      "title": "use or remove or explain the sitenumber parameter in ejam2map() for fips case",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/144",
-      "existing_labels": [
-        "BUG",
-        "PRIORITY MEDIUM",
-        "Affects Web App",
-        "API",
-        "rank:A-high-value-low-cost"
-      ],
-      "milestone": "v3.2022.2",
-      "cost": 0,
-      "benefit": 13,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
-      "rank_labels_to_remove": [
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
-        "rank:D-defer"
-      ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 0\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 137,
@@ -1657,7 +1576,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 1\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 136,
@@ -1668,7 +1587,7 @@
         "PRIORITY LOW",
         "rank:A-high-value-low-cost"
       ],
-      "milestone": "NA",
+      "milestone": "v4",
       "cost": 1,
       "benefit": 7,
       "quadrant": "A",
@@ -1678,7 +1597,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 135,
@@ -1700,29 +1619,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 127,
-      "title": "web app details tab with table of all sites is too sluggish as it appears after clicking to view that tab",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/127",
-      "existing_labels": [
-        "BUG",
-        "PRIORITY MEDIUM",
-        "Affects Web App",
-        "rank:A-high-value-low-cost"
-      ],
-      "milestone": "v3.2022.2",
-      "cost": 0,
-      "benefit": 13,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
-      "rank_labels_to_remove": [
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
-        "rank:D-defer"
-      ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 0\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 126,
@@ -1745,7 +1642,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 119,
@@ -1767,7 +1664,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 109,
@@ -1780,7 +1677,7 @@
         "Affects R users only - NOT web app users",
         "rank:A-high-value-low-cost"
       ],
-      "milestone": "NA",
+      "milestone": "v4",
       "cost": 1,
       "benefit": 10,
       "quadrant": "A",
@@ -1790,7 +1687,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 1\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 102,
@@ -1814,7 +1711,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 0\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 96,
@@ -1838,7 +1735,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 95,
@@ -1864,7 +1761,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 8\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 93,
@@ -1888,7 +1785,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 92,
@@ -1912,7 +1809,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 91,
@@ -1936,7 +1833,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 89,
@@ -1960,7 +1857,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 87,
@@ -1985,7 +1882,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 6\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 86,
@@ -2009,7 +1906,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 85,
@@ -2036,7 +1933,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 12\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 12\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 84,
@@ -2061,7 +1958,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 83,
@@ -2086,7 +1983,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 82,
@@ -2110,7 +2007,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 81,
@@ -2134,7 +2031,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 80,
@@ -2159,7 +2056,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 77,
@@ -2184,7 +2081,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 75,
@@ -2210,7 +2107,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 74,
@@ -2233,7 +2130,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 73,
@@ -2250,14 +2147,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 10,
-      "quadrant": "B",
-      "rank_label": "rank:B-high-value-high-cost",
+      "quadrant": "A",
+      "rank_label": "rank:A-high-value-low-cost",
       "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 72,
@@ -2282,7 +2179,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 70,
@@ -2305,30 +2202,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 69,
-      "title": "enable other units like kilometers for entry of radius",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/69",
-      "existing_labels": [
-        "enhancement",
-        "PRIORITY MEDIUM",
-        "retain-0325",
-        "from archive",
-        "rank:C-low-value-low-cost"
-      ],
-      "milestone": "NA",
-      "cost": 2,
-      "benefit": 5,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
-      "rank_labels_to_remove": [
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
-        "rank:D-defer"
-      ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 68,
@@ -2351,7 +2225,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 66,
@@ -2376,7 +2250,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 10\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 10\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 63,
@@ -2400,7 +2274,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 62,
@@ -2424,7 +2298,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 61,
@@ -2447,7 +2321,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 60,
@@ -2467,14 +2341,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 0,
-      "quadrant": "D",
-      "rank_label": "rank:D-defer",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
         "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost"
+        "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 59,
@@ -2497,7 +2371,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 58,
@@ -2520,7 +2394,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 57,
@@ -2545,7 +2419,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 56,
@@ -2572,7 +2446,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 6\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 55,
@@ -2595,7 +2469,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 54,
@@ -2620,7 +2494,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 9\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 9\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 53,
@@ -2645,7 +2519,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 6\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 52,
@@ -2670,7 +2544,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 8\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 50,
@@ -2697,7 +2571,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 46,
@@ -2722,7 +2596,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 8\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 44,
@@ -2748,7 +2622,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 18\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 18\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 43,
@@ -2765,14 +2639,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 2,
-      "quadrant": "D",
-      "rank_label": "rank:D-defer",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
         "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost"
+        "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 42,
@@ -2796,7 +2670,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 41,
@@ -2813,14 +2687,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 2,
-      "quadrant": "D",
-      "rank_label": "rank:D-defer",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
         "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost"
+        "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 40,
@@ -2836,14 +2710,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 5,
-      "quadrant": "B",
-      "rank_label": "rank:B-high-value-high-cost",
+      "quadrant": "A",
+      "rank_label": "rank:A-high-value-low-cost",
       "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 39,
@@ -2860,14 +2734,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 2,
-      "quadrant": "D",
-      "rank_label": "rank:D-defer",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
         "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost"
+        "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 37,
@@ -2892,7 +2766,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 35,
@@ -2917,7 +2791,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 34,
@@ -2942,7 +2816,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 6\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 33,
@@ -2967,7 +2841,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 5\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 5\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 32,
@@ -2993,7 +2867,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 11\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 11\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 31,
@@ -3017,7 +2891,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 29,
@@ -3041,7 +2915,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 8\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 27,
@@ -3068,7 +2942,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 7\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 7\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 26,
@@ -3092,7 +2966,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 25,
@@ -3116,7 +2990,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 12\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 12\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 24,
@@ -3133,14 +3007,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 4,
-      "quadrant": "D",
-      "rank_label": "rank:D-defer",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
         "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost"
+        "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 3\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 19,
@@ -3164,7 +3038,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 6\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 18,
@@ -3185,7 +3059,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 7\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 7\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 16,
@@ -3209,7 +3083,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-24\nCost score: 2\nBenefit score: 14\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 14\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     }
   ]
 }

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.json
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generated": "2026-07-27",
+    "generated": "2026-08-02",
     "source": "Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)",
     "repository": "Public-Environmental-Data-Partners/EJAM",
     "open_issue_count": 132,
@@ -14,34 +14,15 @@
     },
     "report_path": "inst/issues/ejam_issues_scored_by_risk_and_value.MD",
     "run_changes": {
-      "previous_run": "2026-07-26",
-      "opened_count": 1,
+      "previous_run": "2026-07-27",
+      "opened_count": 0,
       "closed_count": 0,
-      "quadrant_changed_count": 19,
-      "opened_issue_numbers": [
-        536
-      ],
+      "quadrant_changed_count": 2,
+      "opened_issue_numbers": [],
       "closed_issue_numbers": [],
       "quadrant_changed_issue_numbers": [
-        40,
-        58,
-        70,
-        92,
-        96,
-        102,
-        162,
-        163,
-        224,
-        284,
-        288,
-        350,
-        361,
-        403,
-        454,
-        455,
-        484,
-        486,
-        490
+        136,
+        458
       ]
     }
   },
@@ -66,7 +47,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 535,
@@ -88,7 +69,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 527,
@@ -110,7 +91,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 513,
@@ -132,7 +113,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 511,
@@ -154,7 +135,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 510,
@@ -176,7 +157,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 508,
@@ -196,7 +177,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 507,
@@ -216,7 +197,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 504,
@@ -237,7 +218,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 497,
@@ -259,7 +240,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 490,
@@ -281,7 +262,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 486,
@@ -302,7 +283,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 6\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 6\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 484,
@@ -323,7 +304,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 482,
@@ -343,7 +324,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 1\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 1\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 464,
@@ -362,29 +343,29 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 458,
-      "title": "in-app report header for a 1-site analysis should say Community Report not Multisite Summary",
+      "title": "Share one report-header rule across in-app, download, and API paths (1-site vs multisite, FIPS place name)",
       "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/458",
       "existing_labels": [
         "enhancement",
-        "PRIORITY LOW",
+        "PRIORITY HIGH-ish but not a bug",
         "Affects Web App",
         "Community Report"
       ],
       "milestone": "v4",
-      "cost": 1,
-      "benefit": 4,
-      "quadrant": "C",
-      "rank_label": "rank:C-low-value-low-cost",
+      "cost": 3,
+      "benefit": 17,
+      "quadrant": "A",
+      "rank_label": "rank:A-high-value-low-cost",
       "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
+        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 455,
@@ -404,7 +385,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 454,
@@ -424,7 +405,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 446,
@@ -444,7 +425,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 7\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 7\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 403,
@@ -467,7 +448,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 400,
@@ -489,7 +470,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 399,
@@ -513,7 +494,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 11\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 11\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 387,
@@ -535,7 +516,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 386,
@@ -554,7 +535,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 361,
@@ -576,7 +557,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 354,
@@ -599,7 +580,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 350,
@@ -622,7 +603,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 349,
@@ -648,7 +629,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 344,
@@ -672,7 +653,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 343,
@@ -691,7 +672,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 342,
@@ -714,7 +695,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 341,
@@ -737,7 +718,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 293,
@@ -761,7 +742,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 5\nBenefit score: 19\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 5\nBenefit score: 19\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 288,
@@ -784,7 +765,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 284,
@@ -806,7 +787,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 6\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 6\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 279,
@@ -829,7 +810,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 5\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 5\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 274,
@@ -852,7 +833,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 268,
@@ -872,7 +853,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 256,
@@ -896,7 +877,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 249,
@@ -918,7 +899,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 231,
@@ -940,7 +921,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 226,
@@ -964,7 +945,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 7\nBenefit score: 16\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 7\nBenefit score: 16\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 224,
@@ -985,7 +966,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 223,
@@ -1007,7 +988,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 208,
@@ -1029,7 +1010,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 194,
@@ -1052,7 +1033,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 5\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 5\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 193,
@@ -1076,7 +1057,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 5\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 5\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 192,
@@ -1099,7 +1080,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 184,
@@ -1123,7 +1104,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 183,
@@ -1147,7 +1128,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 182,
@@ -1170,7 +1151,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 181,
@@ -1194,7 +1175,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 180,
@@ -1217,7 +1198,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 7\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 7\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 179,
@@ -1240,7 +1221,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 177,
@@ -1262,7 +1243,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 176,
@@ -1285,7 +1266,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 175,
@@ -1307,7 +1288,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 174,
@@ -1330,7 +1311,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 172,
@@ -1353,7 +1334,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 170,
@@ -1376,7 +1357,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 169,
@@ -1399,7 +1380,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 168,
@@ -1423,7 +1404,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 167,
@@ -1447,7 +1428,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 166,
@@ -1470,7 +1451,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 163,
@@ -1492,7 +1473,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 162,
@@ -1514,7 +1495,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 161,
@@ -1536,7 +1517,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 159,
@@ -1560,7 +1541,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 153,
@@ -1583,7 +1564,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 152,
@@ -1607,7 +1588,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 137,
@@ -1629,7 +1610,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 136,
@@ -1643,14 +1624,14 @@
       "milestone": "v4",
       "cost": 1,
       "benefit": 7,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 135,
@@ -1672,7 +1653,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 126,
@@ -1695,7 +1676,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 119,
@@ -1717,7 +1698,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 102,
@@ -1741,7 +1722,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 96,
@@ -1765,7 +1746,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 95,
@@ -1791,7 +1772,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 93,
@@ -1815,7 +1796,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 92,
@@ -1839,7 +1820,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 91,
@@ -1863,7 +1844,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 89,
@@ -1887,7 +1868,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 87,
@@ -1912,7 +1893,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 86,
@@ -1936,7 +1917,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 85,
@@ -1963,7 +1944,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 12\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 12\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 84,
@@ -1988,7 +1969,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 83,
@@ -2013,7 +1994,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 82,
@@ -2037,7 +2018,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 81,
@@ -2061,7 +2042,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 80,
@@ -2086,7 +2067,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 77,
@@ -2111,7 +2092,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 75,
@@ -2137,7 +2118,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 74,
@@ -2160,7 +2141,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 73,
@@ -2184,7 +2165,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 72,
@@ -2209,7 +2190,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 70,
@@ -2232,7 +2213,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 68,
@@ -2255,7 +2236,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 66,
@@ -2280,7 +2261,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 10\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 10\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 63,
@@ -2304,7 +2285,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 62,
@@ -2328,7 +2309,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 61,
@@ -2351,7 +2332,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 60,
@@ -2378,7 +2359,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 59,
@@ -2401,7 +2382,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 58,
@@ -2424,7 +2405,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 57,
@@ -2449,7 +2430,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 56,
@@ -2476,7 +2457,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 55,
@@ -2499,7 +2480,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 54,
@@ -2524,7 +2505,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 9\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 9\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 53,
@@ -2549,7 +2530,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 52,
@@ -2574,7 +2555,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 50,
@@ -2601,7 +2582,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 46,
@@ -2626,7 +2607,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 44,
@@ -2652,7 +2633,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 18\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 18\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 43,
@@ -2676,7 +2657,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 42,
@@ -2700,7 +2681,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 41,
@@ -2724,7 +2705,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 40,
@@ -2747,7 +2728,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 39,
@@ -2771,7 +2752,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 37,
@@ -2796,7 +2777,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 35,
@@ -2821,7 +2802,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 34,
@@ -2846,7 +2827,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 33,
@@ -2871,7 +2852,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 5\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 5\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 32,
@@ -2897,7 +2878,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 11\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 11\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 31,
@@ -2921,7 +2902,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 29,
@@ -2945,7 +2926,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 27,
@@ -2972,7 +2953,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 7\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 7\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 26,
@@ -2996,7 +2977,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 25,
@@ -3020,7 +3001,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 12\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 12\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 24,
@@ -3044,7 +3025,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 19,
@@ -3068,7 +3049,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 18,
@@ -3089,7 +3070,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 7\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 7\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 16,
@@ -3114,7 +3095,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     }
   ]
 }

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.json
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.json
@@ -1,9 +1,9 @@
 {
   "metadata": {
-    "generated": "2026-07-26",
+    "generated": "2026-07-27",
     "source": "Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)",
     "repository": "Public-Environmental-Data-Partners/EJAM",
-    "open_issue_count": 131,
+    "open_issue_count": 132,
     "cost_median": 4,
     "benefit_median": 5,
     "rank_labels": {
@@ -14,21 +14,60 @@
     },
     "report_path": "inst/issues/ejam_issues_scored_by_risk_and_value.MD",
     "run_changes": {
-      "previous_run": "2026-07-25",
-      "opened_count": 2,
-      "closed_count": 1,
-      "quadrant_changed_count": 0,
+      "previous_run": "2026-07-26",
+      "opened_count": 1,
+      "closed_count": 0,
+      "quadrant_changed_count": 19,
       "opened_issue_numbers": [
-        527,
-        535
+        536
       ],
-      "closed_issue_numbers": [
-        109
-      ],
-      "quadrant_changed_issue_numbers": []
+      "closed_issue_numbers": [],
+      "quadrant_changed_issue_numbers": [
+        40,
+        58,
+        70,
+        92,
+        96,
+        102,
+        162,
+        163,
+        224,
+        284,
+        288,
+        350,
+        361,
+        403,
+        454,
+        455,
+        484,
+        486,
+        490
+      ]
     }
   },
   "issues": [
+    {
+      "number": 536,
+      "title": "redo list of URLs in url_package() documentation",
+      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/536",
+      "existing_labels": [
+        "documentation",
+        "PRIORITY LOW",
+        "refactor",
+        "Affects R users only - NOT web app users"
+      ],
+      "milestone": "NA",
+      "cost": 4,
+      "benefit": 2,
+      "quadrant": "D",
+      "rank_label": "rank:D-defer",
+      "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
+        "rank:C-low-value-low-cost"
+      ],
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+    },
     {
       "number": 535,
       "title": "Consolidate app-settings vignette: EJScreen deep links + cross-vignette overlap",
@@ -49,7 +88,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 527,
@@ -71,7 +110,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 513,
@@ -93,7 +132,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 511,
@@ -115,7 +154,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 510,
@@ -137,7 +176,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 508,
@@ -157,7 +196,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 507,
@@ -177,7 +216,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 504,
@@ -198,7 +237,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 497,
@@ -220,7 +259,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 490,
@@ -235,14 +274,14 @@
       "milestone": "v4",
       "cost": 1,
       "benefit": 7,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 486,
@@ -256,14 +295,14 @@
       "milestone": "v4",
       "cost": 1,
       "benefit": 6,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 6\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 6\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 484,
@@ -277,14 +316,14 @@
       "milestone": "v4",
       "cost": 3,
       "benefit": 7,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 482,
@@ -304,7 +343,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 1\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 1\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 464,
@@ -323,7 +362,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 458,
@@ -345,7 +384,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 455,
@@ -358,14 +397,14 @@
       "milestone": "v4",
       "cost": 1,
       "benefit": 5,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 454,
@@ -378,14 +417,14 @@
       "milestone": "v4",
       "cost": 3,
       "benefit": 5,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 446,
@@ -405,7 +444,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 7\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 7\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 403,
@@ -421,14 +460,14 @@
       "milestone": "NA",
       "cost": 1,
       "benefit": 5,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 400,
@@ -450,7 +489,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 399,
@@ -474,7 +513,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 11\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 11\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 387,
@@ -496,7 +535,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 386,
@@ -515,7 +554,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 361,
@@ -530,14 +569,14 @@
       "milestone": "NA",
       "cost": 1,
       "benefit": 7,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 354,
@@ -560,7 +599,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 350,
@@ -576,14 +615,14 @@
       "milestone": "NA",
       "cost": 2,
       "benefit": 5,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 349,
@@ -609,7 +648,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 344,
@@ -633,7 +672,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 343,
@@ -652,7 +691,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 342,
@@ -675,7 +714,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 341,
@@ -698,7 +737,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 293,
@@ -722,7 +761,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 5\nBenefit score: 19\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 5\nBenefit score: 19\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 288,
@@ -738,14 +777,14 @@
       "milestone": "v3.2022.2",
       "cost": 2,
       "benefit": 7,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 284,
@@ -760,14 +799,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 6,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 6\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 6\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 279,
@@ -790,7 +829,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 5\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 5\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 274,
@@ -813,7 +852,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 268,
@@ -833,7 +872,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 256,
@@ -857,7 +896,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 249,
@@ -879,7 +918,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 231,
@@ -901,7 +940,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 226,
@@ -925,7 +964,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 7\nBenefit score: 16\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 7\nBenefit score: 16\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 224,
@@ -939,14 +978,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 5,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 223,
@@ -968,7 +1007,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 208,
@@ -990,7 +1029,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 194,
@@ -1013,7 +1052,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 5\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 5\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 193,
@@ -1037,7 +1076,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 5\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 5\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 192,
@@ -1060,7 +1099,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 184,
@@ -1084,7 +1123,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 183,
@@ -1108,7 +1147,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 182,
@@ -1131,7 +1170,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 181,
@@ -1155,7 +1194,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 180,
@@ -1178,7 +1217,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 7\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 7\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 179,
@@ -1201,7 +1240,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 177,
@@ -1223,7 +1262,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 176,
@@ -1246,7 +1285,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 175,
@@ -1268,7 +1307,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 174,
@@ -1291,7 +1330,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 172,
@@ -1314,7 +1353,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 170,
@@ -1337,7 +1376,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 169,
@@ -1360,7 +1399,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 168,
@@ -1384,7 +1423,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 167,
@@ -1408,7 +1447,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 166,
@@ -1431,7 +1470,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 163,
@@ -1446,14 +1485,14 @@
       "milestone": "NA",
       "cost": 1,
       "benefit": 7,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 162,
@@ -1468,14 +1507,14 @@
       "milestone": "v4",
       "cost": 1,
       "benefit": 7,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 161,
@@ -1497,7 +1536,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 159,
@@ -1521,7 +1560,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 153,
@@ -1544,7 +1583,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 152,
@@ -1568,7 +1607,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 137,
@@ -1590,7 +1629,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 136,
@@ -1611,7 +1650,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 135,
@@ -1633,7 +1672,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 126,
@@ -1656,7 +1695,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 119,
@@ -1678,7 +1717,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 102,
@@ -1695,14 +1734,14 @@
       "milestone": "NA",
       "cost": 0,
       "benefit": 5,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 0\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 96,
@@ -1719,14 +1758,14 @@
       "milestone": "NA",
       "cost": 2,
       "benefit": 5,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 95,
@@ -1752,7 +1791,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 93,
@@ -1776,7 +1815,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 92,
@@ -1793,14 +1832,14 @@
       "milestone": "NA",
       "cost": 2,
       "benefit": 5,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 91,
@@ -1824,7 +1863,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 89,
@@ -1848,7 +1887,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 87,
@@ -1873,7 +1912,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 86,
@@ -1897,7 +1936,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 85,
@@ -1924,7 +1963,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 12\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 12\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 84,
@@ -1949,7 +1988,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 83,
@@ -1974,7 +2013,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 82,
@@ -1998,7 +2037,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 81,
@@ -2022,7 +2061,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 80,
@@ -2047,7 +2086,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 77,
@@ -2072,7 +2111,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 75,
@@ -2098,7 +2137,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 74,
@@ -2121,7 +2160,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 73,
@@ -2145,7 +2184,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 72,
@@ -2170,7 +2209,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 70,
@@ -2186,14 +2225,14 @@
       "milestone": "NA",
       "cost": 2,
       "benefit": 7,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 68,
@@ -2216,7 +2255,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 66,
@@ -2241,7 +2280,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 10\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 10\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 63,
@@ -2265,7 +2304,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 62,
@@ -2289,7 +2328,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 61,
@@ -2312,7 +2351,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 60,
@@ -2339,7 +2378,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 59,
@@ -2362,7 +2401,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 58,
@@ -2378,14 +2417,14 @@
       "milestone": "NA",
       "cost": 2,
       "benefit": 5,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 57,
@@ -2410,7 +2449,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 56,
@@ -2437,7 +2476,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 55,
@@ -2460,7 +2499,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 54,
@@ -2485,7 +2524,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 9\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 9\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 53,
@@ -2510,7 +2549,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 52,
@@ -2535,7 +2574,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 50,
@@ -2562,7 +2601,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 46,
@@ -2587,7 +2626,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 44,
@@ -2613,7 +2652,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 18\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 18\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 43,
@@ -2637,7 +2676,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 42,
@@ -2661,7 +2700,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 41,
@@ -2685,7 +2724,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 40,
@@ -2701,14 +2740,14 @@
       "milestone": "NA",
       "cost": 3,
       "benefit": 5,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
       "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 39,
@@ -2732,7 +2771,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 37,
@@ -2757,7 +2796,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 35,
@@ -2782,7 +2821,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 34,
@@ -2807,7 +2846,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 33,
@@ -2832,7 +2871,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 5\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 5\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 32,
@@ -2858,7 +2897,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 11\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 11\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 31,
@@ -2882,7 +2921,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 29,
@@ -2906,7 +2945,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 8\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 27,
@@ -2933,7 +2972,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 7\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 7\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 26,
@@ -2957,7 +2996,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 25,
@@ -2981,7 +3020,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 12\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 12\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 24,
@@ -3005,7 +3044,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 19,
@@ -3029,7 +3068,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 6\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 18,
@@ -3050,7 +3089,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 7\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 7\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 16,
@@ -3075,7 +3114,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-27\nCost score: 2\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     }
   ]
 }

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.json
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.json
@@ -1,9 +1,9 @@
 {
   "metadata": {
-    "generated": "2026-07-25",
+    "generated": "2026-07-26",
     "source": "Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)",
     "repository": "Public-Environmental-Data-Partners/EJAM",
-    "open_issue_count": 130,
+    "open_issue_count": 131,
     "cost_median": 4,
     "benefit_median": 5,
     "rank_labels": {
@@ -14,51 +14,65 @@
     },
     "report_path": "inst/issues/ejam_issues_scored_by_risk_and_value.MD",
     "run_changes": {
-      "previous_run": "2026-07-24",
-      "opened_count": 4,
-      "closed_count": 11,
-      "quadrant_changed_count": 17,
+      "previous_run": "2026-07-25",
+      "opened_count": 2,
+      "closed_count": 1,
+      "quadrant_changed_count": 0,
       "opened_issue_numbers": [
-        268,
-        510,
-        511,
-        513
+        527,
+        535
       ],
       "closed_issue_numbers": [
-        69,
-        127,
-        144,
-        156,
-        205,
-        242,
-        348,
-        385,
-        410,
-        465,
-        467
+        109
       ],
-      "quadrant_changed_issue_numbers": [
-        24,
-        39,
-        40,
-        41,
-        43,
-        60,
-        73,
-        159,
-        184,
-        224,
-        284,
-        341,
-        342,
-        400,
-        454,
-        484,
-        504
-      ]
+      "quadrant_changed_issue_numbers": []
     }
   },
   "issues": [
+    {
+      "number": 535,
+      "title": "Consolidate app-settings vignette: EJScreen deep links + cross-vignette overlap",
+      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/535",
+      "existing_labels": [
+        "documentation",
+        "enhancement",
+        "PRIORITY LOW",
+        "Affects R users only - NOT web app users"
+      ],
+      "milestone": "v4",
+      "cost": 1,
+      "benefit": 2,
+      "quadrant": "C",
+      "rank_label": "rank:C-low-value-low-cost",
+      "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
+        "rank:D-defer"
+      ],
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+    },
+    {
+      "number": 527,
+      "title": "shapes_from_fips() errors offline even when the county boundary is built into the package",
+      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/527",
+      "existing_labels": [
+        "BUG",
+        "PRIORITY MEDIUM",
+        "test",
+        "Affects R users only - NOT web app users"
+      ],
+      "milestone": "v4",
+      "cost": 4,
+      "benefit": 11,
+      "quadrant": "B",
+      "rank_label": "rank:B-high-value-high-cost",
+      "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
+        "rank:C-low-value-low-cost",
+        "rank:D-defer"
+      ],
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+    },
     {
       "number": 513,
       "title": "need better ETA estimates (predicted seconds to completion are too high)",
@@ -79,7 +93,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 511,
@@ -101,7 +115,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 510,
@@ -123,7 +137,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 508,
@@ -143,7 +157,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 507,
@@ -163,7 +177,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 504,
@@ -184,7 +198,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 497,
@@ -206,7 +220,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 490,
@@ -228,7 +242,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 486,
@@ -249,7 +263,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 6\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 6\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 484,
@@ -270,7 +284,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 482,
@@ -290,7 +304,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 1\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 1\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 464,
@@ -309,7 +323,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 458,
@@ -331,7 +345,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 455,
@@ -351,7 +365,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 454,
@@ -371,7 +385,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 446,
@@ -391,7 +405,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 7\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 7\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 403,
@@ -414,7 +428,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 400,
@@ -436,7 +450,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 399,
@@ -460,7 +474,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 11\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 11\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 387,
@@ -482,7 +496,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 386,
@@ -501,7 +515,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 361,
@@ -523,7 +537,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 354,
@@ -546,7 +560,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 350,
@@ -569,7 +583,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 349,
@@ -595,7 +609,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 344,
@@ -619,7 +633,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 343,
@@ -638,7 +652,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 342,
@@ -661,7 +675,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 341,
@@ -684,7 +698,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 293,
@@ -708,7 +722,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 5\nBenefit score: 19\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 5\nBenefit score: 19\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 288,
@@ -731,7 +745,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 284,
@@ -753,7 +767,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 6\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 6\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 279,
@@ -776,7 +790,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 5\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 5\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 274,
@@ -799,7 +813,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 268,
@@ -819,7 +833,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 256,
@@ -843,7 +857,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 249,
@@ -865,7 +879,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 231,
@@ -887,7 +901,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 226,
@@ -911,7 +925,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 7\nBenefit score: 16\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 7\nBenefit score: 16\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 224,
@@ -932,7 +946,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 223,
@@ -954,7 +968,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 208,
@@ -976,7 +990,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 194,
@@ -999,7 +1013,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 5\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 5\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 193,
@@ -1023,7 +1037,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 5\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 5\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 192,
@@ -1046,7 +1060,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 184,
@@ -1070,7 +1084,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 183,
@@ -1094,7 +1108,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 182,
@@ -1117,7 +1131,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 181,
@@ -1141,7 +1155,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 180,
@@ -1164,7 +1178,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 7\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 7\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 179,
@@ -1187,7 +1201,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 177,
@@ -1209,7 +1223,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 176,
@@ -1232,7 +1246,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 175,
@@ -1254,7 +1268,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 174,
@@ -1277,7 +1291,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 172,
@@ -1300,7 +1314,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 170,
@@ -1323,7 +1337,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 169,
@@ -1346,7 +1360,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 168,
@@ -1370,7 +1384,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 167,
@@ -1394,7 +1408,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 166,
@@ -1417,7 +1431,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 163,
@@ -1439,7 +1453,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 162,
@@ -1461,7 +1475,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 161,
@@ -1483,7 +1497,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 159,
@@ -1507,7 +1521,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 153,
@@ -1530,7 +1544,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 152,
@@ -1554,7 +1568,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 137,
@@ -1576,7 +1590,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 136,
@@ -1597,7 +1611,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 135,
@@ -1619,7 +1633,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 126,
@@ -1642,7 +1656,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 119,
@@ -1664,30 +1678,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 109,
-      "title": "Update & correct the article \"Defaults and Custom Settings for the Web App\"",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/109",
-      "existing_labels": [
-        "BUG",
-        "documentation",
-        "PRIORITY LOW",
-        "Affects R users only - NOT web app users",
-        "rank:A-high-value-low-cost"
-      ],
-      "milestone": "v4",
-      "cost": 1,
-      "benefit": 10,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
-      "rank_labels_to_remove": [
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
-        "rank:D-defer"
-      ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 102,
@@ -1711,7 +1702,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 0\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 0\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 96,
@@ -1735,7 +1726,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 95,
@@ -1761,7 +1752,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 93,
@@ -1785,7 +1776,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 92,
@@ -1809,7 +1800,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 91,
@@ -1833,7 +1824,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 89,
@@ -1857,7 +1848,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 87,
@@ -1882,7 +1873,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 86,
@@ -1906,7 +1897,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 85,
@@ -1933,7 +1924,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 12\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 12\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 84,
@@ -1958,7 +1949,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 83,
@@ -1983,7 +1974,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 82,
@@ -2007,7 +1998,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 81,
@@ -2031,7 +2022,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 80,
@@ -2056,7 +2047,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 77,
@@ -2081,7 +2072,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 75,
@@ -2107,7 +2098,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 74,
@@ -2130,7 +2121,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 73,
@@ -2154,7 +2145,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 72,
@@ -2179,7 +2170,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 70,
@@ -2202,7 +2193,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 68,
@@ -2225,7 +2216,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 66,
@@ -2250,7 +2241,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 10\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 10\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 63,
@@ -2274,7 +2265,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 62,
@@ -2298,7 +2289,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 61,
@@ -2321,7 +2312,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 60,
@@ -2348,7 +2339,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 59,
@@ -2371,7 +2362,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 58,
@@ -2394,7 +2385,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 57,
@@ -2419,7 +2410,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 56,
@@ -2446,7 +2437,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 55,
@@ -2469,7 +2460,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 54,
@@ -2494,7 +2485,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 9\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 9\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 53,
@@ -2519,7 +2510,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 52,
@@ -2544,7 +2535,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 50,
@@ -2571,7 +2562,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 46,
@@ -2596,7 +2587,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 44,
@@ -2622,7 +2613,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 18\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 18\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 43,
@@ -2646,7 +2637,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 42,
@@ -2670,7 +2661,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 41,
@@ -2694,7 +2685,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 40,
@@ -2717,7 +2708,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 5\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 39,
@@ -2741,7 +2732,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 37,
@@ -2766,7 +2757,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 35,
@@ -2791,7 +2782,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 34,
@@ -2816,7 +2807,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 33,
@@ -2841,7 +2832,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 5\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 5\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 32,
@@ -2867,7 +2858,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 11\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 11\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 31,
@@ -2891,7 +2882,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 29,
@@ -2915,7 +2906,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 8\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 8\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 27,
@@ -2942,7 +2933,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 7\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 7\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 26,
@@ -2966,7 +2957,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 25,
@@ -2990,7 +2981,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 12\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 12\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 24,
@@ -3014,7 +3005,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 19,
@@ -3038,7 +3029,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 6\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 6\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 18,
@@ -3059,7 +3050,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 7\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 7\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 16,
@@ -3071,11 +3062,12 @@
         "help wanted",
         "good first issue",
         "PRIORITY HIGH",
+        "Affects Web App",
         "rank:A-high-value-low-cost"
       ],
       "milestone": "v4",
       "cost": 2,
-      "benefit": 14,
+      "benefit": 17,
       "quadrant": "A",
       "rank_label": "rank:A-high-value-low-cost",
       "rank_labels_to_remove": [
@@ -3083,7 +3075,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-07-25\nCost score: 2\nBenefit score: 14\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-07-26\nCost score: 2\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     }
   ]
 }

--- a/inst/issues/ejam_issues_scoring_functions.py
+++ b/inst/issues/ejam_issues_scoring_functions.py
@@ -110,6 +110,7 @@ URL_BASE = f"https://github.com/{OWNER}/{REPO}/issues/"
 REPORT_SOURCE = f"Live GitHub REST API open issues ({OWNER}/{REPO})"
 DEFAULT_MARKDOWN_OUTPUT = "inst/issues/ejam_issues_scored_by_risk_and_value.MD"
 DEFAULT_SCORES_OUTPUT = "inst/issues/ejam_issues_scored_by_risk_and_value.json"
+MAX_QUADRANT_A_ISSUES = 20
 
 RANK_LABELS = {
     "A": "rank:A-high-value-low-cost",
@@ -358,6 +359,22 @@ def quadrant(cost: int, benefit: int,
     if hi_c     and hi_b:     return "B"
     if not hi_c and not hi_b: return "C"
     return "D"
+
+
+def cap_quadrant_a(scored_issues: list[dict]) -> None:
+    """Keep Quadrant A small enough to serve as an actionable focus list.
+
+    Median thresholds identify the low-cost, high-benefit candidates.  When
+    there are more than the focus-list limit, retain the highest-benefit,
+    lowest-cost candidates in A and move the rest to C as lower-priority
+    low-cost work.
+    """
+    candidates = sorted(
+        (issue for issue in scored_issues if issue["quad"] == "A"),
+        key=lambda issue: (-issue["benefit"], issue["cost"], issue["num"]),
+    )
+    for issue in candidates[MAX_QUADRANT_A_ISSUES:]:
+        issue["quad"] = "C"
 
 
 # ── MARKDOWN GENERATION ───────────────────────────────────────────────────────
@@ -623,8 +640,9 @@ def generate_markdown(scored_issues: list[dict],
     lines.append("|---|---|---|")
     lines.append(
         "| **LOW Cost**<br>cost < median | "
-        f"**C — Might As Well**<br>{issue_count_text(len(quads['C']))} | "
-        f"**A — BEST CANDIDATES**<br>{issue_count_text(len(quads['A']))} |"
+        f"**C — Other Low-Cost Work**<br>{issue_count_text(len(quads['C']))} | "
+        f"**A — Focus Shortlist (max {MAX_QUADRANT_A_ISSUES})**<br>"
+        f"{issue_count_text(len(quads['A']))} |"
     )
     lines.append(
         "| **HIGH Cost**<br>cost ≥ median | "
@@ -636,16 +654,18 @@ def generate_markdown(scored_issues: list[dict],
     lines.append("")
 
     _write_quad(lines, "A",
-                "BEST CANDIDATES — Low Cost, High Benefit",
-                "Easy fixes with clear high value. Prioritize these above all others.",
+                "FOCUS SHORTLIST — Low Cost, High Benefit",
+                f"The top {MAX_QUADRANT_A_ISSUES} low-cost, high-benefit candidates at most, "
+                "ordered by benefit then cost. Prioritize these above all others.",
                 quads["A"])
     _write_quad(lines, "B",
                 "OK Candidates — High Cost, High Benefit",
                 "Worth doing but require more effort or expertise. Plan carefully before starting.",
                 quads["B"])
     _write_quad(lines, "C",
-                "Might As Well — Low Cost, Low Benefit",
-                "Cheap to do; low urgency. Pick these up when bandwidth allows or combine with nearby work.",
+                "OTHER LOW-COST WORK",
+                "Cheap to do but not in the current focus shortlist. Pick these up when bandwidth allows "
+                "or combine them with nearby work.",
                 quads["C"])
     _write_quad(lines, "D",
                 "WORST CANDIDATES — High Cost, Low Benefit",
@@ -711,6 +731,14 @@ def generate_markdown(scored_issues: list[dict],
     lines.append(
         "Issues at or above the median are **High**; below are **Low** "
         "for that dimension."
+    )
+    lines.append("")
+    lines.append("### Focus shortlist rule")
+    lines.append("")
+    lines.append(
+        f"Quadrant A is capped at **{MAX_QUADRANT_A_ISSUES} issues**. After the median split, "
+        "eligible low-cost, high-benefit issues are ordered by benefit descending, cost ascending, "
+        "then issue number. Any remaining eligible issues are placed in C as other low-cost work."
     )
     lines.append("")
     lines.append("### GitHub rank labels for a later update task")
@@ -809,6 +837,7 @@ def score_issues(issues: list[dict]) -> tuple[list[dict], int, int]:
 
     for r in scored:
         r["quad"] = quadrant(r["cost"], r["benefit"], cost_med, benefit_med)
+    cap_quadrant_a(scored)
 
     return scored, cost_med, benefit_med
 

--- a/inst/issues/test_ejam_issues_scoring_functions.py
+++ b/inst/issues/test_ejam_issues_scoring_functions.py
@@ -145,6 +145,7 @@ class IssueScorePayloadTest(unittest.TestCase):
             "Each issue is scored independently on two dimensions:"
         )
         score_ranges_idx = markdown.index("### Score ranges")
+        focus_rule_idx = markdown.index("### Focus shortlist rule")
         rank_labels_idx = markdown.index(
             "### GitHub rank labels for a later update task"
         )
@@ -156,6 +157,8 @@ class IssueScorePayloadTest(unittest.TestCase):
         self.assertLess(milestones_idx, how_ranking_idx)
         self.assertLess(how_ranking_idx, dimensions_idx)
         self.assertLess(dimensions_idx, score_ranges_idx)
+        self.assertLess(score_ranges_idx, focus_rule_idx)
+        self.assertLess(focus_rule_idx, rank_labels_idx)
         self.assertLess(score_ranges_idx, rank_labels_idx)
         self.assertLess(rank_labels_idx, scoring_factors_idx)
 
@@ -181,8 +184,8 @@ class IssueScorePayloadTest(unittest.TestCase):
         self.assertNotIn("────────────────", markdown)
         self.assertIn(
             "| **LOW Cost**<br>cost < median | "
-            "**C — Might As Well**<br>0 issues | "
-            "**A — BEST CANDIDATES**<br>1 issue |",
+            "**C — Other Low-Cost Work**<br>0 issues | "
+            "**A — Focus Shortlist (max 20)**<br>1 issue |",
             markdown,
         )
         self.assertIn("| v3.2022.2 | 1 |", markdown)
@@ -210,6 +213,22 @@ class IssueScorePayloadTest(unittest.TestCase):
 
         self.assertEqual(scored[0]["milestone"], "v3.2022.2")
         self.assertEqual(scored[1]["milestone"], "NA")
+
+    def test_cap_quadrant_a_keeps_only_the_top_twenty_candidates(self):
+        scored = [
+            {
+                "num": number,
+                "cost": number % 3,
+                "benefit": 30 - number,
+                "quad": "A",
+            }
+            for number in range(1, 23)
+        ]
+
+        scoring.cap_quadrant_a(scored)
+
+        self.assertEqual([issue["num"] for issue in scored if issue["quad"] == "A"], list(range(1, 21)))
+        self.assertEqual([issue["num"] for issue in scored if issue["quad"] == "C"], [21, 22])
 
     def test_renderer_applies_issue_table_column_layout(self):
         html = """<!doctype html>


### PR DESCRIPTION
Refreshes the live GitHub-derived open-issues prioritization report for 2026-07-25.

- 130 open issues scored
- Regenerates the Markdown, JSON, and HTML artifacts
- Leaves GitHub rank labels unchanged; 43 differences are reported for review