### PR TITLE
Fix the three R parse errors that lintr found

### DIFF
--- a/data-raw/datacreate_NAICS.R
+++ b/data-raw/datacreate_NAICS.R
@@ -50,11 +50,11 @@ metadata_add_and_use_this("NAICS")
 dataset_documenter(varname = "NAICS",
                    title = "NAICS (DATA) named vector of all NAICS code numbers and industry name for each",
                    description = "A named vector of more than 2,000 NAICS code numbers and industry name for each",
-                   details = "This is a named set of numeric codes, where a name has the code and title,
+                   details = paste0("This is a named set of numeric codes, where a name has the code and title,
 like '22132 - Sewage Treatment Facilities' or '22 - Utilities'
 Revised codes have been published every five years, such as in 2017 and 2022.
 
-", paste0("This dataset is based on the NAICS codes released in", vintage_naics_codes_to_get, ".)","
+This dataset is based on the NAICS codes released in ", vintage_naics_codes_to_get, ".
 
 The version used should match the version used in assigning codes to the EPA FRS facilities.
 As of 5/2026, the 2017 NAICS codes were being used in EJAM because
@@ -66,5 +66,5 @@ For more info, see [naics_download()] and (https://naics.com)
 and [2022 codes](https://www.census.gov/naics/?58967?yearbck=2022)
 
 and [2017 codes](https://www.census.gov/naics/?58967?yearbck=2017)
-                   ",
+                   "),
                    seealso = " [naics_download()] [naicstable] [naics_from_any()] [naics_categories()] [NAICS]")

--- a/inst/report/written_report/long_report_template_2-10-25.Rmd
+++ b/inst/report/written_report/long_report_template_2-10-25.Rmd
@@ -2727,30 +2727,30 @@ suggesting useful background literature.
 # 
 ## Notes on formatting for a manuscript
 
-This manuscript will follow the guidelines in the Guide for Authors of
-the relevant journal. For detailed instructions on the elsevier
-article class, see
-<https://www.elsevier.com/authors/policies-and-guidelines/latex-instructions>
+# This manuscript will follow the guidelines in the Guide for Authors of
+# the relevant journal. For detailed instructions on the elsevier
+# article class, see
+# <https://www.elsevier.com/authors/policies-and-guidelines/latex-instructions>
   
   ## Bibliography styles
   
-  Here are two sample references: [@Feynman1963118; @Dirac1953888]. 
+  # Here are two sample references: [@Feynman1963118; @Dirac1953888]. 
 
-By default, natbib will be used with the `authoryear` style, set in the 
-`classoption` variable in a YAML. 
-You can set  extra options with 
-`natbiboptions` variable in a YAML header:
+# By default, natbib will be used with the `authoryear` style, set in the 
+# `classoption` variable in a YAML. 
+# You can set  extra options with 
+# `natbiboptions` variable in a YAML header:
   #``` yaml
   #natbiboptions: longnamesfirst,angle,semicolon
   #```
   
-  There are various more specific bibliography styles available at
-<https://support.stmdocs.in/wiki/index.php?title=Model-wise_bibliographic_style_files>.
-To use one of these, add it in the header using, for example,
-`biblio-style: model1-num-names`.
+  # There are various more specific bibliography styles available at
+# <https://support.stmdocs.in/wiki/index.php?title=Model-wise_bibliographic_style_files>.
+# To use one of these, add it in the header using, for example,
+# `biblio-style: model1-num-names`.
 
-If `citation_package` is set to `default` in `elsevier_article()`, then
-pandoc is used for citations instead of `natbib`.
+# If `citation_package` is set to `default` in `elsevier_article()`, then
+# pandoc is used for citations instead of `natbib`.
 
 
 

--- a/inst/report/written_report/report.Rmd
+++ b/inst/report/written_report/report.Rmd
@@ -952,30 +952,30 @@ suggesting useful background literature.
 # 
 ## Notes on formatting for a manuscript
 
-This manuscript will follow the guidelines in the Guide for Authors of
-the relevant journal. For detailed instructions on the elsevier
-article class, see
-<https://www.elsevier.com/authors/policies-and-guidelines/latex-instructions>
+# This manuscript will follow the guidelines in the Guide for Authors of
+# the relevant journal. For detailed instructions on the elsevier
+# article class, see
+# <https://www.elsevier.com/authors/policies-and-guidelines/latex-instructions>
 
 ## Bibliography styles
 
-Here are two sample references: [@Feynman1963118; @Dirac1953888]. 
+# Here are two sample references: [@Feynman1963118; @Dirac1953888]. 
 
-By default, natbib will be used with the `authoryear` style, set in the 
-`classoption` variable in a YAML. 
-You can set  extra options with 
-`natbiboptions` variable in a YAML header:
+# By default, natbib will be used with the `authoryear` style, set in the 
+# `classoption` variable in a YAML. 
+# You can set  extra options with 
+# `natbiboptions` variable in a YAML header:
 #``` yaml
 #natbiboptions: longnamesfirst,angle,semicolon
 #```
 
-There are various more specific bibliography styles available at
-<https://support.stmdocs.in/wiki/index.php?title=Model-wise_bibliographic_style_files>.
-To use one of these, add it in the header using, for example,
-`biblio-style: model1-num-names`.
+# There are various more specific bibliography styles available at
+# <https://support.stmdocs.in/wiki/index.php?title=Model-wise_bibliographic_style_files>.
+# To use one of these, add it in the header using, for example,
+# `biblio-style: model1-num-names`.
 
-If `citation_package` is set to `default` in `elsevier_article()`, then
-pandoc is used for citations instead of `natbib`.
+# If `citation_package` is set to `default` in `elsevier_article()`, then
+# pandoc is used for citations instead of `natbib`.
 
 
 


### PR DESCRIPTION
Fixes the three `error`-severity findings surfaced by the repaired lintr check in [#543](https://github.com/Public-Environmental-Data-Partners/EJAM/pull/543). All three are genuine — each is R that cannot be parsed. None had ever been reported, because that workflow discarded its own results before anyone saw them.

This is deliberately separate from #543 so the CI-config change and these content fixes can be reviewed and reverted independently. Neither depends on the other.

---

## 1. `data-raw/datacreate_NAICS.R` — the script does not parse at all

A real bug. `parse()` fails with `71:0: unexpected end of input`, so the script cannot be sourced.

In the `dataset_documenter()` call, `details =` closed its string early on line 57 and then opened a `paste0()` whose third argument was `".)"` — the paren meant to close the call was *inside* the string — and the trailing `,"` started a string that ran to the end of the file. Both `paste0(` and `dataset_documenter(` were left open.

```r
# before
details = "This is a named set of numeric codes, ...
...
", paste0("This dataset is based on the NAICS codes released in", vintage_naics_codes_to_get, ".)","

# after
details = paste0("This is a named set of numeric codes, ...
...
This dataset is based on the NAICS codes released in ", vintage_naics_codes_to_get, ".
```

Rewritten as the single `paste0()` that was evidently intended. Two consequences beyond parsing:

- the vintage year now actually interpolates — `"released in 2017."`
- the missing space is fixed, which would otherwise have rendered `"released in2017"`

All existing prose is kept verbatim. Verified by evaluating the `details` argument and reading the result:

```
This is a named set of numeric codes, where a name has the code and title,
like '22132 - Sewage Treatment Facilities' or '22 - Utilities'
Revised codes have been published every five years, such as in 2017 and 2022.

This dataset is based on the NAICS codes released in 2017.
...
```

Nothing shipped was affected — `data-raw/` is Rbuildignored — but the script was unrunnable.

## 2 & 3. The two report templates — prose inside an R chunk

`inst/report/written_report/report.Rmd` (chunk at line 949) and `long_report_template_2-10-25.Rmd` (chunk at 2724) both park a block of markdown prose *inside a real R chunk* to hide it. lintr is correct that the chunk isn't valid R.

I initially guessed these were false positives from lintr mis-slicing the file. They are not — the code fences are balanced and the prose is genuinely inside a fenced `{r}` chunk.

The author had already started commenting the block out (the first lines begin `#` / `##`) and stopped partway. This finishes the job on the remaining 15 lines in each file.

**Nothing rendered changes.** Both chunks are `eval=FALSE, include=FALSE`, so knitr neither runs nor emits them, and every edited line sits inside the chunk body:

| file | chunk | lines changed |
|---|---|---|
| `report.Rmd` | 949–989 | 955–978 |
| `long_report_template_2-10-25.Rmd` | 2724–2764 | 2730–2753 |

Chunk headers and fences are untouched (`git diff | grep '^[+-]```'` is empty).

`report.Rmd` is live — [R/app_server.R:3738](https://github.com/Public-Environmental-Data-Partners/EJAM/blob/development/R/app_server.R#L3738) copies and renders it for the written-report feature — which is why the fix stays *inside* the chunk rather than converting it to an HTML comment. The block contains an `-->` of its own, which would have closed such a comment early and dumped the rest into the document.

## Result

Whole-repo lint after these fixes:

```
before: 91 findings, 3 parse errors
after:  88 findings, 0 parse errors
```

That matters beyond the three fixes: with the `error` category at zero, the next genuine syntax error will stand out instead of hiding among known noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)