### PR TITLE
CI: run the real checks on main, and cheap checks on development PRs (MERGE AFTER v3.2022.2 SHIPS)

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -2,8 +2,20 @@
 name: 'R CMD check'
 
 on:
+  # Runs where the risk actually is: PRs into main, and main itself - main is
+  # what a release tag is cut from, and merges here are sometimes made with
+  # --admin (which bypasses PR checks) or pushed directly as hotfixes, so the
+  # post-merge run is the only thing that catches what a bypass skipped.
+  #
+  # Deliberately NOT run on PRs into development: this is a 5-platform matrix
+  # (macOS bills at 10x, Windows at 2x) on a package whose check takes ~12
+  # minutes. development PRs get the cheap ubuntu gates (lintr, quick install)
+  # instead. Revisit if breakage keeps reaching main.
   pull_request:
     branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
 
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help

--- a/.github/workflows/install-quick-check.yaml
+++ b/.github/workflows/install-quick-check.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main", "development" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "development" ]
   workflow_dispatch:
     inputs:
       install_source:

--- a/.github/workflows/lintr.yaml
+++ b/.github/workflows/lintr.yaml
@@ -2,8 +2,13 @@
 name: 'lintr checks code style and syntax errors'
 
 on:
+  # Cheap (single ubuntu job), so run it broadly - this is the fast feedback
+  # that development PRs currently get none of.
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "development" ]
+  push:
+    branches: [ "main", "development" ]
+  workflow_dispatch:
 
 # lintr provides static code analysis for R.
 # It checks for adherence to a given style,

--- a/.github/workflows/test-webapp-functionality.yaml
+++ b/.github/workflows/test-webapp-functionality.yaml
@@ -2,8 +2,14 @@
 name: 'Test web app UI and functionality'
 
 on:
+  # Expensive (macos-15, nine sequential shinytest2 app runs), so it stays
+  # scoped to main: PRs into it, and main itself after a merge, since --admin
+  # merges and direct hotfix pushes bypass the PR run.
   pull_request:
     branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
> **Draft on purpose — do not merge until v3.2022.2 has been published.** Re-enabling two workflows that have been dark for five months will very likely surface unrelated failures, and that is not something to discover on release morning.

## Two gaps

**1. R CMD check and lintr are switched off.**

```
disabled_manually  R CMD check   [check-standard.yaml]
disabled_manually  lintr         [lintr.yaml]
```

Both are `disabled_manually` in the Actions UI, so their `PRs into main` triggers never fire. **No R CMD check has run in CI on this repository since 2026-02-09**, and the four runs before that were failures or cancellations — the usual reason a workflow goes dark. The only reason we know v3.2022.2 passes is a local `devtools::check()` run (0 ERRORs / 0 WARNINGs / 4 benign NOTEs).

This also means Public-Environmental-Data-Partners/EJAM#511's table is inaccurate: it lists `check-standard` as "PRs → main only", not knowing it is disabled outright.

⚠️ **Merging this PR alone changes nothing.** Both workflows must be re-enabled in the Actions UI — that cannot be done from a commit.

**2. Nothing ran on `main` after a merge** except the quick install check. That matters because a release tag is cut from `main`, merges into it are sometimes made with `--admin` (which bypasses PR checks — every merge during v3.2022.2 prep was), and hotfixes have been pushed to `main` directly before. The post-merge run is the only thing that catches what a bypass skipped.

## Triggers after this change

| workflow | cost | runs on |
|---|---|---|
| `check-standard` (R CMD check) | 5-platform matrix, ~12 min/job | PRs → main, **push to main**, dispatch |
| `test-webapp-functionality` | macos-15, 9 shinytest2 runs | PRs → main, **push to main**, dispatch |
| `lintr` | single ubuntu | PRs → main **and development**, push to both, dispatch |
| `install-quick-check` | single ubuntu | adds **PRs → development** |

The two expensive workflows stay scoped to `main` deliberately — macOS bills at 10×, Windows at 2×. development PRs get the cheap ubuntu gates, which is still a large improvement on nothing. **The check matrix itself is unchanged**; I deliberately avoided a dynamic `fromJSON` matrix to vary it per base branch, because that adds runtime fragility to a workflow being switched back on unattended.

## Merge plan

1. v3.2022.2 publishes (Aug 1)
2. Merge this
3. Re-enable both workflows in the Actions UI
4. Expect red — the matrix includes r-devel, oldrel-1, Windows and macOS, none of which today's local check covered
5. Fix what surfaces before treating any of these as required

Related: Public-Environmental-Data-Partners/EJAM#511 (the gap this addresses), Public-Environmental-Data-Partners/EJAM#510 (deploy branches still have no checks at all — not covered here).