### PR TITLE
Make the lintr workflow actually finish, and lint for mistakes not style

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,6 +10,7 @@
 ^\.github$
 ^\.positai$
 ^\.claude$
+^\.lintr$
 ^data/.*[.]arrow$
 ^data-raw/pipeline_outputs$
 ^data-raw/pipeline_outputs/.*

--- a/.github/workflows/lintr.yaml
+++ b/.github/workflows/lintr.yaml
@@ -60,9 +60,24 @@ jobs:
           extra-packages: lintr
 
       - name: Run lintr
+        # Which linters run is set by the .lintr file at the root of the repo,
+        # which lint_dir() picks up. See the comments in that file.
         run: lintr::sarif_output(lintr::lint_dir("."), "lintr-results.sarif")
         shell: Rscript {0}
         continue-on-error: true
+
+      # lintr can report a lint at column 0 (indentation_linter does this for a
+      # line that should be indented but is not), and SARIF requires
+      # startColumn >= 1. One out-of-range value makes GitHub reject the whole
+      # file, so every result is lost - that is what used to fail this job. The
+      # .lintr file does not enable any linter that does this today; this step
+      # just keeps one stray lint from taking the whole upload down again.
+      - name: Fix out-of-range columns in the SARIF file
+        run: |
+          jq '(.. | objects | select(has("startColumn")) | .startColumn) |= (if . < 1 then 1 else . end)
+              | (.. | objects | select(has("endColumn"))   | .endColumn)   |= (if . < 1 then 1 else . end)' \
+            lintr-results.sarif > lintr-results.fixed.sarif
+          mv lintr-results.fixed.sarif lintr-results.sarif
 
       - name: Upload analysis results to GitHub
         uses: github/codeql-action/upload-sarif@v4

--- a/.lintr
+++ b/.lintr
@@ -23,6 +23,14 @@
 # export). Writing data.table::setDT() explicitly is a deliberate convention
 # here, so that linter is all noise and would bury the other ~90 findings.
 #
+# missing_package_linter is switched off out of the common_mistakes set for a
+# similar reason: it answers "is this package installed *here*", not "is this
+# package name a typo". The lintr workflow installs EJAM's dependencies but not
+# EJAM itself, so every library(EJAM) in data-raw/, vignettes/ and tests/ came
+# back as "Package 'EJAM' is not installed" - 29 findings, plus 2 more for
+# census2020download, which is only on GitHub. That was 31 of 110 alerts in the
+# first successful run, all of them about the runner rather than the code.
+#
 # NOTE: indentation_linter must stay out of this set for a second reason - it
 # reports column 0 for a line that should be indented but is not, and column 0
 # is invalid in SARIF (startColumn must be >= 1), which made every upload of the
@@ -30,7 +38,7 @@
 # defensively, but not enabling the linter is the real fix.
 
 linters: c(
-    lintr::linters_with_tags("common_mistakes"),
+    lintr::linters_with_tags("common_mistakes", missing_package_linter = NULL),
     list(package_hooks_linter = lintr::package_hooks_linter())
   )
 exclusions: list("docs", "man", "planning", "data-raw/pipeline_outputs")

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,37 @@
+# Configuration for lintr, used by the "lintr checks code style and syntax errors"
+# GitHub Actions workflow (.github/workflows/lintr.yaml) and by lintr::lint_dir()
+# or lintr::lint_package() when run locally.
+#
+# We deliberately do NOT use lintr's default linter set. The defaults are mostly
+# style rules (indentation, spacing, line length, quote style, ...) that flag
+# tens of thousands of lines here without pointing at anything broken, which
+# buries the handful of findings that do matter and is far more than a GitHub
+# code scanning upload will accept.
+#
+# Instead we run the linters that catch likely mistakes rather than formatting:
+#   - everything tagged "common_mistakes" (all_equal_linter, equals_na_linter,
+#     missing_argument_linter, sprintf_linter, vector_logic_linter, ...)
+#   - package_hooks_linter - problems in .onLoad / .onAttach / .onDetach
+# Parse (syntax) errors are always reported, whatever the linter set.
+#
+# object_usage_linter is intentionally left out: it has to load the package to
+# work, which is slow and noisy in this repo.
+#
+# namespace_linter is left out too. On this code it produced 658 findings, every
+# one of them "Don't use `::` to access <fun>, which is already imported from
+# data.table" - and zero real ones (no calls to functions a package does not
+# export). Writing data.table::setDT() explicitly is a deliberate convention
+# here, so that linter is all noise and would bury the other ~90 findings.
+#
+# NOTE: indentation_linter must stay out of this set for a second reason - it
+# reports column 0 for a line that should be indented but is not, and column 0
+# is invalid in SARIF (startColumn must be >= 1), which made every upload of the
+# results to GitHub code scanning fail. The workflow also clamps the value
+# defensively, but not enabling the linter is the real fix.
+
+linters: c(
+    lintr::linters_with_tags("common_mistakes"),
+    list(package_hooks_linter = lintr::package_hooks_linter())
+  )
+exclusions: list("docs", "man", "planning", "data-raw/pipeline_outputs")
+encoding: "UTF-8"


