### PR TITLE
Give the point-geometry rule one home, in shapefix() (rest of #550)

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -711,25 +711,21 @@ app_server <- function(input, output, session) {
     #   ###################################### #
     # do the rest whether it was uploaded or came via ejamapp()
 
-    if (!is.null(shp)) {
-      # if shp contains point features, present message in app
-      ## this case is not caught by shapefile_from_any currently - but could use shapefix somehow? ***
-      if (any(sf::st_geometry_type(shp) == "POINT")) {
-        shp <- NULL
-        disable_buttons[['SHP']] <- TRUE
-        ## the file is readable and EJAM can analyze it - just via the latlon upload option,
-        ## which has a usable radius slider (this one starts at minradius_shapefile = 0,
-        ## and points buffered by 0 miles would find no blocks). see issue #550
-        msg <- "This is a shapefile of points, not polygons. To analyze points with a buffer distance, choose 'Latitude/Longitude file upload' instead."
-        cat(msg, "\n")
-        shiny::validate(msg)
-      }
-    }
-    # note that shapefile_from_any() returns some info in attributes of the returned object, like error messages and counts of valid points
-    if (!is.null(attr(shp, "validate_errmsg")))            {shiny::validate( attr(shp, "validate_errmsg") )}
-    if (!is.null(attr(shp, "disable_buttons_SHP")))        {disable_buttons[['SHP']]        <- attr(shp, "disable_buttons_SHP")}
+    ## shapefile_from_any() runs shapefix(), which inspects the geometry and reports what it
+    ## found via attributes on the returned object - including a point-geometry upload, which
+    ## this option does not accept (points-with-buffers is the latlon upload option instead).
+    ## The rule itself lives in shapefix() only; see ?shapefix and issue #550.
+    ##
+    ## Order matters here: shiny::validate() halts this reactive, so anything that must take
+    ## effect on a rejected upload has to be set BEFORE the validate() call, not after it.
     if (!is.null(attr(shp, "num_valid_pts_uploaded_SHP"))) {num_valid_pts_uploaded[['SHP']] <- attr(shp, "num_valid_pts_uploaded_SHP")}
     if (!is.null(attr(shp, "invalid_alert_SHP")))          {invalid_alert[['SHP']]          <- attr(shp, "invalid_alert_SHP")}
+    if (!is.null(attr(shp, "validate_errmsg"))) {
+      disable_buttons[['SHP']] <- TRUE # Start button disabled, and must stay disabled
+      cat(attr(shp, "validate_errmsg"), "\n") # for console / server log
+      shiny::validate( attr(shp, "validate_errmsg") )
+    }
+    if (!is.null(attr(shp, "disable_buttons_SHP")))        {disable_buttons[['SHP']]        <- attr(shp, "disable_buttons_SHP")}
     if ("sf" %in% class(shp)) {
       disable_buttons[['SHP']] <- FALSE # Start button enabled
     }

--- a/R/shapefile_xyz.R
+++ b/R/shapefile_xyz.R
@@ -94,8 +94,14 @@ shapefile_from_any <- function(path = NULL, cleanit = TRUE, crs = 4269, layer = 
     } else {
       path <- sf::st_transform(path, crs = crs)
     }
-    # path = shapefix(path) # also do here?
-    return(path) # input param called "path" actually was already a spatial object so just return it
+    ## shapefix() here too, not only on the file-reading path at the end of this function.
+    ## Callers already assume shapefile_from_any() always runs it - see ejamit(), which
+    ## expects the "valid"/"invalid_msg" columns, and app_server.R data_up_shp(), which
+    ## reads the findings from attributes. A supplied sf object used to skip it, so
+    ## ejamapp(shapefile = <sf points>) arrived with no findings attached and the Start
+    ## button was re-enabled instead of rejecting the upload. see issue #550
+    if (is.null(path)) {return(NULL)} # shapefile_clean() returns NULL when no rows were valid
+    return(shapefix(path)) # input param called "path" actually was already a spatial object
   }
 
   # if it is already just a regular nonspatial data.frame/data.table, try to convert it to spatial if it has lat/lon columns (but we want polygons not points for ejamit or server)

--- a/R/shapefile_xyz.R
+++ b/R/shapefile_xyz.R
@@ -100,8 +100,11 @@ shapefile_from_any <- function(path = NULL, cleanit = TRUE, crs = 4269, layer = 
     ## reads the findings from attributes. A supplied sf object used to skip it, so
     ## ejamapp(shapefile = <sf points>) arrived with no findings attached and the Start
     ## button was re-enabled instead of rejecting the upload. see issue #550
+    ## crs forwarded, because shapefix() st_transform()s to its own default of 4269 -
+    ## so calling it bare would undo the crs asked for just above. see the same call
+    ## at the end of this function.
     if (is.null(path)) {return(NULL)} # shapefile_clean() returns NULL when no rows were valid
-    return(shapefix(path)) # input param called "path" actually was already a spatial object
+    return(shapefix(path, crs = crs)) # input param called "path" actually was already a spatial object
   }
 
   # if it is already just a regular nonspatial data.frame/data.table, try to convert it to spatial if it has lat/lon columns (but we want polygons not points for ejamit or server)
@@ -218,7 +221,10 @@ shapefile_from_any <- function(path = NULL, cleanit = TRUE, crs = 4269, layer = 
     return(NULL)
   } else {
     return(
-      shapefix(x)
+      ## crs forwarded here for the same reason as on the sf path above: without it,
+      ## shapefix() transforms to its own default of 4269 and a caller asking for any
+      ## other crs silently got 4269 back, contradicting the @param crs contract.
+      shapefix(x, crs = crs)
     )
   }
 }

