### PR TITLE
Skip, don't fail, NAICS scrape tests when naics.com won't answer

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -307,7 +307,13 @@ bad_numbers <- list(
 skip_if_naics_web_unavailable <- function(scraped) {
 
   if (!is.data.frame(scraped) || nrow(scraped) == 0) {
-    testthat::skip("naics.com returned no search results (bot mitigation, or the site changed)")
+    testthat::skip(paste(
+      "naics.com returned no search results, so it is blocking or failing for this runner.",
+      "Blocking is intermittent: it hits some jobs some of the time.",
+      "If instead this skip shows up on every platform on every run, suspect the scraper,",
+      "not the runner - check that the '.first_child a' selector in naics_findwebscrape()",
+      "still matches the page. See Public-Environmental-Data-Partners/EJAM#560"
+    ))
   }
   invisible(scraped)
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -306,7 +306,17 @@ bad_numbers <- list(
 
 skip_if_naics_web_unavailable <- function(scraped) {
 
-  if (!is.data.frame(scraped) || nrow(scraped) == 0) {
+  # Only the known symptom gets a skip. Anything else - NULL, a list, some other
+  # type - is a scraper regression rather than naics.com blocking a runner, and
+  # skipping it would hide exactly what we want to hear about.
+  if (!is.data.frame(scraped)) {
+    testthat::fail(paste0(
+      "naics_findwebscrape() returned ", class(scraped)[1], ", not a data.frame. ",
+      "That is a scraper regression, not naics.com blocking this runner."
+    ))
+    return(invisible(scraped))
+  }
+  if (nrow(scraped) == 0) {
     testthat::skip(paste(
       "naics.com returned no search results, so it is blocking or failing for this runner.",
       "Blocking is intermittent: it hits some jobs some of the time.",

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -287,6 +287,32 @@ bad_numbers <- list(
 # rm(x)
 ############################### ################################ #
 
+# helper for tests that scrape naics.com ####
+
+# naics.com sits behind bot mitigation that sometimes serves the search page to a
+# CI runner without any search results in it. rvest::read_html() still succeeds,
+# but the ".first_child a" elements are not there, so naics_findwebscrape() hands
+# back a 0-row data.frame with no error and no warning, and any test that checks
+# the contents then fails for a reason that has nothing to do with EJAM.
+#
+# Seen in R CMD check run 31491603711 (2026-08-11): ubuntu-latest release and
+# oldrel-1 failed these while macOS, Windows, and ubuntu-latest devel passed the
+# very same commit, and the same queries return full results from a laptop.
+# See Public-Environmental-Data-Partners/EJAM#560
+#
+# Every query guarded this way has a known, non-empty answer, so 0 rows means the
+# site did not answer, not that the query found nothing. Skip in that case, so a
+# blocked runner does not turn into a red check.
+
+skip_if_naics_web_unavailable <- function(scraped) {
+
+  if (!is.data.frame(scraped) || nrow(scraped) == 0) {
+    testthat::skip("naics.com returned no search results (bot mitigation, or the site changed)")
+  }
+  invisible(scraped)
+}
+############################### ################################ #
+
 # helpers to check map functions ####
 
 # these 2 got used in some test files:

--- a/tests/testthat/test-frs_from_naics.R
+++ b/tests/testthat/test-frs_from_naics.R
@@ -10,9 +10,14 @@
 # website_scrape = TRUE does work however, since it grabs a data frame with the column 'code'
 # the code is stirng instead of numeric, but that doesn't seem to matter to regid_from_naics (in latlon_from_naics.R)
 
-test_that('website_url and website_scrape cause errors',{
+test_that('website_url causes an error',{
   expect_error( expect_warning({  val <- frs_from_naics(21112, website_url = TRUE)})) # "crude petroleum"
-  skip_if(offline()) # website_scrape = TRUE reaches naics.com
+  })
+
+# website_scrape = TRUE reaches naics.com, so it is its own test and stays covered
+# offline only for the website_url case above
+test_that('website_scrape does not cause an error',{
+  skip_if(offline())
   expect_no_error({val <- frs_from_naics(21112, website_scrape = TRUE)}) # "crude petroleum"
   })
 

--- a/tests/testthat/test-frs_from_naics.R
+++ b/tests/testthat/test-frs_from_naics.R
@@ -12,15 +12,24 @@
 
 test_that('website_url and website_scrape cause errors',{
   expect_error( expect_warning({  val <- frs_from_naics(21112, website_url = TRUE)})) # "crude petroleum"
+  skip_if(offline()) # website_scrape = TRUE reaches naics.com
   expect_no_error({val <- frs_from_naics(21112, website_scrape = TRUE)}) # "crude petroleum"
   })
 
 # however, even using naics_from_any gave an error that the function naics_url_of_query does not exist
 # after renaming this to naics_url_of_code, it worked successfully (in script naics_url_of_code.R)
-test_that('naics_from_any URL and scrape lookup works', {
+test_that('naics_from_any URL lookup works', {
   expect_equal(naics_from_any("crude petroleum")$code, c(21112, 211120))
   expect_equal(naics_from_any(21112, website_url = TRUE), "https://www.naics.com/six-digit-naics/?v=2017&code=21112")
-  expect_equal(naics_from_any(21112, website_scrape = TRUE),
+  })
+
+# The scrape needs naics.com to actually answer, so it is its own test and gets
+# skipped, not failed, when the site does not. See skip_if_naics_web_unavailable() in setup.R
+test_that('naics_from_any scrape lookup works', {
+  skip_if(offline())
+  scraped <- naics_from_any(21112, website_scrape = TRUE)
+  skip_if_naics_web_unavailable(scraped)
+  expect_equal(scraped,
                data.frame("code" = "211120", "name" = "Crude Petroleum Extraction"))
   })
 

--- a/tests/testthat/test-naics_findwebscrape.R
+++ b/tests/testthat/test-naics_findwebscrape.R
@@ -13,6 +13,7 @@ test_that('the function works for naics codes (numeric or string) and query text
   expect_no_warning({
     val <- naics_findwebscrape(212221)
     })
+  skip_if_naics_web_unavailable(val)
   expect_true(212221 %in% val$code)
 })
 
@@ -29,6 +30,7 @@ test_that('you can filter the results of webscrape', {
   skip_if(offline())
   query = "gold mining"
   expect_no_warning({val <- naics_findwebscrape(query)})
+  skip_if_naics_web_unavailable(val)
 
   query_split = strsplit(query, " ")
   query_mod = paste0(unlist(query_split), collapse = ".*")

--- a/tests/testthat/test-naics_from_any.R
+++ b/tests/testthat/test-naics_from_any.R
@@ -9,11 +9,21 @@
 # after renaming this to naics_url_of_code in the naics_from_any function (& sourcing it)
 # it worked successfully (naics_url_of_code is in script naics_url_of_code.R)
 
-test_that('naics_from_any() -- URL and scrape lookup works', {
+test_that('naics_from_any() -- URL lookup works', {
 
   expect_equal(naics_from_any("crude petroleum")$code, c(21112, 211120))
   expect_equal(naics_from_any(21112, website_url = TRUE), "https://www.naics.com/six-digit-naics/?v=2017&code=21112")
-  expect_equal(naics_from_any(21112, website_scrape = TRUE),
+
+  })
+
+# The scrape needs naics.com to actually answer, so it is its own test and gets
+# skipped, not failed, when the site does not. See skip_if_naics_web_unavailable() in setup.R
+test_that('naics_from_any() -- scrape lookup works', {
+
+  skip_if(offline())
+  scraped <- naics_from_any(21112, website_scrape = TRUE)
+  skip_if_naics_web_unavailable(scraped)
+  expect_equal(scraped,
                data.frame("code" = "211120", "name" = "Crude Petroleum Extraction"))
 
   })


### PR DESCRIPTION
Fixes the four NAICS web-scrape test failures in [R CMD check run 31491603711](https://github.com/Public-Environmental-Data-Partners/EJAM/actions/runs/31491603711).

## Not an upstream site change

The same commit passed these four tests on macOS, on Windows, and on `ubuntu-latest (devel)` — only `ubuntu-latest (release)` and `ubuntu-latest (oldrel-1)` failed them, with the same SKIP count (35) everywhere so nothing was skipped instead of run. And the scrape works today: `.first_child a` still returns 102 elements starting `212221` / `Gold Ore Mining`, on repeated rapid requests including with no `User-Agent`.

naics.com is behind Cloudflare bot mitigation that intermittently serves a CI runner the search page **without the results in it**. The response is still HTTP 200 and still parses, so `rvest::read_html()` does not error, the selector matches nothing, and `naics_findwebscrape()` returns a 0-row data.frame with no error and no warning. That is why the `expect_no_warning()` wrappers all passed and only the content assertions failed.

## Change

Every query in these tests has a known non-empty answer, so 0 rows means the site did not answer — not that the query found nothing.

- `tests/testthat/setup.R` — new `skip_if_naics_web_unavailable()`, called after the scrape in the four affected tests.
- `test-naics_from_any.R`, `test-frs_from_naics.R` — the scrape assertions move into their own `test_that()` blocks guarded by `skip_if(offline())`. They previously had **no** offline guard at all, so they would have failed outright with no network, and a naics.com outage took the offline-safe assertions in the same block down with them.

No package code changes, so no `R/test_ejam.R` update is needed (no test file added or renamed).

## Verified locally, both directions

| | result |
|---|---|
| site answering | 61 expectations pass, **0 failed, 0 skipped** |
| `naics_findwebscrape()` stubbed to return 0 rows | **0 failed**, exactly those 4 tests skip, everything else still passes |

## Left out on purpose

`naics_findwebscrape()` still cannot tell a caller "the site did not answer" apart from "nothing matched your query" — both are a silent 0-row data.frame. A `warning()` there would surface it to users, not just tests, but the tests wrap these calls in `expect_no_warning()` and changing an exported function's behavior is a separate decision. Noted in the issue.

Closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)