### PR TITLE
Release workflow: start pkgdown and the install check itself

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,8 +146,30 @@ jobs:
             fi
           fi
 
+          # Whether a published release for this version exists once this job is
+          # done - either because a step below publishes it, or because it was
+          # already published. This is what gates the downstream dispatches, and
+          # it is deliberately NOT the same as "skip".
+          #
+          # Using skip there would make a failed dispatch unrecoverable: the
+          # release is published by the time the dispatch runs, so a rerun sees
+          # already_published -> skip=true, quietly does nothing, and finishes
+          # green with the follow-up workflow still never started. That is the
+          # exact silent gap this workflow is meant to close. Rerunning is
+          # therefore the supported recovery path, and re-dispatching for an
+          # already-published tag is harmless: pkgdown rebuilds identical docs
+          # and the install check just runs again.
+          #
+          # A scheduled run that bails on a version mismatch keeps mode=create
+          # with SKIP=true, so it correctly dispatches nothing.
+          RELEASED=false
+          if [ "$MODE" = 'already_published' ] || [ "$SKIP" = 'false' ]; then
+            RELEASED=true
+          fi
+
           echo "skip=$SKIP" >> "$GITHUB_OUTPUT"
           echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "released=$RELEASED" >> "$GITHUB_OUTPUT"
           echo "tag_exists=$TAG_EXISTS" >> "$GITHUB_OUTPUT"
 
       - name: Extract the NEWS.md section for this version
@@ -321,7 +343,7 @@ jobs:
       # while v3.2022.x is the one users are pointed at - would overwrite the
       # root docs. The gate has to be enforced on this side of the dispatch.
       - name: Start pkgdown and the install check
-        if: steps.guard.outputs.skip == 'false' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
+        if: steps.guard.outputs.released == 'true' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -329,6 +351,7 @@ jobs:
           TAG='${{ steps.ver.outputs.tag }}'
           VERSION='${{ steps.ver.outputs.version }}'
           failed=''
+          : > recovery.txt
 
           # The install check should run for every release, recommended or not.
           if gh workflow run install-release-user-check.yaml --ref main \
@@ -336,6 +359,7 @@ jobs:
             echo "- Started install-release-user-check on \`$TAG\`." >> "$GITHUB_STEP_SUMMARY"
           else
             failed="$failed install-release-user-check"
+            echo "> gh workflow run install-release-user-check.yaml --ref main -f ref=$TAG -f expected_version=$VERSION" >> recovery.txt
           fi
 
           # The docs ROOT is only for the release GitHub marks "Latest". That flag
@@ -355,6 +379,7 @@ jobs:
               echo "- Started pkgdown to rebuild the docs root from \`$TAG\`." >> "$GITHUB_STEP_SUMMARY"
             else
               failed="$failed pkgdown"
+              echo "> gh workflow run pkgdown.yaml --ref main -f ref=$TAG -f target_folder=. -f pkgdown_dev_mode=release" >> recovery.txt
             fi
           else
             echo "::notice::$TAG is not the Latest release (Latest is '${latest_tag:-unknown}'); leaving the docs root alone."
@@ -369,12 +394,12 @@ jobs:
               echo ""
               echo "> [!WARNING]"
               echo "> Could not start:$failed. The release is published; only these follow-ups did not start."
-              echo "> Run them by hand:"
+              echo "> Rerunning this job is the supported fix - it will retry them for the"
+              echo "> already-published tag. To do it by hand instead:"
               echo "> \`\`\`"
-              echo "> gh workflow run pkgdown.yaml --ref main -f ref=$TAG -f target_folder=. -f pkgdown_dev_mode=release"
-              echo "> gh workflow run install-release-user-check.yaml --ref main -f ref=$TAG -f expected_version=$VERSION"
+              cat recovery.txt
               echo "> \`\`\`"
             } >> "$GITHUB_STEP_SUMMARY"
-            echo "::error::Failed to start:$failed. See the job summary for the manual commands."
+            echo "::error::Failed to start:$failed. Rerun this job, or see the summary for the manual command(s)."
             exit 1
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,11 @@ name: 'Release: tag and publish'
 #     matching NEWS.md section.
 #   * already published -> nothing happens; a shipped release is never touched.
 #
+# Whenever something is actually published, the last step starts pkgdown and the
+# install check by hand. It has to: GitHub does not create workflow runs from
+# events raised by the default GITHUB_TOKEN, so the `release: published` event
+# this workflow generates triggers nothing on its own.
+#
 # The scheduled path is deliberately one-shot: it refuses to do anything unless
 # DESCRIPTION on `main` still reads exactly SCHEDULED_EXPECTED_VERSION. So when
 # this cron fires again in later years it will find a different version and exit
@@ -52,6 +57,9 @@ on:
 
 permissions:
   contents: write
+  # Needed by the final step, which uses `gh workflow run` to start the
+  # workflows that publishing cannot start on its own. See its comment.
+  actions: write
 
 env:
   # Guard for the scheduled run only - see the header comment.
@@ -291,3 +299,82 @@ jobs:
             echo "- Tag: \`$TAG\`"
             echo "- https://github.com/${{ github.repository }}/releases/tag/$TAG"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Start the workflows that publishing cannot start by itself.
