### PR TITLE
Fix the R CMD check ERRORs that #530 exposed on main

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -130,6 +130,7 @@ Suggests:
     devtools,
     fipio,
     ggridges (>= 0.5.7),
+    here,
     mapview,
     miniUI,
     openssl,

--- a/R/URL_FUNCTIONS_part1.R
+++ b/R/URL_FUNCTIONS_part1.R
@@ -17,7 +17,7 @@
 #' @param yr year of ACS data (end year of 5-year period)
 #' @param fiveorone must be 5 or 1
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' # requires a Census API key -- see ?tidycensus::census_api_key
 #' url_acs_table_info()
 #' }

--- a/R/acs_bycounty.R
+++ b/R/acs_bycounty.R
@@ -24,7 +24,8 @@
 #'
 #' @examples
 #' ## also see examples for acs_bybg()
-#' \donttest{
+#' # requires a Census API key -- see ?tidycensus::census_api_key
+#' \dontrun{
 #'   x     <- acs_bycounty(myvars = "B03002_003", myst = "NY",
 #'     yr = acs_endyear(guess_always = TRUE, guess_census_has_published = TRUE)) # nhwa
 #'   denom <- acs_bycounty(myvars = "B03002_001", myst = "NY",

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -201,6 +201,7 @@ USGS
 UST
 USTs
 USVI
+Unsetting
 VPC
 WFM
 WKID
@@ -226,6 +227,7 @@ addedbuffermiles
 addin
 aoimap
 api
+apidev
 apidocs
 apinames
 apirepo
@@ -462,6 +464,7 @@ grepv
 gridded
 handoff
 hardcoded
+hardcoding
 headernames
 hhlds
 hisp

--- a/man/acs_bycounty.Rd
+++ b/man/acs_bycounty.Rd
@@ -22,7 +22,8 @@ download ACS 5year data from Census API, at County resolution
 }
 \examples{
 ## also see examples for acs_bybg()
-\donttest{
+# requires a Census API key -- see ?tidycensus::census_api_key
+\dontrun{
   x     <- acs_bycounty(myvars = "B03002_003", myst = "NY",
     yr = acs_endyear(guess_always = TRUE, guess_census_has_published = TRUE)) # nhwa
   denom <- acs_bycounty(myvars = "B03002_001", myst = "NY",

--- a/man/url_acs_table_info.Rd
+++ b/man/url_acs_table_info.Rd
@@ -27,7 +27,7 @@ vector of URLs
 get URL(s) of Census Bureau pages showing ACS 5-year tables examples
 }
 \examples{
-\donttest{
+\dontrun{
 # requires a Census API key -- see ?tidycensus::census_api_key
 url_acs_table_info()
 }


### PR DESCRIPTION
Fixes the two `R CMD check` ERRORs documented in #548 — `Status: 2 ERRORs, 4 NOTEs` on both `macos-latest (release)` and `windows-latest (release)`, first seen on [run 31042164263](https://github.com/Public-Environmental-Data-Partners/EJAM/actions/runs/31042164263).

These are pre-existing failures that #530 made visible by running the real checks on `main`. Nothing here is caused by [#542](https://github.com/Public-Environmental-Data-Partners/EJAM/pull/542), the PR whose checks surfaced them — it changes only a workflow file.

Targets `development`, not `main`, so it reaches `main` through the normal release sync rather than adding more direct-to-main drift.

## 1. `--run-donttest` example needing a Census API key

`acs_bycounty()` wrapped its example in `\donttest{}`, but the example calls `tidycensus::get_acs()`, which errors without `CENSUS_API_KEY`. `\donttest` is exactly what `--run-donttest` runs, so it was guaranteed to fail on any machine without a key.

Changed to `\dontrun{}` — which is what `acs_bybg()` already does for the same reason.

`url_acs_table_info()` had the identical problem, with a comment already reading *"requires a Census API key"* inside a `\donttest` block. Fixed too, because example checking halts at the first error — it would simply have become the next failure once `acs_bycounty` stopped being first.

Verified with `tools::Rd2ex()`: both examples now extract to **0 lines that would execute** under `R CMD check`.

## 2. `here` used but never declared

`inst/golem-config.yml:17` has `golem_wd: !expr here::here()` under the `dev:` config, so `config::get(config = "dev")` evaluates `here::here()`. `here` appeared **nowhere** in `DESCRIPTION`, so a clean check machine doesn't have it:

```
── Error ('test-webapp-ui_and_server.R:129:5'): golem-config works and app is set as 'production' not 'dev'
  *  loadNamespace(x): there is no package called 'here'
```

Added to `Suggests`. This passes locally for most of us only because `here` is already installed as a transitive dependency of something else — which is exactly why it went unnoticed.

## 3. Spelling wordlist drift

Three words from recent vignette edits made the spelling test's output stop matching its `.Rout.save`: `apidev` (from the real `apidev.ejanalysis.com` hostname), `hardcoding`, `Unsetting`. All legitimate terms, not typos.

Added by hand rather than with `spelling::update_wordlist()`. That function wanted to **prune 17 words** as well, and pruning is riskier than it looks here: the check runs against the *built* package, not the source tree, so a word that still appears there would re-break the test for no reason. It also re-sorts under locale collation, which would have rewritten the whole file — the existing wordlist is ASCII-ordered, so the three additions are inserted in that ordering and the diff is exactly three lines.

## Verification

```
spelling::spell_check_package()        0 errors  (was 3)
DESCRIPTION Suggests                   ggridges < here < mapview
man/acs_bycounty.Rd                    parses; 0 executable example lines
man/url_acs_table_info.Rd              parses; 0 executable example lines
inst/WORDLIST                          853 -> 856 words, 3-line diff
```

`man/*.Rd` were edited directly rather than via `roxygenise()` — a full roxygen run needs the package data loaded (it dies on `object 'NAICS' not found` with `load_code = "source"`) and would have churned `NAMESPACE`. The two Rd edits mirror the roxygen source exactly.

## Not included

#548 records four Windows-only saved-results comparison failures, an API-mirror drift test, and a macOS shinytest2 error. Those need a judgement call about which numbers are correct, so they're deliberately out of scope here.

Closes #548 only in part — leaving the issue open for the remaining items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)