### PR TITLE
Release workflow: postpone the August 1 run to 17:00 EDT

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ name: 'Release: tag and publish'
 #
 #   1. Manually (workflow_dispatch) - the normal path. Use dry_run first to see
 #      exactly what would be tagged and what the notes would say.
-#   2. On a schedule - 13:00 UTC on August 1, to ship v3.2022.2 without anyone
+#   2. On a schedule - 21:00 UTC on August 1, to ship v3.2022.2 without anyone
 #      having to be at a keyboard.
 #
 # What it does depends on what is already on the releases page:
@@ -47,8 +47,8 @@ on:
         type: boolean
         default: true
   schedule:
-    # 13:00 UTC = 09:00 EDT on August 1.
-    - cron: '0 13 1 8 *'
+    # 21:00 UTC = 17:00 EDT on August 1.
+    - cron: '0 21 1 8 *'
 
 permissions:
   contents: write


### PR DESCRIPTION
Moves today's scheduled v3.2022.2 publish from 09:00 EDT to **17:00 EDT** (13:00 UTC → 21:00 UTC), at Mark's request.

## What changes

One cron line, plus the two comments that state the time:

```diff
-    # 13:00 UTC = 09:00 EDT on August 1.
-    - cron: '0 13 1 8 *'
+    # 21:00 UTC = 17:00 EDT on August 1.
+    - cron: '0 21 1 8 *'
```

## What does NOT change

The draft, `SCHEDULED_EXPECTED_VERSION` (`3.2022.2`, still matching `DESCRIPTION` on `main`), and the `publish_draft` path are all untouched. The run still publishes the reviewed draft as-is, and `--latest` is still forced on a `schedule` event — which is what satisfies pkgdown's Latest gate so the docs root rebuilds itself.

## Timing

Opened at ~00:30 EDT, roughly 8.5 hours before the original 13:00 UTC firing, so the old schedule cannot go off first. GitHub reads the cron from the workflow file on the default branch, so this must merge to `main` to take effect.

Verified before pushing: YAML parses and the schedule reads `0 21 1 8 *`; no local machine paths in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)