+      #
+      # GitHub deliberately does NOT create workflow runs from events raised by
+      # the default GITHUB_TOKEN. The steps above publish with that token, so the
+      # `release: published` event they generate triggers nothing: pkgdown never
+      # rebuilds the docs root, and install-release-user-check never runs on the
+      # tag. Proven on 2026-08-01 - v3.2022.2 published cleanly at 21:44 UTC and
+      # neither workflow ran; the docs root still served 3.2022.1 two days later,
+      # until both were dispatched by hand.
+      #
+      # `workflow_dispatch` is the documented exception to that rule, which is
+      # why this works with no PAT and no new secret. It needs `actions: write`,
+      # declared at the top of this file.
+      #
+      # Note this deliberately re-implements pkgdown's "Latest" gate rather than
+      # relying on it. Passing target_folder explicitly overrides that gate
+      # ("a manual workflow_dispatch target always wins"), so without the check
+      # below, publishing a non-recommended line - say v3.2024.0, which exists
+      # while v3.2022.x is the one users are pointed at - would overwrite the
+      # root docs. The gate has to be enforced on this side of the dispatch.
+      - name: Start pkgdown and the install check
+        if: steps.guard.outputs.skip == 'false' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          TAG='${{ steps.ver.outputs.tag }}'
+          VERSION='${{ steps.ver.outputs.version }}'
+          failed=''
+
+          # The install check should run for every release, recommended or not.
+          if gh workflow run install-release-user-check.yaml --ref main \
+               -f ref="$TAG" -f expected_version="$VERSION"; then
+            echo "- Started install-release-user-check on \`$TAG\`." >> "$GITHUB_STEP_SUMMARY"
+          else
+            failed="$failed install-release-user-check"
+          fi
+
+          # The docs ROOT is only for the release GitHub marks "Latest". That flag
+          # is curated by hand and already encodes "recommended". Retry, because
+          # /releases/latest can lag publication by a moment.
+          latest_tag=''
+          for attempt in 1 2 3 4 5; do
+            latest_tag="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name 2>/dev/null || echo '')"
+            [ "$latest_tag" = "$TAG" ] && break
+            echo "attempt $attempt: Latest reads '${latest_tag:-unknown}', expected '$TAG'; retrying"
+            sleep 10
+          done
+
+          if [ "$latest_tag" = "$TAG" ]; then
+            if gh workflow run pkgdown.yaml --ref main \
+                 -f ref="$TAG" -f target_folder=. -f pkgdown_dev_mode=release; then
+              echo "- Started pkgdown to rebuild the docs root from \`$TAG\`." >> "$GITHUB_STEP_SUMMARY"
+            else
+              failed="$failed pkgdown"
+            fi
+          else
+            echo "::notice::$TAG is not the Latest release (Latest is '${latest_tag:-unknown}'); leaving the docs root alone."
+            echo "- Skipped pkgdown: \`$TAG\` is not the Latest release." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # Fail loudly if a dispatch did not go through. The release itself is
+          # already published and is not harmed by a red run here - but a silent
+          # miss is the exact failure this step exists to prevent.
+          if [ -n "$failed" ]; then
+            {
+              echo ""
+              echo "> [!WARNING]"
+              echo "> Could not start:$failed. The release is published; only these follow-ups did not start."
+              echo "> Run them by hand:"
+              echo "> \`\`\`"
+              echo "> gh workflow run pkgdown.yaml --ref main -f ref=$TAG -f target_folder=. -f pkgdown_dev_mode=release"
+              echo "> gh workflow run install-release-user-check.yaml --ref main -f ref=$TAG -f expected_version=$VERSION"
+              echo "> \`\`\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::Failed to start:$failed. See the job summary for the manual commands."
+            exit 1
+          fi


### PR DESCRIPTION
Fixes the gap found when v3.2022.2 shipped: **publishing a release from this workflow triggers nothing downstream.**

## What went wrong

GitHub does not create workflow runs from events raised by the default `GITHUB_TOKEN`. `release.yaml` publishes with that token, so the `release: published` event it generates never reached `pkgdown.yaml` or `install-release-user-check.yaml`.

Observed 2026-08-01: v3.2022.2 published cleanly at 21:44 UTC, and **neither workflow ran**. The docs root still served 3.2022.1 two days later, until both were dispatched by hand. Nothing was red — the release run itself succeeded, and the *absence* of two runs was the only symptom, which is what made it easy to miss.

## The fix

A final step dispatches both workflows. `workflow_dispatch` is the documented exception to the `GITHUB_TOKEN` rule, so this needs **no PAT and no new secret** — only `actions: write`, added to the permissions block.

## Two things worth reviewing

**It re-implements pkgdown's "Latest" gate instead of trusting it.** Passing `target_folder` explicitly overrides that gate on pkgdown's side ("a manual workflow_dispatch target always wins"). Without the check added here, publishing a non-recommended line — v3.2024.0 exists while v3.2022.x is what users are pointed at — would overwrite the root docs. So the gate is enforced before the dispatch, with the same 5-attempt retry pkgdown uses, since `/releases/latest` can lag publication. The install check is not gated; it runs for every release.

**A dispatch that fails to start fails the step**, with the manual commands written into the job summary. By then the release is published and a red run does no harm — whereas a silent miss is exactly the failure being fixed.

## Verification

- YAML parses; steps and permissions confirmed via `YAML.load_file`.
- The step's shell script passes `bash -n`.
- Dry runs are unaffected: the step carries the same `!(workflow_dispatch && dry_run)` guard as the publish steps, so `dry_run=true` still touches nothing.
- No local machine paths in the diff.

Cannot be end-to-end tested without publishing a release. The next release is the real test; if it fails, the job summary says exactly what to run by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)