### PR TITLE
Do not dispatch downstream workflows on a scheduled version mismatch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,11 +101,16 @@ jobs:
           set -euo pipefail
           VERSION='${{ steps.ver.outputs.version }}'
           SKIP=false
+          # Tracked separately from SKIP because a scheduled version mismatch must
+          # suppress the downstream dispatches too, and SKIP alone cannot express
+          # that - see the RELEASED comment below.
+          SCHEDULE_VERSION_MISMATCH=false
 
           if [ '${{ github.event_name }}' = 'schedule' ]; then
             if [ "$VERSION" != "$SCHEDULED_EXPECTED_VERSION" ]; then
               echo "::notice::Scheduled run is a no-op. DESCRIPTION on main is $VERSION but this schedule only ships $SCHEDULED_EXPECTED_VERSION."
               SKIP=true
+              SCHEDULE_VERSION_MISMATCH=true
             fi
           else
             EXPECTED='${{ inputs.expected_version }}'
@@ -160,10 +165,16 @@ jobs:
           # already-published tag is harmless: pkgdown rebuilds identical docs
           # and the install check just runs again.
           #
-          # A scheduled run that bails on a version mismatch keeps mode=create
-          # with SKIP=true, so it correctly dispatches nothing.
+          # A scheduled run that bails on a version mismatch must dispatch
+          # nothing, and needs its own flag to say so. MODE is decided after the
+          # mismatch check and from the release page alone, so on a future annual
+          # firing - DESCRIPTION long past the pinned version, that version's
+          # release already published - it would land on already_published and
+          # dispatch pkgdown and the install check for a run that just announced
+          # itself a no-op.
           RELEASED=false
-          if [ "$MODE" = 'already_published' ] || [ "$SKIP" = 'false' ]; then
+          if [ "$SCHEDULE_VERSION_MISMATCH" = 'false' ] &&
+             { [ "$MODE" = 'already_published' ] || [ "$SKIP" = 'false' ]; }; then
             RELEASED=true
           fi
 


### PR DESCRIPTION
Fixes on `main` the bug found in review of #541. Same commit (`fdc83b85`), cherry-picked.

## The bug

`MODE` is decided *after* the version-mismatch check, and purely from what is on the releases page. So on a **future annual firing** — `DESCRIPTION` long past the pinned `SCHEDULED_EXPECTED_VERSION`, and that version's release already published — the run would:

1. print *"Scheduled run is a no-op"* and set `SKIP=true`, then
2. reach `gh release view`, land on `MODE=already_published`, and
3. set `RELEASED=true` → **dispatch pkgdown and the install check anyway.**

The code comment asserted the opposite ("keeps mode=create with SKIP=true, so it correctly dispatches nothing"), which is what made it easy to miss.

A scheduled version mismatch is now tracked in its own flag and excluded from the dispatch gate, and the comment describes what the code actually does.

## Not urgent

The cron is `0 21 1 8 *`, so the **next possible occurrence is August 1, 2027**. The consequence is a wasted pkgdown rebuild (~16 min) plus an install-check run — nothing destructive, and pkgdown's own "Latest" gate still protects the docs root. This is drift hygiene, not a live incident.

## Verified

| event | version vs pin | release state | dispatch |
|---|---|---|---|
| schedule | **mismatch** | published | **false** ← was `true` |
| schedule | mismatch | none | false |
| schedule | match | draft | true |
| schedule | match | none | true |
| workflow_dispatch | match | **already published** | **true** |
| workflow_dispatch | match | none | true |

The second-to-last row matters most: a manual rerun when the release is already published must still dispatch, since that is the recovery path for a dispatch that failed after publication — the exact gap `RELEASED` was split from `SKIP` to close. Preserved.

## Why a separate PR

#541 syncs `main`'s file to `development`, so it deliberately carried `main`'s content verbatim — bug included. Fixing only there would have left `main` wrong and reversed the drift this was all meant to remove. With both merged, the two branches match again.