### PR TITLE
Document Community and Multisite Report examples in the basics vignette (fixes #344)

### DIFF
--- a/vignettes/basics.Rmd
+++ b/vignettes/basics.Rmd
@@ -141,30 +141,38 @@ out <- testoutput_ejamit_100pts_1miles
 ejam2map(out, launch_browser = FALSE) 
 ```
 
-## Community report via `ejam2report()`
+## Report via `ejam2report()`
 
-`ejam2report()` turns the analysis results into a community report that can be
-viewed in a browser or saved as a PDF.
+`ejam2report()` turns the analysis results into a multisite report or community
+report that can be viewed in a browser or saved as an HTML file (with
+interactive map linking to each site's report) or saved as a PDF (better page
+breaks for printing).
 
 ```{r ejam2report1_show_commands, eval=FALSE, echo = TRUE}
 
 out <- testoutput_ejamit_100pts_1miles
 
+# Create a multisite report for all sites:
 ejam2report(out)
 
-# Save the report as a PDF:
+# Save the multisite report as a PDF:
 ejam2report(out, fileextension = "pdf")
 
-# Or create a report for one site:
+# Save the multisite report as an interactive HTML file:
+ejam2report(out, fileextension = "html")
+
+# Create a community report for one site:
 ejam2report(out, sitenumber = 1, analysis_title = "Site #1")
 ```
 
 See a complete example:
 
-- [Community report for 100 point locations, using a one-mile
+- [Interactive HTML Multisite Report for a 10-site analysis of point locations,
+  using a one-mile radius](https://github.com/Public-Environmental-Data-Partners/EJAM/blob/main/inst/testdata/examples_of_output/testoutput_ejam2report_10pts_1miles.html)
+- [Multisite Report for 100 point locations, using a one-mile
   radius](https://github.com/Public-Environmental-Data-Partners/EJAM/blob/main/inst/testdata/examples_of_output/testoutput_ejam2report_100pts_1miles.pdf)
 
-More PDF examples show reports for [selected
+More Multisite Report PDF examples cover [selected
 counties](https://github.com/Public-Environmental-Data-Partners/EJAM/blob/main/inst/testdata/examples_of_output/testoutput_ejam2report_fips_counties.pdf)
 and [uploaded
 shapes](https://github.com/Public-Environmental-Data-Partners/EJAM/blob/main/inst/testdata/examples_of_output/testoutput_ejam2report_shapes_2.pdf).
@@ -229,7 +237,7 @@ nonattainment areas, impaired waters, CEJST or IRA disadvantaged communities,
 housing burden communities, food deserts, transportation disadvantaged
 communities), compared to the share of all US residents -- and the share of all
 residents of the state(s) analyzed -- who have those features or overlaps.
-This info also appears in the community report, and in the "Area Features" tab
+This info also appears in the Report, and in the "Area Features" tab
 of the spreadsheet from `ejam2excel()`.
 
 ```{r ejam2areafeatures, eval=FALSE, echo=TRUE}

--- a/vignettes/basics.Rmd
+++ b/vignettes/basics.Rmd
@@ -141,7 +141,10 @@ out <- testoutput_ejamit_100pts_1miles
 ejam2map(out, launch_browser = FALSE) 
 ```
 
-## Report via `ejam2report()` (interactive html file)
+## Community report via `ejam2report()`
+
+`ejam2report()` turns the analysis results into a community report that can be
+viewed in a browser or saved as a PDF.
 
 ```{r ejam2report1_show_commands, eval=FALSE, echo = TRUE}
 
@@ -149,49 +152,22 @@ out <- testoutput_ejamit_100pts_1miles
 
 ejam2report(out)
 
-## OR for one site:
-#
-# y <- ejam2report(out, sitenumber = 1, analysis_title = "Site #1")
+# Save the report as a PDF:
+ejam2report(out, fileextension = "pdf")
+
+# Or create a report for one site:
+ejam2report(out, sitenumber = 1, analysis_title = "Site #1")
 ```
 
+See a complete example:
 
-<!-- 1 REMOVE REPORT EXAMPLE FROM THE VIGNETTE UNTIL IT IS WORKING CORRECTLY:
+- [Community report for 100 point locations, using a one-mile
+  radius](https://github.com/Public-Environmental-Data-Partners/EJAM/blob/main/inst/testdata/examples_of_output/testoutput_ejam2report_100pts_1miles.pdf)
 
-```{r ejam2report1_includeHTML, echo=FALSE, include = FALSE}
-## one approach is to include html report that was already created:
-# fname = system.file("testdata/examples_of_output/testoutput_ejam2report_10pts_1miles.html", package = "EJAM")
-# htmltools::includeHTML(fname)
-```
-
-REMOVED UNTIL FIXED  -->
-
-<!-- 2 REMOVE REPORT EXAMPLE FROM THE VIGNETTE UNTIL IT IS WORKING CORRECTLY:
-
-```{r ejam2report1_gethtml, eval=TRUE, include=FALSE}
-#### xfun::file_string('file.html') # Another method of including some html here
-## 2d approach is get html of report then use results="asis" in R chunk inside html chunk:
-# out <- testoutput_ejamit_100pts_1miles
-# myreport <- ejam2report(out, launch_browser = FALSE, return_html = TRUE)
-```
-
-````{=html}
-```{r ejam2report1_returnhtmlasis, eval=TRUE, echo=FALSE, results='asis'}
-#  myreport
-```
-````
-
-REMOVED UNTIL FIXED  -->
-
-<!-- 3 REMOVE REPORT EXAMPLE FROM THE VIGNETTE UNTIL IT IS WORKING CORRECTLY: 
-
-3d approach to try to insert snapshots of the summary report tables and barplot instead of rendered output of the ejam2report() function... 
-
-![Summary table of environmental and residential population indicators as raw value, average and percentile (in State and in US overall)](images/image-report_top_example.png){width="100%"}
-![Summary table of Summary Indexes, population subgroups, sex, and language indicators](images/image-report_EJ_table_example.png){width="100%"} 
-![US map showing analyzed points](images/image-map_example.png){width="100%"}
-![Barplot comparing residential population indicators as ratios to US average](images/image-barplot_example.png){width="100%"}
-
-REMOVED UNTIL FIXED  -->
+More PDF examples show reports for [selected
+counties](https://github.com/Public-Environmental-Data-Partners/EJAM/blob/main/inst/testdata/examples_of_output/testoutput_ejam2report_fips_counties.pdf)
+and [uploaded
+shapes](https://github.com/Public-Environmental-Data-Partners/EJAM/blob/main/inst/testdata/examples_of_output/testoutput_ejam2report_shapes_2.pdf).
 
 
 ## Table of Results in RStudio console


### PR DESCRIPTION
## What changed

- make the Report section in the basics vignette easier to find
- distinguish a one-site Community Report from a greater-than-one-site Multisite Report
- show how to save a Multisite Report as either an interactive HTML file or a PDF
- link the tracked 10-site interactive HTML example and the existing 100-point PDF example
- link the selected-county and uploaded-shape PDF examples
- remove the obsolete commented-out attempts to embed Report output directly in the vignette

## Why

The basics vignette explained how to call `ejam2report()` but hid all Report
examples inside disabled comments. The revised wording now identifies Community
Reports and Multisite Reports accurately, and the tracked examples give readers
prominent, stable output to inspect without embedding a large Report in pkgdown.

## Validation

- `git diff --check`
- confirmed the linked 10-site HTML artifact exists on `main`, contains Site 1
  through Site 10, and includes ten per-site Report URLs
- confirmed the linked PDF artifacts exist on `main`
- confirmed `fileextension` accepts both `"html"` and `"pdf"` in
  `ejam2report()`
- configured RStudio's bundled Pandoc with the existing
  `pkgdown_configure_pandoc()` helper and completed a structure-only conversion
  of `vignettes/basics.Rmd` with Pandoc
- full evaluated vignette render not completed locally because the article's
  unrelated full dynamic-data setup continued loading

Closes #344

— Codex
