### PR TITLE
Point-shapefile upload: say what to do instead (part 1 of #550)

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -717,7 +717,10 @@ app_server <- function(input, output, session) {
       if (any(sf::st_geometry_type(shp) == "POINT")) {
         shp <- NULL
         disable_buttons[['SHP']] <- TRUE
-        msg <- "Shape file must be of polygon geometry."
+        ## the file is readable and EJAM can analyze it - just via the latlon upload option,
+        ## which has a usable radius slider (this one starts at minradius_shapefile = 0,
+        ## and points buffered by 0 miles would find no blocks). see issue #550
+        msg <- "This is a shapefile of points, not polygons. To analyze points with a buffer distance, choose 'Latitude/Longitude file upload' instead."
         cat(msg, "\n")
         shiny::validate(msg)
       }

--- a/R/shapefix.R
+++ b/R/shapefix.R
@@ -58,8 +58,10 @@ shapefix = function(shp,
   }
   if (any(sf::st_geometry_type(shp) == "POINT") && !interactive() && shiny::isRunning()) {
     disable_buttons_SHP <- TRUE
+    ## returned as an attribute, for app_server.R to show via shiny::validate() - there is no
+    ## non-shiny stop() path here, since this branch only runs when shiny::isRunning() is TRUE.
     ## keep this wording identical to the copy in app_server.R until the two are merged - see issue #550
-    validate_errmsg <- ("This is a shapefile of points, not polygons. To analyze points with a buffer distance, choose 'Latitude/Longitude file upload' instead.") # which does stop() if not in shiny
+    validate_errmsg <- "This is a shapefile of points, not polygons. To analyze points with a buffer distance, choose 'Latitude/Longitude file upload' instead."
   }
   # Drop Z and/or M dimensions from feature geometries, resetting classes appropriately
   shp <- sf::st_zm(shp)

--- a/R/shapefix.R
+++ b/R/shapefix.R
@@ -58,7 +58,8 @@ shapefix = function(shp,
   }
   if (any(sf::st_geometry_type(shp) == "POINT") && !interactive() && shiny::isRunning()) {
     disable_buttons_SHP <- TRUE
-    validate_errmsg <- ("Shape file must be of polygon geometry.") # which does stop() if not in shiny
+    ## keep this wording identical to the copy in app_server.R until the two are merged - see issue #550
+    validate_errmsg <- ("This is a shapefile of points, not polygons. To analyze points with a buffer distance, choose 'Latitude/Longitude file upload' instead.") # which does stop() if not in shiny
   }
   # Drop Z and/or M dimensions from feature geometries, resetting classes appropriately
   shp <- sf::st_zm(shp)


### PR DESCRIPTION
Addresses **Part 1 of #550** — the misleading error message. Part 2 (deduping the rule between `app_server.R` and `shapefix.R`) is deliberately not in scope here.

## The problem

Uploading a point shapefile to **"Shapefile of polygons file upload"** was rejected with:

> Shape file must be of polygon geometry.

That tells the user their file is invalid. **It isn't.** The file reads fine and EJAM can analyze it — just through the separate "Latitude/Longitude file upload" option, which has a working radius slider. The message named the constraint but not the remedy, so it was a dead end for anyone who didn't already know the lat/lon path existed.

This surfaces easily because `inst/testdata/shapes/stations.zip` is a **point** shapefile (86 POINT features) sitting in the same testdata folder as `portland_shp.zip` (98 MULTIPOLYGON) — easy to grab the wrong one and be confused by the result.

## The change

> This is a shapefile of points, not polygons. To analyze points with a buffer distance, choose "Latitude/Longitude file upload" instead.

**The rejection itself is unchanged and still correct.** The polygon path's slider starts at `minradius_shapefile = 0`, so points buffered by 0 miles would match no census blocks and return an empty analysis with no error at all. The guard is doing real work; only the wording was unhelpful. A comment at the `app_server.R` site records that reasoning so the next reader doesn't mistake the guard for over-restriction.

## Scope

Wording only — no behavior change, no new capability, 6 lines across 2 files.

Verified nothing asserted either string: `grep` across all `.R` and `.Rmd` found no test or vignette referencing the old message, and none referencing the new one, so no test updates are needed.

Both copies are kept **byte-identical** (verified) with a comment in `shapefix.R` saying to keep them that way until Part 2 merges them. `app_server.R:717` is the copy that actually fires — it calls `shiny::validate()`, which halts the reactive before `shapefix.R`'s copy is reached.

Leaves #550 open for Part 2.