### PR TITLE
Fix the R CMD check shinytest2 ERROR and three NOTEs

### DIFF
--- a/.github/workflows/test-webapp-functionality.yaml
+++ b/.github/workflows/test-webapp-functionality.yaml
@@ -37,6 +37,13 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       NOT_CRAN: true
       SHINYTEST2_APP_DRIVER_TEST_ON_CRAN: 1
+      # Every step below filters to a test-webapp-<category>-functionality.R
+      # file, and those all call shinytest2_webapp_functionality_individual(),
+      # which skips unless this is set. It never was, so all nine steps were
+      # skipping and this workflow reported success while running no tests:
+      #   "Individual web app category tests are skipped by default."
+      # (verified in run 31042164366). Setting it makes them actually run.
+      EJAM_SHINYTEST2_INDIVIDUAL: true
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -129,6 +129,7 @@ Suggests:
     datasets,
     devtools,
     fipio,
+    gglorenz,
     ggridges (>= 0.5.7),
     here,
     mapview,

--- a/R/aaa_globalVariables.R
+++ b/R/aaa_globalVariables.R
@@ -303,12 +303,20 @@ from_misc_add = sort(setdiff(from_misc, union(from_varlist_add, union(from_datas
 # here, rather than mixed into the lists above, so it stays obvious that they
 # came from a specific check run and can be re-derived from one.
 #
-# stat_lorenz was in this NOTE too but is deliberately NOT listed: it is a
-# function from gglorenz, not a column, so listing it would have hidden a
-# genuinely undeclared dependency. It is now called as gglorenz::stat_lorenz()
-# with gglorenz added to Suggests.
+# Two names from that NOTE are deliberately NOT listed, because neither is a
+# column and listing them would bury a real defect rather than quiet a false
+# positive:
+#
+#   stat_lorenz - a function from gglorenz, not a column. Now called as
+#     gglorenz::stat_lorenz() with gglorenz added to Suggests.
+#
+#   bysite - undefined inside plot_lorenz_distance_by_dcount(), which takes
+#     bybg_people and then pipes bysite, so it errors on the first call.
+#     Declaring it would have silenced the one signal pointing at that bug.
+#     Leaving it undeclared keeps a 1-name NOTE that is telling the truth.
+#     See Public-Environmental-Data-Partners/EJAM#553.
 from_rcmdcheck_add <- c(
-  "..display_cols", "CNTY_NAME", "STATE_NAME", "ST_ABBREV", "bysite",
+  "..display_cols", "CNTY_NAME", "STATE_NAME", "ST_ABBREV",
   "diff_gt_tolerance", "diff_gt_tolerance_non_island", "difference_stage",
   "difference_stage_order", "differing_rows_non_island", "intptlat", "intptlon",
   "max_rel_diff", "max_rel_diff_non_island", "max_rel_diff_non_island_pct",

--- a/R/aaa_globalVariables.R
+++ b/R/aaa_globalVariables.R
@@ -296,6 +296,28 @@ from_misc_add = sort(setdiff(from_misc, union(from_varlist_add, union(from_datas
 ########################################### #
 ########################################### #
 
+########################################### #
+# Names R CMD check reported as "no visible binding for global variable".
+# All are column names used in data.table / dplyr non-standard evaluation, so
+# they are not really undefined - the checker just cannot see them. Grouped
+# here, rather than mixed into the lists above, so it stays obvious that they
+# came from a specific check run and can be re-derived from one.
+#
+# stat_lorenz was in this NOTE too but is deliberately NOT listed: it is a
+# function from gglorenz, not a column, so listing it would have hidden a
+# genuinely undeclared dependency. It is now called as gglorenz::stat_lorenz()
+# with gglorenz added to Suggests.
+from_rcmdcheck_add <- c(
+  "..display_cols", "CNTY_NAME", "STATE_NAME", "ST_ABBREV", "bysite",
+  "diff_gt_tolerance", "diff_gt_tolerance_non_island", "difference_stage",
+  "difference_stage_order", "differing_rows_non_island", "intptlat", "intptlon",
+  "max_rel_diff", "max_rel_diff_non_island", "max_rel_diff_non_island_pct",
+  "max_rel_diff_pct", "mean_rel_diff", "mean_rel_diff_non_island",
+  "mean_rel_diff_non_island_pct", "mean_rel_diff_pct", "na_mismatch",
+  "na_mismatch_non_island", "site_fips", "varlist"
+)
+########################################### #
+
 if (getRversion() >= "2.15.1") {
   utils::globalVariables(
     sort(
@@ -305,7 +327,8 @@ if (getRversion() >= "2.15.1") {
           from_varlist_add,
           from_datasets_add,
           from_check_var_add,
-          from_islandareas_pipeline_add
+          from_islandareas_pipeline_add,
+          from_rcmdcheck_add
         )
       )
     )

--- a/R/community_report_helper_funs.R
+++ b/R/community_report_helper_funs.R
@@ -439,6 +439,13 @@ report_sections_page_break_before <- c(
   "Facility Counts"
 )
 
+# Heading for the flagged-areas rows, shared by fill_tbl_full_subgroups() and
+# fill_tbl_flagged_areas_section(). A constant rather than a repeated literal
+# for two reasons: it was duplicated in both signatures, and at 94 characters
+# it pushed the \usage line of fill_tbl_full_subgroups.Rd past the 90-character
+# limit R CMD check enforces. The text itself is unchanged.
+flagged_areas_section_title_default <- "% of These Residents Who Have This Feature or Area Type in (or Overlapping) Their Blockgroup"
+
 #' Create full demog subgroup/ language/ health/ community/ etc. HTML table of indicator rows
 #' @seealso used by [build_community_report()]
 #' @param output_df single row of results table from doaggregate or possibly ejamit(),
@@ -457,7 +464,9 @@ report_sections_page_break_before <- c(
 #'   to the US and State averages) is inserted just after the
 #'   "Climate" section (or after "Poverty" if there is no Climate section).
 #'   NULL (default) omits that section.
-#' @param flagged_areas_section_title title text for the flagged-areas section subheader row
+#' @param flagged_areas_section_title title text for the flagged-areas section subheader row.
+#'   Defaults to "% of These Residents Who Have This Feature or Area Type in
+#'   (or Overlapping) Their Blockgroup".
 #'
 #' @keywords internal
 #'
@@ -468,7 +477,7 @@ fill_tbl_full_subgroups <- function(output_df,
                                     extratable_show_ratios_in_report = TRUE,
                                     hide_missing_rows_for = names_d_language,
                                     flagged_areas_df = NULL,
-                                    flagged_areas_section_title = "% of These Residents Who Have This Feature or Area Type in (or Overlapping) Their Blockgroup"
+                                    flagged_areas_section_title = flagged_areas_section_title_default
                                     ## more params? ***
 ) {
 
@@ -643,7 +652,7 @@ fill_tbl_full_subgroups <- function(output_df,
 #' @noRd
 fill_tbl_flagged_areas_section <- function(flagged_areas_df,
                                            extratable_show_ratios_in_report = TRUE,
-                                           section_title = "% of These Residents Who Have This Feature or Area Type in (or Overlapping) Their Blockgroup") {
+                                           section_title = flagged_areas_section_title_default) {
 
   neededcols <- c("Indicator", "Percent_of_these_People")
   if (is.null(flagged_areas_df) || !is.data.frame(flagged_areas_df) ||

--- a/R/datasets_arrow_publish.R
+++ b/R/datasets_arrow_publish.R
@@ -22,8 +22,8 @@
 #' @param validate_arrow Logical. If `TRUE`, confirm files can be opened as
 #'   Arrow IPC files before publishing.
 #' @examples
-#'  fpaths <- file.path("data", paste0(EJAM:::.arrow_ds_names, ".arrow"))
 #'  \dontrun{
+#'  fpaths <- file.path("data", paste0(EJAM:::.arrow_ds_names, ".arrow"))
 #'
 #'  stopifnot(all(file.exists(fpaths)))
 #'  EJAM:::datasets_arrow_publish(

--- a/R/datasets_arrow_s3_download.R
+++ b/R/datasets_arrow_s3_download.R
@@ -3,8 +3,8 @@
 
 datasets_arrow_s3_download <- function(
 
-  yr = EJAM:::acs_endyear(guess_census_has_published = TRUE), # e.g., "2024"
-  files = paste0(EJAM:::.arrow_ds_names, ".arrow"),  # e.g.,  bgej.arrow
+  yr = acs_endyear(guess_census_has_published = TRUE), # e.g., "2024"
+  files = paste0(.arrow_ds_names, ".arrow"),  # e.g.,  bgej.arrow
   s3_root = "s3://pedp-data-preserved/ejscreen-data-processing/pipeline",
   local_root = file.path(getwd(), "data-raw", "pipeline_outputs"),
   aws_profile = Sys.getenv("AWS_PROFILE", unset = "")

--- a/R/ejamapi_local.R
+++ b/R/ejamapi_local.R
@@ -91,7 +91,7 @@ ejamapi_local <- function(
     # so it cannot do this itself; on the deployed API the Docker image bakes
     # the data in instead.
     if (!exists("blockwts", envir = globalenv())) dataload_dynamic("blockwts")
-    if (!EJAM:::localtree_exists()) indexblocks()
+    if (!localtree_exists()) indexblocks()
 
     if (requireNamespace("beepr", quietly = TRUE)) {
       beepr::beep() # alerts when finished with package loading and ready

--- a/R/plot_lorenz_popcount_by_site-DRAFT.R
+++ b/R/plot_lorenz_popcount_by_site-DRAFT.R
@@ -27,7 +27,7 @@ plot_lorenz_popcount_by_site <- function(bysite, radius) {
     # ggplot(aes(pop)) +
     ggplot2::ggplot(ggplot2::aes(x = pop, colour = "Demog Index State Percentile")) +
 
-    stat_lorenz(desc = TRUE) +  # from the gglorenz package, not in Imports or Suggests for now
+    gglorenz::stat_lorenz(desc = TRUE) +  # gglorenz is in Suggests; these draft plots are not exported
     ggplot2::coord_fixed() +
     ggplot2::geom_abline(linetype = "dashed") +
     ggplot2::theme_minimal() +
@@ -59,7 +59,7 @@ plot_lorenz_distance_by_dcount <- function(bybg_people, varname = NULL) {
   bysite |>
     ggplot2::ggplot(ggplot2::aes(x = distance_min_avgperson, n = pop * pctnhaa)) +
 
-    stat_lorenz(desc = TRUE) +    # from the gglorenz package, not in Imports or Suggests for now
+    gglorenz::stat_lorenz(desc = TRUE) +    # gglorenz is in Suggests; these draft plots are not exported
     ggplot2::coord_fixed() +
     ggplot2::geom_abline(linetype = "dashed") +
     ggplot2::theme_minimal() +

--- a/R/url_ejamapi.R
+++ b/R/url_ejamapi.R
@@ -114,7 +114,8 @@
 #'  x_links = url_ejamapi(pts2, as_html = TRUE, linktext = "Report")
 #'
 #'  \dontrun{
-#'  browseURL(paste0(url_package("api"), "/report?lat=33&lon=-112&buffer=4"))  # API base from DESCRIPTION
+#'  # API base comes from DESCRIPTION
+#'  browseURL(paste0(url_package("api"), "/report?lat=33&lon=-112&buffer=4"))
 #'
 #'  browseURL(x[1])
 #'  browseURL(y[1])

--- a/man/datasets_arrow_publish.Rd
+++ b/man/datasets_arrow_publish.Rd
@@ -56,8 +56,8 @@ repository release assets. Defaults are intentionally conservative: dry-run
 only, do not overwrite existing assets, and do not mark the release as latest.
 }
 \examples{
- fpaths <- file.path("data", paste0(EJAM:::.arrow_ds_names, ".arrow"))
  \dontrun{
+ fpaths <- file.path("data", paste0(EJAM:::.arrow_ds_names, ".arrow"))
 
  stopifnot(all(file.exists(fpaths)))
  EJAM:::datasets_arrow_publish(

--- a/man/fill_tbl_full_subgroups.Rd
+++ b/man/fill_tbl_full_subgroups.Rd
@@ -12,8 +12,7 @@ fill_tbl_full_subgroups(
   extratable_show_ratios_in_report = TRUE,
   hide_missing_rows_for = names_d_language,
   flagged_areas_df = NULL,
-  flagged_areas_section_title =
-    "\% of These Residents Who Have This Feature or Area Type in (or Overlapping) Their Blockgroup"
+  flagged_areas_section_title = flagged_areas_section_title_default
 )
 }
 \arguments{
@@ -40,7 +39,9 @@ to the US and State averages) is inserted just after the
 "Climate" section (or after "Poverty" if there is no Climate section).
 NULL (default) omits that section.}
 
-\item{flagged_areas_section_title}{title text for the flagged-areas section subheader row}
+\item{flagged_areas_section_title}{title text for the flagged-areas section subheader row.
+Defaults to "\% of These Residents Who Have This Feature or Area Type in
+(or Overlapping) Their Blockgroup".}
 }
 \description{
 Create full demog subgroup/ language/ health/ community/ etc. HTML table of indicator rows

--- a/man/url_ejamapi.Rd
+++ b/man/url_ejamapi.Rd
@@ -163,7 +163,8 @@ radius_donut_lower_edge).
  x_links = url_ejamapi(pts2, as_html = TRUE, linktext = "Report")
 
  \dontrun{
- browseURL(paste0(url_package("api"), "/report?lat=33&lon=-112&buffer=4"))  # API base from DESCRIPTION
+ # API base comes from DESCRIPTION
+ browseURL(paste0(url_package("api"), "/report?lat=33&lon=-112&buffer=4"))
 
  browseURL(x[1])
  browseURL(y[1])

--- a/tests/testthat/setup-shinytest2.R
+++ b/tests/testthat/setup-shinytest2.R
@@ -197,6 +197,21 @@ shinytest2_webapp_functionality <- function(test_category = "all") {
 
     testthat::skip_if_not_installed("shinytest2") # setup-shinytest2.R is sourced automatically by testthat, but shinytest2 itself is only needed for these web app tests
 
+    # These launch the whole app in a real browser and are slow and very
+    # environment-sensitive - waits like app$wait_for_idle(timeout = 5 * 1000)
+    # are tuned for the dedicated test-webapp-functionality.yaml runner, and a
+    # cold R CMD check machine cannot meet them. Left ungated they were the one
+    # ERROR failing R CMD check on every platform, with "An error occurred while
+    # waiting for Shiny to be stable".
+    #
+    # SHINYTEST2_APP_DRIVER_TEST_ON_CRAN is shinytest2's own opt-in variable and
+    # test-webapp-functionality.yaml already sets it to 1, so that workflow runs
+    # the full suite exactly as before. Nothing else sets it, so R CMD check now
+    # skips these instead of failing. Set it locally to run them by hand.
+    if (!ejam_shinytest2_truthy_env("SHINYTEST2_APP_DRIVER_TEST_ON_CRAN")) {
+      testthat::skip("shinytest2 app tests run only when SHINYTEST2_APP_DRIVER_TEST_ON_CRAN is set - see .github/workflows/test-webapp-functionality.yaml")
+    }
+
     test_log_dir <- file.path(tempdir(), "ejam-shinytest2-logs")
     dir.create(test_log_dir, recursive = TRUE, showWarnings = FALSE)
 


### PR DESCRIPTION
Takes `R CMD check` from **1 ERROR, 4 NOTEs** toward clean. Addresses the ERROR and three of the four NOTEs.

## The ERROR: shinytest2 — and a workflow that was testing nothing

`R CMD check` ran the full browser-driven app suite and died on *"An error occurred while waiting for Shiny to be stable"* — a `wait_for_idle(timeout = 5 * 1000)` that a cold check machine cannot meet. EJAM's wrapper had no CRAN or CI gate, only `skip_if_not_installed()`.

It now skips unless `SHINYTEST2_APP_DRIVER_TEST_ON_CRAN` is set — shinytest2's own opt-in variable, which `test-webapp-functionality.yaml` already sets.

**That alone would have traded a red check for no coverage at all**, because that workflow was not running these tests either. Every step filters to a `test-webapp-<category>-functionality.R` file; all of those call `shinytest2_webapp_functionality_individual()`, which skips unless `EJAM_SHINYTEST2_INDIVIDUAL` is set — and nothing set it. Run [31042164366](https://github.com/Public-Environmental-Data-Partners/EJAM/actions/runs/31042164366) logged *"Individual web app category tests are skipped by default"* while reporting success. Nine steps, all no-ops.

So this also sets `EJAM_SHINYTEST2_INDIVIDUAL: true` in that workflow. **Expect it to get slower and possibly go red** — these will be running for real, likely for the first time in a while. That is the point: green-because-skipped was worse.

## NOTE: `:::` calls to the package's own namespace

Dropped `EJAM:::` from `acs_endyear()`, `.arrow_ds_names`, and `localtree_exists()` in package code. Also moved an `@examples` line in `datasets_arrow_publish.R` inside its `\dontrun{}` — it referenced `EJAM:::.arrow_ds_names` and sat *outside* the block, so it was executing during checks.

## NOTE: no visible binding for global variable

Added the 24 data.table/dplyr NSE column names to the existing `globalVariables()` machinery, in their own vector so their provenance stays obvious.

**`stat_lorenz` is deliberately not declared.** It was in the same list, but it is a *function* from `gglorenz`, not a column — declaring it would have buried a genuinely undeclared dependency (the code comment even said *"not in Imports or Suggests for now"*). It is now `gglorenz::stat_lorenz()` with `gglorenz` added to Suggests, matching the fully-qualified style the rest of that draft file already uses.

## NOTE: Rd line widths

The 94-character flagged-areas heading was duplicated in two signatures and pushed `fill_tbl_full_subgroups.Rd`'s `\usage` past 90 characters. Now one internal constant used by both, with the literal recorded in `@param` so nothing is lost from the docs. Also split the over-long `url_ejamapi` example line.

Verified the constant is identical to the old literal and that **both** functions' defaults still resolve to it, so report output is unchanged.

## Not included

**NOTE: relative paths in package URLs** (~30 links across 11 vignettes). Left alone on purpose — those `../reference/index.html` links are *correct* on the pkgdown site and only look wrong to `R CMD check`, which inspects the built package. Fixing means either hardcoding the docs hostname, against the `url_package()` single-sourcing, or converting to `?topic` references that render differently on the site. Worth a decision, not a silent change.

**The four saved-results comparison failures are Windows-only and are not data drift** — see the PR discussion. Not touched here.