### PR DESCRIPTION
## The problem

The **lintr checks code style and syntax errors** workflow has failed on **every run since it was added** — all 6 completed runs, back to the first one on Nov 4 2025. It has never reported a single finding.

The lint step is not the problem. The upload is:

```
instance.runs[0].results[1559].locations[0].physicalLocation.region.startColumn
must be greater than or equal to 1
```

`indentation_linter` reports **column 0** for a line that should be indented but is not (*"Indentation should be 6 spaces but is 0 spaces"*), and `lintr::sarif_output()` copies that 0 straight into `region.startColumn`. SARIF requires `startColumn >= 1`, so `github/codeql-action/upload-sarif` rejects the file — and one out-of-range value discards **every** result, not just the bad one.

The `Run lintr` step looks green only because of its `continue-on-error: true`.

Reproduced locally on the first 40 files of `R/`:

```
total lints: 6187
lints with column < 1: 29   <- all indentation_linter
```

## The fix

**1. Add a `.lintr` config** (there wasn't one), which `lint_dir()` picks up automatically. It selects the linters tagged `common_mistakes` plus `package_hooks_linter` — roughly the subset the workflow's own comment block has been proposing all along — instead of lintr's mostly-stylistic defaults.

This drops `indentation_linter`, the actual source of the zero columns, and it also fixes a second problem that was waiting behind the first: ~6,200 lints in 40 files extrapolates to roughly 100,000 across all 715 `.R`/`.Rmd` files, well past the 25,000 results GitHub accepts per SARIF upload — and 100k formatting complaints is not signal anyone would read.

| | lints | runtime |
|---|---|---|
| lintr defaults | ~6,200 in the first 40 files of `R/` | 4m 32s on CI |
| this config | **91 across the whole repo** | 25s locally |

`namespace_linter` is deliberately left out even though the workflow comment suggested it: all **658** of its findings were *"Don't use `::` to access &lt;fun&gt;, which is already imported from data.table"* and **zero** were real (no calls to functions a package doesn't export). Explicit `data.table::` calls are a deliberate convention here, so it was pure noise that would have buried the other 91.

`object_usage_linter` stays out for the reason the existing comment gives — it has to load the package.

**2. Clamp `startColumn`/`endColumn` to >= 1** in the SARIF before upload, so that if some future linter emits a column 0 it costs one bogus column number instead of the whole run. Verified against a deliberately poisoned file: 2 out-of-range values corrected, all 91 results preserved, JSON still valid.

**3. `.Rbuildignore` the new `.lintr`**, as lintr recommends, so it doesn't turn up as a stray hidden file in `R CMD check`.

## What the check finds now

91 findings, which is a readable number:

```
vector_logic_linter        28     download_file_linter       9
unused_import_linter       21     all_equal_linter           7
redundant_equals_linter    14     missing_argument_linter    6
duplicate_argument_linter   3     error (parse failures)     3
```

Not fixed here — this PR is only about making the check run — but worth flagging:

- **`data-raw/datacreate_NAICS.R` does not parse at all.** Line 57 has an unterminated `paste0(`: the `details =` string closes early at `".)","` and swallows the rest of the call, so `parse()` hits end-of-input. The script cannot be sourced. It's in `data-raw/` so nothing shipped is affected, but this is exactly what a syntax check is for, and it has been sitting there uncaught for nine months.
- The two `error` findings in `inst/report/written_report/report.Rmd` and `long_report_template_2-10-25.Rmd` look like **false positives** — lintr's knitr chunk extraction treating a block of markdown prose as R code. Both files fail on the same duplicated prose block, and their code fences are balanced. Worth confirming before anyone acts on those two alerts.

## Testing

- `.lintr` parses and applies (`lint()` honours it; 17 findings on `app_server.R` rather than hundreds).
- Full `lint_dir(".")` with this config: 91 lints, **0 with column < 1**, 73 KB SARIF, 25s.
- jq clamp tested against a SARIF with `startColumn: 0` and `endColumn: 0` injected: both corrected to 1, all 91 results intact.
- `.github/workflows/lintr.yaml` re-parsed as YAML; the jq block scalar survives intact.

Note the workflow still won't *fail* on lint findings — it uploads them to code scanning. This PR only makes that upload succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)