### PR TITLE
Move browseURL examples from donttest to dontrun

### DIFF
--- a/R/NAICS_FUNCTIONS.R
+++ b/R/NAICS_FUNCTIONS.R
@@ -350,7 +350,7 @@ naics_url_of_code <- function(naics) {
 #'  # browseURL(naics_from_any("copper smelting", website_url=TRUE) )
 #'
 #'   url_naics.com("copper smelting")
-#'   \donttest{
+#'   \dontrun{
 #'   naics_findwebscrape("copper smelting")
 #'   browseURL(url_naics.com("copper smelting"))
 #'   browseURL(naics_url_of_code(326))

--- a/R/URL_FUNCTIONS_part2.R
+++ b/R/URL_FUNCTIONS_part2.R
@@ -79,7 +79,7 @@
 #' @seealso  [url_ejamapi()]  [url_ejscreenmap()]
 #'   [url_echo_facility()] [url_frs_facility()]  [url_enviromapper()]
 #' @return URL(s)
-#' @examples  \donttest{
+#' @examples  \dontrun{
 #'  browseURL(url_echo_facility(110070874073))
 #'  }
 #'
@@ -151,7 +151,7 @@ url_echo_facility <- function(regid = NULL,
 #' @return URL(s)
 #' @examples
 #' x = url_frs_facility(testinput_regid)
-#' \donttest{
+#' \dontrun{
 #' browseURL(x[1])
 #' }
 #' url_frs_facility(testinput_registry_id)

--- a/R/utils_locate_by_id.R
+++ b/R/utils_locate_by_id.R
@@ -37,7 +37,7 @@
 #' @return vector of URLs as strings, same length as id parameter
 #' @examples
 #' EJAM:::url_by_id(testinput_regid)
-#' \donttest{
+#' \dontrun{
 #' browseURL(EJAM:::url_by_id(testinput_regid)[1])
 #'
 #' urlx = EJAM:::url_by_id(testinput_regid[1])

--- a/man/naics_findwebscrape.Rd
+++ b/man/naics_findwebscrape.Rd
@@ -22,7 +22,7 @@ but this looks at naics.com website which lists various aliases for a sector.
  # browseURL(naics_from_any("copper smelting", website_url=TRUE) )
 
   url_naics.com("copper smelting")
-  \donttest{
+  \dontrun{
   naics_findwebscrape("copper smelting")
   browseURL(url_naics.com("copper smelting"))
   browseURL(naics_url_of_code(326))

--- a/man/url_by_id.Rd
+++ b/man/url_by_id.Rd
@@ -47,7 +47,7 @@ https://frs-public.epa.gov/ords/frs_public2/frs_rest_services.get_facilities?reg
 }
 \examples{
 EJAM:::url_by_id(testinput_regid)
-\donttest{
+\dontrun{
 browseURL(EJAM:::url_by_id(testinput_regid)[1])
 
 urlx = EJAM:::url_by_id(testinput_regid[1])

--- a/man/url_echo_facility.Rd
+++ b/man/url_echo_facility.Rd
@@ -41,7 +41,7 @@ Get URL(s) for EPA ECHO webpage with facility information
 Additional details...
 }
 \examples{
- \donttest{
+ \dontrun{
  browseURL(url_echo_facility(110070874073))
  }
 

--- a/man/url_frs_facility.Rd
+++ b/man/url_frs_facility.Rd
@@ -40,7 +40,7 @@ Get URL(s) for reports on facilities from EPA FRS (facility registry service)
 }
 \examples{
 x = url_frs_facility(testinput_regid)
-\donttest{
+\dontrun{
 browseURL(x[1])
 }
 url_frs_facility(testinput_registry_id)


### PR DESCRIPTION
`R CMD check` runs `\donttest{}` examples under `--as-cran`, so four examples that open a browser or hit the network were failing on a headless runner. On macOS this was the **only remaining ERROR** in run [31491603711](https://github.com/Public-Environmental-Data-Partners/EJAM/actions/runs/31491603711):

```
> ### Name: url_by_id
> browseURL(EJAM:::url_by_id(testinput_regid)[1])
```

`\donttest{}` means *"correct but slow to run"*. Opening a browser is never runnable in CI, so these belong in `\dontrun{}`. Same fix #549 applied to the API-key examples — and because example checking **halts at the first error**, those two were hiding these four.

| function | what was inside the block |
|---|---|
| `url_by_id` | `browseURL` + `xml2::read_xml()` against the FRS API |
| `url_echo_facility` | `browseURL` only |
| `url_frs_facility` | `browseURL` only |
| `naics_findwebscrape` | `browseURL` ×2 + a live naics.com scrape |

## Nothing runnable was lost

Every line inside the four blocks needs a browser or the network — I checked each rather than blanket-converting. The runnable lines *outside* those blocks are untouched and still execute:

```r
x = url_frs_facility(testinput_regid)      # still runs
url_frs_facility(testinput_registry_id)    # still runs
url_naics.com("copper smelting")           # still runs
```

## Verified

- `tools::Rd2ex()` on all four Rd files: **no `browseURL` survives into executable examples**.
- The four remaining executable lines all **run offline** — they only build URL strings. Confirmed by executing each.
- A package-wide sweep finds **no `browseURL` left inside any `\donttest{}` block**, so there is no fifth one waiting behind these.

## Expected effect

macOS was at `Status: 1 ERROR, 1 NOTE` with `FAIL 0`. This removes the ERROR, which should put it at **0 ERRORs, 1 NOTE** — the NOTE being the deliberately deferred `checking relative paths in package URLs`.

Linux and Windows have separate outstanding items, tracked in #555 (macOS-specific saved-results fixtures), #557 (the CRLF mirror fix), and the NAICS scrape failures noted on #548.