### PR TITLE
Stop Windows checkouts from converting the EJAM-API mirror to CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,14 @@
 * text=auto
 *.sh text eol=lf
 *.bat text eol=crlf
+
+# inst/plumber/ejam-api/ is a byte-for-byte mirror of the EJAM-API repo (see its
+# SYNC.md), and a test compares it against EJAM-API main by raw bytes. Under
+# "* text=auto" above, Windows checkouts convert these to CRLF, so the installed
+# copy no longer matches the LF bytes fetched from GitHub and the drift test
+# fails on Windows only - reporting drift that does not exist. -text disables
+# all line-ending conversion, which is what "byte-for-byte" requires anyway.
+inst/plumber/ejam-api/** -text
 data-raw/pipeline_outputs/ejscreen_acs_2024/**/*.csv filter=lfs diff=lfs merge=lfs -text
 data-raw/pipeline_outputs/ejscreen_acs_2024/**/*.rds filter=lfs diff=lfs merge=lfs -text
 data-raw/pipeline_outputs/ejscreen_acs_2023/**/*.csv filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
`test-plumber-api.R:94` compares `inst/plumber/ejam-api/` against EJAM-API `main` by raw bytes, and it failed **on Windows only** in run [31066299571](https://github.com/Public-Environmental-Data-Partners/EJAM/actions/runs/31066299571). #548 recorded it as possible mirror drift.

**It is not drift.** I fetched all three mirrored files from EJAM-API `main` and compared:

| file | local | upstream | |
|---|---|---|---|
| `rest_controller.r` | 29748 B · `e9e2895a838f` | 29748 B · `e9e2895a838f` | identical |
| `query_pagination.R` | 2311 B · `f1e74d8464b4` | 2311 B · `f1e74d8464b4` | identical |
| `assets/communityreport.css` | 24165 B · `413ea9287f18` | 24165 B · `413ea9287f18` | identical |

Same SHA-256, same byte counts. The mirror is in sync.

## The actual cause

`.gitattributes` opens with `* text=auto`, which stores text as LF but converts to **native** endings on checkout. On a Windows runner that means CRLF in the working tree, CRLF in the installed package, and so `system.file()` returns CRLF bytes — while `download.file(mode = "wb")` fetches raw LF from GitHub. The comparison fails.

Unix checkouts do no conversion, which is exactly why ubuntu and macOS passed and only Windows failed.

## The fix

```
inst/plumber/ejam-api/** -text
```

`-text` disables line-ending conversion for that directory. That is not a workaround — it is what the byte-for-byte mirror contract in `inst/plumber/ejam-api/SYNC.md` requires. A file that git is free to rewrite on checkout cannot also be a byte-exact mirror.

**This fixes the test rather than skipping it.** It keeps running on every platform, including Windows, and will still catch genuine drift.

## Verified

- `git check-attr text` returns `unset` for all three mirrored files, and still `auto` for e.g. `R/app_server.R` — the rule is correctly scoped.
- `git add --renormalize inst/plumber/ejam-api/` produces **no change**, confirming the stored bytes are already LF and this only alters checkout behaviour.
- The mirror remains byte-identical to upstream after the change.

## Note for existing clones

CI checkouts are fresh, so this applies immediately there. A local clone that already has CRLF copies needs `git add --renormalize .` once.

EJAM-API itself was only read, never modified — and needs no change, since the problem was entirely on the EJAM side.

Addresses the `test-plumber-api.R` item in #548.