--- a/R/shapefix.R
+++ b/R/shapefix.R
@@ -30,12 +30,33 @@ if (1 == 0) {
 #' @description a way for app_server, and ejamit() via shapefile_from_any(),
 #'  to both use this one function to do the same thing
 #'  whether or not in a reactive context
+#'
+#' @details This function only *reports* problems - it never decides what to do about them.
+#'   Findings come back as attributes on the returned object, and each caller reacts as suits it:
+#'
+#'   - the **web app** (app_server.R) reads the attributes, shows `validate_errmsg` via
+#'     [shiny::validate()], and disables the Start button.
+#'   - **[ejamit()]**, via [shapefile_from_any()], ignores the attributes entirely.
+#'
+#'   That asymmetry is deliberate. Uploading points to the app's "Shapefile of polygons"
+#'   option is blocked, because that option's radius slider starts at `minradius_shapefile = 0`
+#'   and points buffered by 0 miles would find no blocks - the app has a separate
+#'   "Latitude/Longitude file upload" option for points-with-buffers. But an R user calling
+#'   `ejamit(shapefile = <points>, radius = 3)` supplies a real radius, so that works and is
+#'   not blocked here. See issue #550.
+#'
+#'   Because the decision belongs to the caller, this function deliberately does NOT test
+#'   [shiny::isRunning()]. An earlier version did, which meant the point-geometry check
+#'   silently did nothing in a locally launched app (where `interactive()` is TRUE).
+#'
 #' @param shp simple feature data.frame
 #' @param crs coordinate reference system, default is 4269
 #'
 #' @return returns all rows of shp, but adds columns "valid" and "invalid_msg"
 #'   and adds attributes shiny can use to update some reactives,
 #'   and standardizes "geometry" as the sfc column name.
+#'   Attributes set: `validate_errmsg`, `disable_buttons_SHP`,
+#'   `num_valid_pts_uploaded_SHP`, `invalid_alert_SHP`, `an_map_text_shp`.
 #'
 #' @keywords internal
 #'
@@ -50,17 +71,21 @@ shapefix = function(shp,
   ##  to both use this one function
   ##  to do the same thing whether or not in a reactive context.
 
-  validate_errmsg <- NULL
+  ## initialize every value that gets returned as an attribute, so that each branch below
+  ## only has to set what it actually changes, and no branch can leave one undefined.
+  validate_errmsg            <- NULL
+  disable_buttons_SHP        <- FALSE
+  num_valid_pts_uploaded_SHP <- 0
+  invalid_alert_SHP          <- 0
+  an_map_text_shp            <- NA
 
   if (is.null(shp)) {
     warning("Uploaded file should have valid file extension(s)")
     return(NULL)
   }
-  if (any(sf::st_geometry_type(shp) == "POINT") && !interactive() && shiny::isRunning()) {
+  ## points are reported, not rejected, here - the caller decides. see @details and issue #550
+  if (any(sf::st_geometry_type(shp) %in% c("POINT", "MULTIPOINT"))) {
     disable_buttons_SHP <- TRUE
-    ## returned as an attribute, for app_server.R to show via shiny::validate() - there is no
-    ## non-shiny stop() path here, since this branch only runs when shiny::isRunning() is TRUE.
-    ## keep this wording identical to the copy in app_server.R until the two are merged - see issue #550
     validate_errmsg <- "This is a shapefile of points, not polygons. To analyze points with a buffer distance, choose 'Latitude/Longitude file upload' instead."
   }
   # Drop Z and/or M dimensions from feature geometries, resetting classes appropriately
@@ -94,24 +119,33 @@ shapefix = function(shp,
     invalid_alert_SHP <- 0 # hides the invalid site warning
     an_map_text_shp <- HTML(NULL)  # hides the count of uploaded sites/shapes
     disable_buttons_SHP <- TRUE
-    ## return message if in shiny and do stop() if not in shiny
-    validate_errmsg <- ('No shapes found in file uploaded.')
+    validate_errmsg <- 'No shapes found in file uploaded.'
+    ## zero-length equivalents of what the nrow > 0 branch computes, so that the shared code
+    ## below works on an empty shapefile instead of failing on an undefined object. Without
+    ## these, shapefile with 0 shapes errored with "object 'shp_is_valid' not found" and the
+    ## message above was never reached. see issue #550
+    shp_valid_check <- data.frame(valid = logical(0), reason = character(0))
+    shp_is_valid    <- logical(0)
   }
   # "valid" flag added  ####
-  disable_buttons_SHP <- FALSE
   shp$valid <- shp_is_valid
 
   # "ejam_uniq_id" added ####
 
+  ## seq_len(), not 1:NROW(), so that 0 rows gives integer(0) rather than c(1, 0).
+  ## isTRUE(), because all.equal() returns a descriptive STRING (not FALSE) when unequal,
+  ## and !"some string" is an error - so this warning used to crash instead of warn.
   if (!("ejam_uniq_id" %in% names(shp))) {
-    shp <- cbind(ejam_uniq_id = 1:NROW(shp), shp)
+    shp <- cbind(ejam_uniq_id = seq_len(NROW(shp)), shp)
   } else {
-    if (!all.equal(1:NROW(shp), shp$ejam_uniq_id)) {
+    if (!isTRUE(all.equal(seq_len(NROW(shp)), shp$ejam_uniq_id))) {
       warning("ejam_uniq_id already is a column in the shapefile, but is not 1 through N. However, it will NOT be overwritten.")
     }
   }
   # "invalid_msg" added ####
-  shp$invalid_msg <- NA
+  ## rep(NA, NROW()), not a bare NA, so this also works when there are 0 rows
+  ## (assigning a length-1 value into a 0-row frame is an error). Identical for NROW >= 1.
+  shp$invalid_msg <- rep(NA, NROW(shp))
   shp$invalid_msg[shp$valid == F] <- shp_valid_check$reason[shp$valid == F]
   shp$invalid_msg[is.na(shp$geometry)] <- 'bad geometry'
 

--- a/man/shapefix.Rd
+++ b/man/shapefix.Rd
@@ -15,10 +15,32 @@ shapefix(shp, crs = 4269)
 returns all rows of shp, but adds columns "valid" and "invalid_msg"
 and adds attributes shiny can use to update some reactives,
 and standardizes "geometry" as the sfc column name.
+Attributes set: \code{validate_errmsg}, \code{disable_buttons_SHP},
+\code{num_valid_pts_uploaded_SHP}, \code{invalid_alert_SHP}, \code{an_map_text_shp}.
 }
 \description{
 a way for app_server, and ejamit() via shapefile_from_any(),
 to both use this one function to do the same thing
 whether or not in a reactive context
+}
+\details{
+This function only \emph{reports} problems - it never decides what to do about them.
+Findings come back as attributes on the returned object, and each caller reacts as suits it:
+\itemize{
+\item the \strong{web app} (app_server.R) reads the attributes, shows \code{validate_errmsg} via
+\code{\link[shiny:validate]{shiny::validate()}}, and disables the Start button.
+\item \strong{\code{\link[=ejamit]{ejamit()}}}, via \code{\link[=shapefile_from_any]{shapefile_from_any()}}, ignores the attributes entirely.
+}
+
+That asymmetry is deliberate. Uploading points to the app's "Shapefile of polygons"
+option is blocked, because that option's radius slider starts at \code{minradius_shapefile = 0}
+and points buffered by 0 miles would find no blocks - the app has a separate
+"Latitude/Longitude file upload" option for points-with-buffers. But an R user calling
+\verb{ejamit(shapefile = <points>, radius = 3)} supplies a real radius, so that works and is
+not blocked here. See issue #550.
+
+Because the decision belongs to the caller, this function deliberately does NOT test
+\code{\link[shiny:isRunning]{shiny::isRunning()}}. An earlier version did, which meant the point-geometry check
+silently did nothing in a locally launched app (where \code{interactive()} is TRUE).
 }
 \keyword{internal}

--- a/tests/testthat/test-shapefile_xyz.R
+++ b/tests/testthat/test-shapefile_xyz.R
@@ -519,4 +519,15 @@ test_that("shapefile_from_any() runs shapefix() on a supplied sf object too", {
   # same on the cleanit = TRUE branch, which reaches shapefix() via shapefile_clean()
   expect_true(grepl("shapefile of points",
                     attr(shapefile_from_any(pts, cleanit = TRUE, silentinteractive = TRUE), "validate_errmsg")))
+
+  # and shapefix() must not undo the requested crs: it st_transform()s to its own
+  # default of 4269, so calling it bare made any non-default crs silently come back
+  # as 4269 -- on the file path as well, where that was already true before this PR.
+  expect_equal(sf::st_crs(shapefile_from_any(poly, cleanit = FALSE, crs = 3857, silentinteractive = TRUE))$epsg, 3857L)
+  json_file <- system.file("testdata/shapes/portland.json", package = "EJAM")
+  junk <- capture.output(from_file <- suppressWarnings(
+    shapefile_from_any(json_file, cleanit = FALSE, crs = 3857, silentinteractive = TRUE)))
+  expect_equal(sf::st_crs(from_file)$epsg, 3857L)
+  # default is still 4269 on both paths
+  expect_equal(sf::st_crs(shapefile_from_any(poly, cleanit = FALSE, silentinteractive = TRUE))$epsg, 4269L)
 })

--- a/tests/testthat/test-shapefile_xyz.R
+++ b/tests/testthat/test-shapefile_xyz.R
@@ -494,3 +494,29 @@ test_that("shapefile_from_any() reads bare Feature/Polygon/MultiPolygon GeoJSON,
     expect_s3_class(shapefile_from_any(gj, cleanit = FALSE, silentinteractive = TRUE), "sf")
   }
 })
+
+test_that("shapefile_from_any() runs shapefix() on a supplied sf object too", {
+  # A supplied sf object took a fast-return path that skipped shapefix(), so a
+  # caller could not tell points from polygons: ejamapp(shapefile = <sf points>)
+  # arrived with no findings attached and app_server.R re-enabled Start. Both
+  # ejamit() and app_server.R assume this function always runs shapefix(). see issue #550
+  pts <- sf::st_as_sf(data.frame(lat = c(40.1, 40.2), lon = c(-74.1, -74.2)),
+                      coords = c("lon", "lat"), crs = 4269)
+  ring <- list(rbind(c(-74.1, 40.1), c(-74.0, 40.1), c(-74.0, 40.2), c(-74.1, 40.1)))
+  poly <- sf::st_as_sf(data.frame(id = 1L, geometry = sf::st_sfc(sf::st_polygon(ring), crs = 4269)))
+
+  pts_out <- shapefile_from_any(pts, cleanit = FALSE, silentinteractive = TRUE)
+  expect_true(grepl("shapefile of points", attr(pts_out, "validate_errmsg")))
+  expect_true(attr(pts_out, "disable_buttons_SHP"))
+
+  # polygons still pass, and get the columns ejamit() expects from shapefix()
+  poly_out <- shapefile_from_any(poly, cleanit = FALSE, silentinteractive = TRUE)
+  expect_null(attr(poly_out, "validate_errmsg"))
+  expect_false(attr(poly_out, "disable_buttons_SHP"))
+  expect_true(all(c("ejam_uniq_id", "valid", "invalid_msg") %in% names(poly_out)))
+  expect_s3_class(poly_out, "sf")
+
+  # same on the cleanit = TRUE branch, which reaches shapefix() via shapefile_clean()
+  expect_true(grepl("shapefile of points",
+                    attr(shapefile_from_any(pts, cleanit = TRUE, silentinteractive = TRUE), "validate_errmsg")))
+})

--- a/tests/testthat/test-shapefix.R
+++ b/tests/testthat/test-shapefix.R
@@ -10,3 +10,80 @@ testthat::test_that("shapefix(NULL) returns NULL without error", {
   )
   testthat::expect_null(result)
 })
