### PR TITLE
Title 1-site app reports as Community Reports, with the site and FIPS

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -2624,8 +2624,18 @@ app_server <- function(input, output, session) {
     ## *** consider replacing this with ejam2report(),
     ## but note doing map, plot, tables, footer separately in app_UI() allows for spinners, for example in UI
     isolate({
+      ## 1-site analyses must read like ejam2report() and the API, not like a
+      ## multisite summary. ejam2report() does this by flipping sitenumber from 0
+      ## to the single valid row when only one site is valid; this in-app renderer
+      ## never did, so a 1-site analysis was titled "EJSCREEN Multisite Summary"
+      ## and its header showed no site or FIPS identifier.
+      report_valid_rows  <- which(data_processed()$results_bysite$valid %in% TRUE)
+      report_sitenumber  <- if (length(report_valid_rows) == 1) report_valid_rows[1] else NULL
+      report_is_one_site <- !is.null(report_sitenumber)
+
       residents_within_xyz <- report_residents_within_xyz_from_ejamit(
         ejamitout = data_processed(), ## this function uses the whole list not just ejamout1 to create the header
+        sitenumber = report_sitenumber, # NULL keeps the multisite header; a row number adds "(Site N, FIPS ...)"
         site_method = submitted_upload_method()
         # isolate() done, so change in site_method (e.g., polygon to lat lon) will not trigger re-render if Start not clicked,
         # BUT, changing title does trigger re-render with old data and new title,
@@ -2636,12 +2646,34 @@ app_server <- function(input, output, session) {
 
       pkg_relative_path = function(fpath) {gsub((system.file( "", package = "EJAM")), "", fpath)}
     })
+
+    ## Report TITLE: "EJSCREEN Community Report" for 1 site, "...Multisite Summary" otherwise
+    report_title_now <- if (report_is_one_site) {
+      global_or_param("report_title")
+    } else {
+      global_or_param("report_title_multisite")
+    }
+
+    ## Analysis TITLE: for a 1-site FIPS analysis show the place name, as
+    ## ejam2report() does via fips2name(). Only replaces the untouched default, so
+    ## a title the user typed in the box is never silently overridden.
+    analysis_title_now <- sanitized_analysis_title()
+    if (report_is_one_site && isTRUE(data_processed()$sitetype %in% "fips") &&
+        identical(analysis_title_now, global_or_param("default_standard_analysis_title"))) {
+      fipsname <- tryCatch(
+        fips2name(data_processed()$results_bysite$ejam_uniq_id[report_sitenumber]),
+        error = function(e) NA_character_
+      )
+      if (length(fipsname) == 1 && !is.na(fipsname) && nzchar(fipsname)) {
+        analysis_title_now <- fipsname
+      }
+    }
     full_page <- build_community_report(
 
       logo_path      = pkg_relative_path(global_or_param("report_logo")), # use relative path, not full path #  # NULL means default, "" means no logo
       logo_html      = NULL, # this is the report logo, NOT app_logo_html... and gets defined downstream based on logo_path
-      report_title   = global_or_param("report_title_multisite"),
-      analysis_title = sanitized_analysis_title(), # changing it will trigger re-render here
+      report_title   = report_title_now,   # Community Report if 1 site, Multisite Summary otherwise
+      analysis_title = analysis_title_now, # changing it will trigger re-render here
       locationstr    = residents_within_xyz,
       totalpop       = popstr,
 

--- a/tests/testthat/test-report_residents_within_xyz.R
+++ b/tests/testthat/test-report_residents_within_xyz.R
@@ -559,3 +559,32 @@ test_that("sitenumber_label overrides the displayed site number (issue #348)", {
   # only a number or short text is a valid label (e.g., logical would show as "Site TRUE")
   expect_error(report_residents_within_xyz_from_ejamit(out, sitenumber = 1, sitenumber_label = TRUE))
 })
+
+test_that("a 1-site FIPS header names the site and FIPS, as the app now relies on", {
+  # Contract behind the in-app 1-site report fix in app_server.R: when only one
+  # site is valid, the app passes that row as sitenumber instead of NULL, so the
+  # header matches what ejam2report() and the EJAM API produce for a single site
+  # ("EJSCREEN Community Report" plus "(Site 1, FIPS ...)"), rather than reading
+  # like a multisite summary.
+  out <- testoutput_ejamit_fips_counties
+
+  # multisite framing when no sitenumber is given
+  multi <- report_residents_within_xyz_from_ejamit(out, site_method = "FIPS")
+  expect_false(grepl("FIPS", multi, fixed = TRUE))
+  expect_true(grepl("any of the", multi, fixed = TRUE))
+
+  # single-site framing, with the site number and the FIPS code
+  one <- report_residents_within_xyz_from_ejamit(out, sitenumber = 1, site_method = "FIPS")
+  expect_true(grepl("Site 1", one, fixed = TRUE))
+  expect_true(grepl("FIPS", one, fixed = TRUE))
+  expect_true(grepl(as.character(out$results_bysite$ejam_uniq_id[1]), one, fixed = TRUE))
+  expect_false(grepl("any of the", one, fixed = TRUE))
+
+  # the place name used as the report's analysis title for a 1-site FIPS run
+  nm <- fips2name(out$results_bysite$ejam_uniq_id[1])
+  expect_true(is.character(nm) && length(nm) == 1 && nzchar(nm))
+
+  # the two report titles the app switches between really are different
+  expect_false(identical(global_or_param("report_title"),
+                         global_or_param("report_title_multisite")))
+})


### PR DESCRIPTION
A 1-site analysis in the web app was headed **"EJSCREEN Multisite Summary"** and showed no site number, FIPS code, or place name — while the API produced **"EJSCREEN Community Report"** with the place name and `(Site 1, FIPS ...)` for the same analysis.

## The cause is not where it looks

Neither the report template nor `ejam2report()` is at fault. `ejam2report()` already handles this correctly:

```r
if (sitenumber %in% 0 && nsites == 1) {
  sitenumber <- valid_site_rows[1]
}
```

Flipping `sitenumber` selects the 1-site title and, for FIPS input, sets `analysis_title <- fips2name(...)`. That is exactly what the API shows.

**The app never reaches that code.** `output$comm_report_html` does not call `ejam2report()` — it calls `build_community_report()` directly (`R/app_server.R`), hardcoding `report_title = global_or_param("report_title_multisite")` and passing **no** `sitenumber`. So the in-app report could never render as a single-site report, regardless of how many sites were analyzed.

That also explains why a *downloaded* report was already correct — the download handlers do go through `ejam2report()`.

## The fix

The renderer now derives the valid-site count the same way `ejam2report()` does, and when exactly one site is valid:

- passes that row as `sitenumber`, so the header gains `(Site N, FIPS ...)`
- uses `report_title` → "EJSCREEN Community Report"
- for FIPS input, titles the report with the place name from `fips2name()`

The place name **only replaces the untouched default title**, so a title the user typed into the box is never silently overridden — otherwise the text box and the report would disagree.

## Verified against real output

Using `testoutput_ejamit_fips_counties`:

| | header |
|---|---|
| before | `Residents within any of the 3 specified counties … Area in Square Miles: 1948.54` |
| after (`sitenumber = 1`) | `Residents within this specified county` · **`(Site 1, FIPS 10001)`** · `Area in Square Miles: 586.06` |

`fips2name()` on that site returns **"Kent County, DE"**, which becomes the large header — matching the API's "Carnation city, WA". Confirmed the two title globals really do differ (`EJSCREEN Community Report` vs `EJSCREEN Multisite Summary`).

Regression test added to the existing `test-report_residents_within_xyz.R` — **64 tests pass**. Putting it in an existing file deliberately avoids the `R/test_ejam.R` group-list update that a new test file would require.

## Scope notes

- `output_df` is deliberately left as `results_overall`. For a single valid site it aggregates just that site, so switching to `results_bysite` would change the table-building path for no visible gain — unnecessary risk during release prep.
- The inline logic lives in a Shiny `renderUI`, so it is not unit-testable without a refactor or a shinytest2 run; the test pins the helper contract the fix depends on. **Worth an eyeball on the dev app after deploy**: run one FIPS place and confirm the title, place name, and FIPS line.

## Release

For **v3.2022.2**, so this needs to reach `main` before Aug 1. `DESCRIPTION` is untouched, so the scheduled release's version pin still matches and the automation is unaffected.