### PR TITLE
Sync 1-site Community Report fix to main for v3.2022.2

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -2624,8 +2624,18 @@ app_server <- function(input, output, session) {
     ## *** consider replacing this with ejam2report(),
     ## but note doing map, plot, tables, footer separately in app_UI() allows for spinners, for example in UI
     isolate({
+      ## 1-site analyses must read like ejam2report() and the API, not like a
+      ## multisite summary. ejam2report() does this by flipping sitenumber from 0
+      ## to the single valid row when only one site is valid; this in-app renderer
+      ## never did, so a 1-site analysis was titled "EJSCREEN Multisite Summary"
+      ## and its header showed no site or FIPS identifier.
+      report_valid_rows  <- which(data_processed()$results_bysite$valid %in% TRUE)
+      report_sitenumber  <- if (length(report_valid_rows) == 1) report_valid_rows[1] else NULL
+      report_is_one_site <- !is.null(report_sitenumber)
+
       residents_within_xyz <- report_residents_within_xyz_from_ejamit(
         ejamitout = data_processed(), ## this function uses the whole list not just ejamout1 to create the header
+        sitenumber = report_sitenumber, # NULL keeps the multisite header; a row number adds "(Site N, FIPS ...)"
         site_method = submitted_upload_method()
         # isolate() done, so change in site_method (e.g., polygon to lat lon) will not trigger re-render if Start not clicked,
         # BUT, changing title does trigger re-render with old data and new title,
@@ -2636,12 +2646,34 @@ app_server <- function(input, output, session) {
 
       pkg_relative_path = function(fpath) {gsub((system.file( "", package = "EJAM")), "", fpath)}
     })
+
+    ## Report TITLE: "EJSCREEN Community Report" for 1 site, "...Multisite Summary" otherwise
+    report_title_now <- if (report_is_one_site) {
+      global_or_param("report_title")
+    } else {
+      global_or_param("report_title_multisite")
+    }
+
+    ## Analysis TITLE: for a 1-site FIPS analysis show the place name, as
+    ## ejam2report() does via fips2name(). Only replaces the untouched default, so
+    ## a title the user typed in the box is never silently overridden.
+    analysis_title_now <- sanitized_analysis_title()
+    if (report_is_one_site && isTRUE(data_processed()$sitetype %in% "fips") &&
+        identical(analysis_title_now, global_or_param("default_standard_analysis_title"))) {
+      fipsname <- tryCatch(
+        fips2name(data_processed()$results_bysite$ejam_uniq_id[report_sitenumber]),
+        error = function(e) NA_character_
+      )
+      if (length(fipsname) == 1 && !is.na(fipsname) && nzchar(fipsname)) {
+        analysis_title_now <- fipsname
+      }
+    }
     full_page <- build_community_report(
 
       logo_path      = pkg_relative_path(global_or_param("report_logo")), # use relative path, not full path #  # NULL means default, "" means no logo
       logo_html      = NULL, # this is the report logo, NOT app_logo_html... and gets defined downstream based on logo_path
-      report_title   = global_or_param("report_title_multisite"),
-      analysis_title = sanitized_analysis_title(), # changing it will trigger re-render here
+      report_title   = report_title_now,   # Community Report if 1 site, Multisite Summary otherwise
+      analysis_title = analysis_title_now, # changing it will trigger re-render here
       locationstr    = residents_within_xyz,
       totalpop       = popstr,
 

--- a/tests/testthat/test-report_residents_within_xyz.R
+++ b/tests/testthat/test-report_residents_within_xyz.R
@@ -559,3 +559,32 @@ test_that("sitenumber_label overrides the displayed site number (issue #348)", {
   # only a number or short text is a valid label (e.g., logical would show as "Site TRUE")
   expect_error(report_residents_within_xyz_from_ejamit(out, sitenumber = 1, sitenumber_label = TRUE))
 })
+
+test_that("a 1-site FIPS header names the site and FIPS, as the app now relies on", {
+  # Contract behind the in-app 1-site report fix in app_server.R: when only one
+  # site is valid, the app passes that row as sitenumber instead of NULL, so the
+  # header matches what ejam2report() and the EJAM API produce for a single site
+  # ("EJSCREEN Community Report" plus "(Site 1, FIPS ...)"), rather than reading
+  # like a multisite summary.
+  out <- testoutput_ejamit_fips_counties
+
+  # multisite framing when no sitenumber is given
+  multi <- report_residents_within_xyz_from_ejamit(out, site_method = "FIPS")
+  expect_false(grepl("FIPS", multi, fixed = TRUE))
+  expect_true(grepl("any of the", multi, fixed = TRUE))
+
+  # single-site framing, with the site number and the FIPS code
+  one <- report_residents_within_xyz_from_ejamit(out, sitenumber = 1, site_method = "FIPS")
+  expect_true(grepl("Site 1", one, fixed = TRUE))
+  expect_true(grepl("FIPS", one, fixed = TRUE))
+  expect_true(grepl(as.character(out$results_bysite$ejam_uniq_id[1]), one, fixed = TRUE))
+  expect_false(grepl("any of the", one, fixed = TRUE))
+
+  # the place name used as the report's analysis title for a 1-site FIPS run
+  nm <- fips2name(out$results_bysite$ejam_uniq_id[1])
+  expect_true(is.character(nm) && length(nm) == 1 && nzchar(nm))
+
+  # the two report titles the app switches between really are different
+  expect_false(identical(global_or_param("report_title"),
+                         global_or_param("report_title_multisite")))
+})


### PR DESCRIPTION
Carries `c7bcc647` (#537) from `development` to `main` so the fix ships in v3.2022.2.

A 1-site analysis in the web app was headed "EJSCREEN Multisite Summary" with no site number, FIPS code, or place name, while the API produced "EJSCREEN Community Report" with the place name and `(Site 1, FIPS ...)` for the same analysis.

`ejam2report()` already handled this — it flips `sitenumber` from 0 to the single valid row, which selects the 1-site title and the `fips2name()` place name. The app never reached it: `output$comm_report_html` calls `build_community_report()` directly, hardcoding the multisite title and passing no `sitenumber`. Downloaded reports were already correct, since those go through `ejam2report()`.

Verified against `testoutput_ejamit_fips_counties`: header goes from *"Residents within any of the 3 specified counties"* to *"Residents within this specified county · (Site 1, FIPS 10001)"*, and `fips2name()` yields "Kent County, DE". 64 tests pass in the file carrying the new regression test.

**Release safety:** `DESCRIPTION` is untouched, so the Aug 1 scheduled run's version pin (`3.2022.2`) still matches `main` and the automation is unaffected. The draft release is not modified.

Worth noting this PR runs `test-webapp-functionality` (shinytest2), which exercises the app UI — the most relevant automated gate available for an `app_server.R` change, given `check-standard` is currently disabled.