+################################################################ #
+
+## helpers - read the packaged test shapefiles straight out of their .zip
+zipped_shp <- function(zipname, shpname) {
+  path <- system.file(file.path("testdata/shapes", zipname), package = "EJAM")
+  testthat::skip_if(path == "", paste("test file not found:", zipname))
+  sf::st_read(paste0("/vsizip/", path, "/", shpname), quiet = TRUE)
+}
+
+testthat::test_that("shapefix() flags POINT geometry but still returns the shapefile", {
+  ## stations.zip is a shapefile of 86 points - the app rejects it, ejamit() does not. see issue #550
+  pts <- zipped_shp("stations.zip", "stations.shp")
+  testthat::expect_true(all(sf::st_geometry_type(pts) == "POINT"))
+
+  result <- shapefix(pts)
+
+  ## reported via attributes ...
+  testthat::expect_match(attr(result, "validate_errmsg"), "points, not polygons")
+  testthat::expect_match(attr(result, "validate_errmsg"), "Latitude/Longitude file upload")
+  testthat::expect_true(attr(result, "disable_buttons_SHP"))
+  ## ... but NOT rejected here, so that ejamit(shapefile = <points>, radius = N) still works
+  testthat::expect_s3_class(result, "sf")
+  testthat::expect_equal(NROW(result), NROW(pts))
+})
+
+testthat::test_that("shapefix() also flags MULTIPOINT geometry", {
+  ## the check used to test only == "POINT", so MULTIPOINT slipped through
+  mp <- sf::st_sf(a = 1:2, geometry = sf::st_sfc(
+    sf::st_multipoint(matrix(c(0, 0, 1, 1), ncol = 2)),
+    sf::st_multipoint(matrix(c(2, 2, 3, 3), ncol = 2)), crs = 4269))
+
+  result <- shapefix(mp)
+
+  testthat::expect_match(attr(result, "validate_errmsg"), "points, not polygons")
+  testthat::expect_true(attr(result, "disable_buttons_SHP"))
+})
+
+testthat::test_that("shapefix() leaves polygons alone - no message, buttons enabled", {
+  poly <- zipped_shp("portland_shp.zip", "Neighborhoods_regions.shp")
+
+  result <- shapefix(poly)
+
+  testthat::expect_null(attr(result, "validate_errmsg"))
+  testthat::expect_false(attr(result, "disable_buttons_SHP"))
+  testthat::expect_equal(attr(result, "num_valid_pts_uploaded_SHP"), NROW(poly))
+  testthat::expect_equal(attr(result, "invalid_alert_SHP"), 0)
+  ## the columns shapefix() is responsible for adding
+  testthat::expect_true(all(c("ejam_uniq_id", "siteid", "valid", "invalid_msg") %in% names(result)))
+  testthat::expect_equal(result$ejam_uniq_id, seq_len(NROW(poly)))
+  testthat::expect_equal(attr(result, "sf_column"), "geometry")
+})
+
+testthat::test_that("shapefix() on a shapefile with 0 shapes reports it instead of erroring", {
+  ## used to fail with "object 'shp_is_valid' not found", so the message below was unreachable
+  empty <- sf::st_sf(a = character(0), geometry = sf::st_sfc(crs = 4269))
+
+  result <- shapefix(empty)
+
+  testthat::expect_s3_class(result, "sf")
+  testthat::expect_equal(NROW(result), 0)
+  testthat::expect_equal(attr(result, "validate_errmsg"), "No shapes found in file uploaded.")
+  testthat::expect_true(attr(result, "disable_buttons_SHP"))
+})
+
+testthat::test_that("shapefix() warns (not errors) when ejam_uniq_id is present but not 1:N", {
+  ## used to fail with "invalid argument type", because all.equal() returns a string, not FALSE
+  poly <- zipped_shp("portland_shp.zip", "Neighborhoods_regions.shp")[1:3, ]
+  poly$ejam_uniq_id <- c(99L, 98L, 97L)
+
+  result <- NULL
+  testthat::expect_warning(
+    result <- shapefix(poly),
+    regexp = "not 1 through N"
+  )
+  ## and the existing ids are kept, as the warning says
+  testthat::expect_equal(result$ejam_uniq_id, c(99L, 98L, 97L))
+})


### PR DESCRIPTION
Finishes Public-Environmental-Data-Partners/EJAM#550. Part 1 (Public-Environmental-Data-Partners/EJAM#552) reworded the message; this moves the rule itself into one place and fixes what consolidating it exposed.

## The trap this had to avoid

The obvious dedupe — delete the `app_server.R` copy, keep the one in `shapefix()` — would have **silently stopped rejecting point uploads in locally launched apps.**

`shapefix()`'s copy was gated on `!interactive() && shiny::isRunning()`. In a deployed app `interactive()` is FALSE so it fires, but when you run `ejamapp()` from RStudio `interactive()` is TRUE, so the gate is FALSE and that copy never ran. The `app_server.R` copy was the only thing protecting local sessions.

So instead of picking a copy, the responsibility is split: **`shapefix()` reports, the caller decides.** It always inspects the geometry and returns findings as attributes. The app shows the message and disables Start; `ejamit()` ignores the attributes, so `ejamit(shapefile = <points>, radius = 3)` still works. That asymmetry was already real but undocumented — it's now in `@details` instead of being implied by a shiny gate.

## Defects fixed along the way

All found by probing the function directly, and all confirmed before and after:

| defect | was | now |
|---|---|---|
| `disable_buttons_SHP` clobber | reset to `FALSE` immediately after both branches set it `TRUE`, undoing the point case and the empty-file case | initialized once at the top, only overwritten deliberately |
| shapefile with 0 shapes | **crashed** — `object 'shp_is_valid' not found`; the intended "No shapes found in file uploaded." was unreachable | reports the message |
| `shp$invalid_msg <- NA` on 0 rows | **crashed** — `replacement has 1 row, data has 0` | `rep(NA, NROW(shp))`, identical for `NROW >= 1` |
| `1:NROW(shp)` on 0 rows | gave `c(1, 0)` | `seq_len()` |
| `ejam_uniq_id` present but not 1:N | **crashed** — `invalid argument type`, because `all.equal()` returns a descriptive *string*, not `FALSE` | warns, as intended |
| MULTIPOINT geometry | not caught (`== "POINT"` only) | `%in% c("POINT", "MULTIPOINT")` |

The two crashes are the kind of low-level console error that Public-Environmental-Data-Partners/EJAM#136 is about, though this does not close that issue.

## One ordering fix in app_server.R

`shiny::validate()` halts the reactive, so anything that must take effect on a rejected upload has to be set *before* it. The Start button state was previously being set after a `validate()` call that would skip it. Attributes are now applied first, then `validate()`.

## Verification

- **Polygon happy path is byte-identical before vs after** — same columns in the same order, same crs, same attribute values, checked by A/B probe against the pre-change code
- **shinytest2 `shp-zip` app test passes end to end** (uploads `portland_shp.zip`, runs the analysis) — this is the suite that actually exercises the `app_server.R` change
- `test-shapefix.R` 23 pass (5 new tests), `test-shapefile_xyz.R` 96 pass
- also green: `ejam2shapefile`, `get_blockpoints_in_shape`, `latlon_from_shapefile`, `shape2geojson`, `shape2zip`, `shapes_from_fips`
- the 2 warnings in `test-shape2geojson.R` are pre-existing — confirmed by running that file against `development`

New tests cover point geometry, MULTIPOINT, polygons, the 0-shape file, and the non-1:N `ejam_uniq_id` warning. `test-shapefix.R` was already registered in `R/test_ejam.R`, so no change needed there.

Closes Public-Environmental-Data-Partners/EJAM#550 — though per the branching model the keyword only fires on the eventual `development` → `main` sync, so the issue stays open until then.
