### PR TITLE
chore: refresh open issue ranking report

### DIFF
--- a/inst/issues/ejam_issues_scored_by_risk_and_value.MD
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.MD
@@ -1,6 +1,6 @@
 # EJAM Open Issues — Scored by Cost & Benefit
 
-**Total open issues:** 132  |  **Generated:** 2026-08-02  |  **Source:** Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)
+**Total open issues:** 136  |  **Generated:** 2026-08-11  |  **Source:** Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)
 
 **Score payload:** `inst/issues/ejam_issues_scored_by_risk_and_value.json`
 
@@ -12,9 +12,9 @@
 
 | Metric | Value |
 |--------|-------|
-| Previous run | 2026-07-27 |
-| Issues opened since previous run | 0 |
-| Issues closed since previous run | 0 |
+| Previous run | 2026-08-02 |
+| Issues opened since previous run | 7 |
+| Issues closed since previous run | 3 |
 | Issues whose quadrant changed | 2 |
 
 ---
@@ -23,8 +23,8 @@
 
 | Cost / Benefit | **LOW Benefit**<br>value < median | **HIGH Benefit**<br>value ≥ median |
 |---|---|---|
-| **LOW Cost**<br>cost < median | **C — Other Low-Cost Work**<br>41 issues | **A — Focus Shortlist (max 20)**<br>20 issues |
-| **HIGH Cost**<br>cost ≥ median | **D — WORST CANDIDATES**<br>24 issues | **B — OK Candidates**<br>47 issues |
+| **LOW Cost**<br>cost < median | **C — Other Low-Cost Work**<br>38 issues | **A — Focus Shortlist (max 20)**<br>20 issues |
+| **HIGH Cost**<br>cost ≥ median | **D — WORST CANDIDATES**<br>29 issues | **B — OK Candidates**<br>49 issues |
 
 ---
 
@@ -41,8 +41,6 @@
 - [#342](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342) — use renv package to create lock state for what versions of what packages are used
 - [#341](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341) — Align map_headernames and/or generated avg/pctile/ratio metadata with columns doaggregate() can produce for the report
 - [#400](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400) — improve how webapp users can find info on data vintage (in EJAM web app UI, from community report, and from EJScreen UI)
-- [#344](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344) — Show an example of a community report - e.g., in or linked from "basics" vignette
-- [#249](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/249) — ejam2report() fails if filename is specified without path, or with "./xyz.html"
 - [#137](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/137) — fix bug in popshare_at_top_x_pct() - results sometimes not quite right. seems to interpolate badly.
 - [#268](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/268) — Uploading a file was failing intermittently when live app hosted using AWS with load balancing
 - [#73](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73) — in web app, add ways to analyze multiple radii at once or even continuous radius
@@ -53,6 +51,8 @@
 - [#119](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/119) — some code assumes RStudio user is in root folder of source package - check & warn/document, or fix
 - [#91](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/91) — Excel needs new tab with uploaded places or facilities found
 - [#161](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161) — ejamapp() should be able to handle mix of fips types
+- [#162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) — rename "in_how_many_states"   column  in table of results
+- [#136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) — in web app, fix console  error msg when uploading a shapefile
 
 | # | Issue | Cost | Benefit | Milestone | Priority | Labels (key) |
 |---|-------|------|---------|-----------|----------|--------------|
@@ -64,8 +64,6 @@
 | [342](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342) | use renv package to create lock state for what versions of what packag… | 3 (🔵 Low) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | help wanted, Affects Web App, rank:A-high-value-low-cost |
 | [341](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341) | Align map_headernames and/or generated avg/pctile/ratio metadata with … | 3 (🔵 Low) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | Affects Web App, Community Report, rank:A-high-value-low-cost |
 | [400](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400) | improve how webapp users can find info on data vintage (in EJAM web ap… | 3 (🔵 Low) | 13 (🟩🟩 Very High) | NA | PRIORITY HIGH | Affects Web App, rank:A-high-value-low-cost |
-| [344](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344) | Show an example of a community report - e.g., in or linked from "basic… | 2 (🔵 Low) | 12 (🟩🟦 High) | v4 | PRIORITY HIGH-ish but not a bug | documentation, help wanted, good first issue, rank:A-high-value-low-cost |
-| [249](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/249) | ejam2report() fails if filename is specified without path, or with "./… | 2 (🔵 Low) | 12 (🟩🟦 High) | v3.2022.2 | PRIORITY LOW | BUG, Affects R users only - NOT web app users, rank:A-high-value-low-cost |
 | [137](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/137) | fix bug in popshare_at_top_x_pct() - results sometimes not quite right… | 1 (🟢 Very Low) | 11 (🟩🟦 High) | v4 | PRIORITY MEDIUM | BUG, Affects Web App, rank:A-high-value-low-cost |
 | [268](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/268) | Uploading a file was failing intermittently when live app hosted using… | 2 (🔵 Low) | 11 (🟩🟦 High) | NA | — | BUG, Affects Web App |
 | [73](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73) | in web app, add ways to analyze multiple radii at once or even continu… | 3 (🔵 Low) | 10 (🟩🟦 High) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
@@ -76,13 +74,15 @@
 | [119](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/119) | some code assumes RStudio user is in root folder of source package - c… | 2 (🔵 Low) | 8 (🟦 Medium) | NA | PRIORITY LOW | BUG, Affects R users only - NOT web app users, rank:A-high-value-low-cost |
 | [91](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/91) | Excel needs new tab with uploaded places or facilities found | 2 (🔵 Low) | 8 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
 | [161](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161) | ejamapp() should be able to handle mix of fips types | 0 (🟢 Very Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
+| [162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) | rename "in_how_many_states"   column  in table of results | 1 (🟢 Very Low) | 7 (🟦 Medium) | v4 | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
+| [136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | in web app, fix console  error msg when uploading a shapefile | 1 (🟢 Very Low) | 7 (🟦 Medium) | v4 | PRIORITY LOW | BUG, rank:A-high-value-low-cost |
 
 ---
 
 ## Quadrant B — OK Candidates — High Cost, High Benefit
 *Worth doing but require more effort or expertise. Plan carefully before starting.*
 
-**47 issues**
+**49 issues**
 
 - [#293](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/293) — API takes too long to create a community report from when user clicks
 - [#513](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/513) — need better ETA estimates (predicted seconds to completion are too high)
@@ -94,11 +94,13 @@
 - [#193](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/193) — Create Executive Summary helper functions - summarizer / Methods for Identifying and Focusing on Key Findings
 - [#68](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/68) — allow user to type in radius not only use slider
 - [#46](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46) — Long Report text needed
+- [#555](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/555) — Saved-results fixtures are macOS-specific: the 4 comparisons fail on Linux and Windows
 - [#527](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/527) — shapes_from_fips() errors offline even when the county boundary is built into the package
 - [#126](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126) — enable 1-site report on Polygons / Shapefile, via links/buttons in shiny map popups and table of sites (but NOT outside shiny like in URL-based/link in Excel table)
 - [#279](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279) — Prepare the package to submit to CRAN (and get it accepted for hosting on CRAN)
 - [#87](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/87) — Enable shiny.telemetry log file that is not just a text file on server
 - [#31](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31) — fix distance_avg in doaggregate()$results_bybg_people
+- [#553](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/553) — plot_lorenz_*() draft plots are broken: undefined bysite, filter on a literal, constant aes mapping
 - [#56](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/56) — check/ fix Distance and Site Count summary stats, in doaggregate()
 - [#135](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135) — finish work in progress on default_ss_choose_method  vs input$ ?
 - [#19](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/19) — FIPS missing/problems (mostly in Connecticut)
@@ -144,11 +146,13 @@
 | [193](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/193) | Create Executive Summary helper functions - summarizer / Methods for I… | 5 (🟡 Medium) | 15 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | LongReport_output, Affects Web App, future plan list, rank:B-high-value-high-cost |
 | [68](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/68) | allow user to type in radius not only use slider | 4 (🟡 Medium) | 13 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | rank:B-high-value-high-cost |
 | [46](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46) | Long Report text needed | 8 (🟠 High) | 13 (🟩🟩 Very High) | NA | PRIORITY HIGH-ish but not a bug | LongReport_output, future plan list, rank:B-high-value-high-cost |
+| [555](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/555) | Saved-results fixtures are macOS-specific: the 4 comparisons fail on L… | 4 (🟡 Medium) | 12 (🟩🟦 High) | NA | PRIORITY MEDIUM | BUG, test |
 | [527](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/527) | shapes_from_fips() errors offline even when the county boundary is bui… | 4 (🟡 Medium) | 11 (🟩🟦 High) | v4 | PRIORITY MEDIUM | BUG, test, Affects R users only - NOT web app users |
 | [126](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126) | enable 1-site report on Polygons / Shapefile, via links/buttons in shi… | 4 (🟡 Medium) | 11 (🟩🟦 High) | NA | PRIORITY MEDIUM | Affects Web App, API, rank:B-high-value-high-cost |
 | [279](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279) | Prepare the package to submit to CRAN (and get it accepted for hosting… | 5 (🟡 Medium) | 10 (🟩🟦 High) | NA | PRIORITY MEDIUM | help wanted, Affects R users only - NOT web app users, rank:B-high-value-high-cost |
 | [87](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/87) | Enable shiny.telemetry log file that is not just a text file on server | 6 (🟡 Medium) | 10 (🟩🟦 High) | NA | PRIORITY MEDIUM | datasets-related, Affects Web App, rank:B-high-value-high-cost |
 | [31](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31) | fix distance_avg in doaggregate()$results_bybg_people | 4 (🟡 Medium) | 9 (🟩🟦 High) | NA | PRIORITY MEDIUM | BUG, distance-related, rank:B-high-value-high-cost |
+| [553](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/553) | plot_lorenz_*() draft plots are broken: undefined bysite, filter on a … | 6 (🟡 Medium) | 9 (🟩🟦 High) | NA | PRIORITY LOW | BUG |
 | [56](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/56) | check/ fix Distance and Site Count summary stats, in doaggregate() | 6 (🟡 Medium) | 9 (🟩🟦 High) | NA | PRIORITY MEDIUM | BUG, documentation, calculate/validate to EJScreen, distance-related |
 | [135](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135) | finish work in progress on default_ss_choose_method  vs input$ ? | 4 (🟡 Medium) | 8 (🟦 Medium) | NA | PRIORITY LOW | BUG, Affects R users only - NOT web app users, rank:B-high-value-high-cost |
 | [19](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/19) | FIPS missing/problems (mostly in Connecticut) | 6 (🟡 Medium) | 8 (🟦 Medium) | Data Updates | PRIORITY MEDIUM | BUG, help wanted, maps-related, datasets-related |
@@ -187,14 +191,11 @@
 ## Quadrant C — OTHER LOW-COST WORK
 *Cheap to do but not in the current focus shortlist. Pick these up when bandwidth allows or combine them with nearby work.*
 
-**41 issues**
+**38 issues**
 
 - [#490](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490) — swap us and state ratio columns
 - [#361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) — Add date and time of last updated to help with deploys
 - [#163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) — put certain columns last in table of results (bg count, block count, radius)
-- [#162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) — rename "in_how_many_states"   column  in table of results
-- [#136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) — in web app, fix console  error msg when uploading a shapefile
-- [#288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) — ratio of 1.0 should not be yellow on community report
 - [#70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) — set up alerts that monitor and alert staff when the app goes down - ensure available
 - [#484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) — in overall table, change EJAM Report link for 1-site analysis
 - [#486](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486) — allow zip code analysis in EJAM shiny web app
@@ -236,9 +237,6 @@
 | [490](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490) | swap us and state ratio columns | 1 (🟢 Very Low) | 7 (🟦 Medium) | v4 | PRIORITY MEDIUM | Affects Web App, Community Report |
 | [361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) | Add date and time of last updated to help with deploys | 1 (🟢 Very Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
 | [163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) | put certain columns last in table of results (bg count, block count, r… | 1 (🟢 Very Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
-| [162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) | rename "in_how_many_states"   column  in table of results | 1 (🟢 Very Low) | 7 (🟦 Medium) | v4 | PRIORITY MEDIUM | Affects Web App, rank:A-high-value-low-cost |
-| [136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | in web app, fix console  error msg when uploading a shapefile | 1 (🟢 Very Low) | 7 (🟦 Medium) | v4 | PRIORITY LOW | BUG, rank:A-high-value-low-cost |
-| [288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) | ratio of 1.0 should not be yellow on community report | 2 (🔵 Low) | 7 (🟦 Medium) | v3.2022.2 | PRIORITY MEDIUM | Affects Web App, Community Report, rank:A-high-value-low-cost |
 | [70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) | set up alerts that monitor and alert staff when the app goes down - en… | 2 (🔵 Low) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | rank:A-high-value-low-cost |
 | [484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) | in overall table, change EJAM Report link for 1-site analysis | 3 (🔵 Low) | 7 (🟦 Medium) | v4 | PRIORITY MEDIUM | Affects Web App |
 | [486](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486) | allow zip code analysis in EJAM shiny web app | 1 (🟢 Very Low) | 6 (🟦 Medium) | v4 | PRIORITY LOW | Affects Web App |
@@ -280,17 +278,21 @@
 ## Quadrant D — WORST CANDIDATES — High Cost, Low Benefit
 *Expensive to fix, limited payoff. Defer or deprioritize unless circumstances change.*
 
-**24 issues**
+**29 issues**
 
+- [#560](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/560) — Four NAICS web-scrape tests fail when naics.com blocks a CI runner (seen on Linux)
 - [#508](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/508) — ECR lifecycle policy: prune accumulating dev images (without touching prod)
 - [#507](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/507) — deploy-dev: encode the deployed EJAM version in the dev ECR image tag
 - [#182](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/182) — consider refactoring url_xyz functions
 - [#89](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/89) — clarify what "N places" really means & report on the selection type (in summary report etc.)
 - [#536](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/536) — redo list of URLs in url_package() documentation
 - [#35](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/35) — Review/revise/expand unit testing for URL functions
+- [#546](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/546) — count_sites_with_n_high_scores() ratio default still 1.01, inconsistent with the 1.05 yellow cutoff from #369
 - [#62](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/62) — Enable download of 'Plot of Average Scores' and 'Plot Full Range of Scores' plots
 - [#61](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/61) — downloading excel output with plots for 1000-2000 points takes 10-15 seconds
 - [#55](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/55) — add links to COUNTY-LEVEL reports - on a place - from other tools/ sources
+- [#548](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/548) — R CMD check has 2 ERRORs on macOS and Windows, exposed by #530
+- [#547](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/547) — Define color-coding cutoffs once, as adjustable parameters (design half of #288)
 - [#497](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/497) — refactor / clean up rounding of numbers
 - [#86](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/86) — Fix (or remove?) references to ejampackages data object
 - [#53](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/53) — for proximity score creation tool, resolve how to apply short distances formula (continuous or abrupt)
@@ -300,6 +302,7 @@
 - [#27](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/27) — ability to save/load/bookmark static report settings (and other parameters) -- need to clarify, clean, harmonize, edit documentation
 - [#446](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/446) — Cache/precompute FIPS-based reports and boundaries (layered design: bounds, ejamit results, rendered reports)
 - [#18](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/18) — some FIPS-related functions/data could be improved
+- [#550](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/550) — Point-shapefile upload: make the error message actionable, and dedupe the rule between app_server.R and shapefix.R
 - [#95](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/95) — in map_headernames, consider adding info re: in which tables/ popups/ xls/ etc. should given indicator be included
 - [#29](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/29) — add info about zero results/ zero pop & near other sites, to EJAM::doaggregate() outputs (as already provided by EJAMejscreenapi::ejscreenapi() output)
 - [#387](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/387) — Refactor so 1 release can use any vintage of datasets specified (at load time or per analysis etc)
@@ -309,15 +312,19 @@
 
 | # | Issue | Cost | Benefit | Milestone | Priority | Labels (key) |
 |---|-------|------|---------|-----------|----------|--------------|
+| [560](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/560) | Four NAICS web-scrape tests fail when naics.com blocks a CI runner (se… | 4 (🟡 Medium) | 4 (⬜ Low) | NA | — |  |
 | [508](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/508) | ECR lifecycle policy: prune accumulating dev images (without touching … | 4 (🟡 Medium) | 4 (⬜ Low) | NA | PRIORITY MEDIUM |  |
 | [507](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/507) | deploy-dev: encode the deployed EJAM version in the dev ECR image tag | 4 (🟡 Medium) | 4 (⬜ Low) | NA | PRIORITY MEDIUM |  |
 | [182](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/182) | consider refactoring url_xyz functions | 4 (🟡 Medium) | 4 (⬜ Low) | NA | PRIORITY LOW | refactor, Affects R users only - NOT web app users, rank:D-defer |
 | [89](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/89) | clarify what "N places" really means & report on the selection type (i… | 4 (🟡 Medium) | 4 (⬜ Low) | NA | PRIORITY LOW | still relevant?, Affects Web App, rank:D-defer |
 | [536](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/536) | redo list of URLs in url_package() documentation | 4 (🟡 Medium) | 2 (⬜ Low) | NA | PRIORITY LOW | documentation, refactor, Affects R users only - NOT web app users |
 | [35](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/35) | Review/revise/expand unit testing for URL functions | 4 (🟡 Medium) | 2 (⬜ Low) | NA | PRIORITY LOW | test, URL-related, rank:D-defer |
+| [546](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/546) | count_sites_with_n_high_scores() ratio default still 1.01, inconsisten… | 4 (🟡 Medium) | 1 (⬜ Very Low) | v4 | PRIORITY LOW | LongReport_output |
 | [62](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/62) | Enable download of 'Plot of Average Scores' and 'Plot Full Range of Sc… | 4 (🟡 Medium) | 1 (⬜ Very Low) | NA | PRIORITY LOW | still relevant?, plots-graphs-related, rank:D-defer |
 | [61](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/61) | downloading excel output with plots for 1000-2000 points takes 10-15 s… | 4 (🟡 Medium) | 1 (⬜ Very Low) | NA | PRIORITY LOW | still relevant?, rank:D-defer |
 | [55](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/55) | add links to COUNTY-LEVEL reports - on a place - from other tools/ sou… | 4 (🟡 Medium) | 1 (⬜ Very Low) | NA | PRIORITY LOW | still relevant?, rank:D-defer |
+| [548](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/548) | R CMD check has 2 ERRORs on macOS and Windows, exposed by #530 | 4 (🟡 Medium) | 0 (⬜ Very Low) | v4 | — |  |
+| [547](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/547) | Define color-coding cutoffs once, as adjustable parameters (design hal… | 6 (🟡 Medium) | 4 (⬜ Low) | v4 | PRIORITY MEDIUM | refactor, Community Report |
 | [497](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/497) | refactor / clean up rounding of numbers | 6 (🟡 Medium) | 4 (⬜ Low) | NA | PRIORITY LOW | refactor, Affects R users only - NOT web app users |
 | [86](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/86) | Fix (or remove?) references to ejampackages data object | 6 (🟡 Medium) | 4 (⬜ Low) | NA | PRIORITY LOW | still relevant?, refactor, Affects R users only - NOT web app users, rank:B-high-value-high-cost |
 | [53](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/53) | for proximity score creation tool, resolve how to apply short distance… | 6 (🟡 Medium) | 2 (⬜ Low) | NA | PRIORITY LOW | calculate/validate to EJScreen, distance-related, rank:D-defer |
@@ -327,6 +334,7 @@
 | [27](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/27) | ability to save/load/bookmark static report settings (and other parame… | 7 (🟠 High) | 3 (⬜ Low) | NA | PRIORITY MEDIUM | documentation, refactor, server, Community Report |
 | [446](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/446) | Cache/precompute FIPS-based reports and boundaries (layered design: bo… | 7 (🟠 High) | 2 (⬜ Low) | NA | — | speed / performance (see #226), API |
 | [18](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/18) | some FIPS-related functions/data could be improved | 7 (🟠 High) | 0 (⬜ Very Low) | NA | — | datasets-related, rank:D-defer |
+| [550](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/550) | Point-shapefile upload: make the error message actionable, and dedupe … | 8 (🟠 High) | 4 (⬜ Low) | v4 | PRIORITY LOW | shapefile-related, refactor, Affects Web App |
 | [95](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/95) | in map_headernames, consider adding info re: in which tables/ popups/ … | 8 (🟠 High) | 4 (⬜ Low) | NA | PRIORITY LOW | map-popups-related, still relevant?, datasets-related, Affects R users only - NOT web app users |
 | [29](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/29) | add info about zero results/ zero pop & near other sites, to EJAM::doa… | 8 (🟠 High) | 3 (⬜ Low) | NA | PRIORITY LOW | still relevant?, refactor, rank:D-defer |
 | [387](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/387) | Refactor so 1 release can use any vintage of datasets specified (at lo… | 8 (🟠 High) | 1 (⬜ Very Low) | NA | PRIORITY LOW | refactor, rank:D-defer |
@@ -336,7 +344,7 @@
 
 ---
 
-## Full Table — All 132 Issues
+## Full Table — All 136 Issues
 
 Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 
@@ -350,8 +358,6 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | A | [342](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/342) | 3 | 15 | NA | PRIORITY HIGH-ish but not a bug | use renv package to create lock state for what versions of what packages… |
 | A | [341](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/341) | 3 | 15 | NA | PRIORITY HIGH-ish but not a bug | Align map_headernames and/or generated avg/pctile/ratio metadata with co… |
 | A | [400](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400) | 3 | 13 | NA | PRIORITY HIGH | improve how webapp users can find info on data vintage (in EJAM web app … |
-| A | [344](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344) | 2 | 12 | v4 | PRIORITY HIGH-ish but not a bug | Show an example of a community report - e.g., in or linked from "basics"… |
-| A | [249](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/249) | 2 | 12 | v3.2022.2 | PRIORITY LOW | ejam2report() fails if filename is specified without path, or with "./xy… |
 | A | [137](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/137) | 1 | 11 | v4 | PRIORITY MEDIUM | fix bug in popshare_at_top_x_pct() - results sometimes not quite right. … |
 | A | [268](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/268) | 2 | 11 | NA | — | Uploading a file was failing intermittently when live app hosted using A… |
 | A | [73](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/73) | 3 | 10 | NA | PRIORITY MEDIUM | in web app, add ways to analyze multiple radii at once or even continuou… |
@@ -362,6 +368,8 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | A | [119](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/119) | 2 | 8 | NA | PRIORITY LOW | some code assumes RStudio user is in root folder of source package - che… |
 | A | [91](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/91) | 2 | 8 | NA | PRIORITY MEDIUM | Excel needs new tab with uploaded places or facilities found |
 | A | [161](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161) | 0 | 7 | NA | PRIORITY MEDIUM | ejamapp() should be able to handle mix of fips types |
+| A | [162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) | 1 | 7 | v4 | PRIORITY MEDIUM | rename "in_how_many_states"   column  in table of results |
+| A | [136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | 1 | 7 | v4 | PRIORITY LOW | in web app, fix console  error msg when uploading a shapefile |
 | B | [293](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/293) | 5 | 19 | v4 | PRIORITY HIGH-ish but not a bug | API takes too long to create a community report from when user clicks |
 | B | [513](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/513) | 6 | 17 | v4 | PRIORITY HIGH | need better ETA estimates (predicted seconds to completion are too high) |
 | B | [52](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/52) | 8 | 17 | NA | PRIORITY HIGH-ish but not a bug | Create density score /proximity score/ count-nearby functions, then prov… |
@@ -372,11 +380,13 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | B | [193](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/193) | 5 | 15 | NA | PRIORITY HIGH-ish but not a bug | Create Executive Summary helper functions - summarizer / Methods for Ide… |
 | B | [68](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/68) | 4 | 13 | NA | PRIORITY HIGH-ish but not a bug | allow user to type in radius not only use slider |
 | B | [46](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46) | 8 | 13 | NA | PRIORITY HIGH-ish but not a bug | Long Report text needed |
+| B | [555](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/555) | 4 | 12 | NA | PRIORITY MEDIUM | Saved-results fixtures are macOS-specific: the 4 comparisons fail on Lin… |
 | B | [527](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/527) | 4 | 11 | v4 | PRIORITY MEDIUM | shapes_from_fips() errors offline even when the county boundary is built… |
 | B | [126](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126) | 4 | 11 | NA | PRIORITY MEDIUM | enable 1-site report on Polygons / Shapefile, via links/buttons in shiny… |
 | B | [279](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279) | 5 | 10 | NA | PRIORITY MEDIUM | Prepare the package to submit to CRAN (and get it accepted for hosting o… |
 | B | [87](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/87) | 6 | 10 | NA | PRIORITY MEDIUM | Enable shiny.telemetry log file that is not just a text file on server |
 | B | [31](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31) | 4 | 9 | NA | PRIORITY MEDIUM | fix distance_avg in doaggregate()$results_bybg_people |
+| B | [553](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/553) | 6 | 9 | NA | PRIORITY LOW | plot_lorenz_*() draft plots are broken: undefined bysite, filter on a li… |
 | B | [56](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/56) | 6 | 9 | NA | PRIORITY MEDIUM | check/ fix Distance and Site Count summary stats, in doaggregate() |
 | B | [135](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135) | 4 | 8 | NA | PRIORITY LOW | finish work in progress on default_ss_choose_method  vs input$ ? |
 | B | [19](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/19) | 6 | 8 | Data Updates | PRIORITY MEDIUM | FIPS missing/problems (mostly in Connecticut) |
@@ -412,9 +422,6 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | C | [490](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490) | 1 | 7 | v4 | PRIORITY MEDIUM | swap us and state ratio columns |
 | C | [361](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361) | 1 | 7 | NA | PRIORITY MEDIUM | Add date and time of last updated to help with deploys |
 | C | [163](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163) | 1 | 7 | NA | PRIORITY MEDIUM | put certain columns last in table of results (bg count, block count, rad… |
-| C | [162](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162) | 1 | 7 | v4 | PRIORITY MEDIUM | rename "in_how_many_states"   column  in table of results |
-| C | [136](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136) | 1 | 7 | v4 | PRIORITY LOW | in web app, fix console  error msg when uploading a shapefile |
-| C | [288](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288) | 2 | 7 | v3.2022.2 | PRIORITY MEDIUM | ratio of 1.0 should not be yellow on community report |
 | C | [70](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70) | 2 | 7 | NA | PRIORITY MEDIUM | set up alerts that monitor and alert staff when the app goes down - ensu… |
 | C | [484](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/484) | 3 | 7 | v4 | PRIORITY MEDIUM | in overall table, change EJAM Report link for 1-site analysis |
 | C | [486](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/486) | 1 | 6 | v4 | PRIORITY LOW | allow zip code analysis in EJAM shiny web app |
@@ -450,15 +457,19 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | C | [343](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/343) | 1 | 0 | NA | — | check/loosen/drop minimum required version of each package specified in … |
 | C | [42](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/42) | 1 | 0 | NA | PRIORITY LOW | Remove unused report template files |
 | C | [60](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60) | 3 | 0 | NA | PRIORITY LOW | Rename community report functions with common convention |
+| D | [560](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/560) | 4 | 4 | NA | — | Four NAICS web-scrape tests fail when naics.com blocks a CI runner (seen… |
 | D | [508](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/508) | 4 | 4 | NA | PRIORITY MEDIUM | ECR lifecycle policy: prune accumulating dev images (without touching pr… |
 | D | [507](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/507) | 4 | 4 | NA | PRIORITY MEDIUM | deploy-dev: encode the deployed EJAM version in the dev ECR image tag |
 | D | [182](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/182) | 4 | 4 | NA | PRIORITY LOW | consider refactoring url_xyz functions |
 | D | [89](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/89) | 4 | 4 | NA | PRIORITY LOW | clarify what "N places" really means & report on the selection type (in … |
 | D | [536](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/536) | 4 | 2 | NA | PRIORITY LOW | redo list of URLs in url_package() documentation |
 | D | [35](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/35) | 4 | 2 | NA | PRIORITY LOW | Review/revise/expand unit testing for URL functions |
+| D | [546](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/546) | 4 | 1 | v4 | PRIORITY LOW | count_sites_with_n_high_scores() ratio default still 1.01, inconsistent … |
 | D | [62](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/62) | 4 | 1 | NA | PRIORITY LOW | Enable download of 'Plot of Average Scores' and 'Plot Full Range of Scor… |
 | D | [61](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/61) | 4 | 1 | NA | PRIORITY LOW | downloading excel output with plots for 1000-2000 points takes 10-15 sec… |
 | D | [55](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/55) | 4 | 1 | NA | PRIORITY LOW | add links to COUNTY-LEVEL reports - on a place - from other tools/ sourc… |
+| D | [548](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/548) | 4 | 0 | v4 | — | R CMD check has 2 ERRORs on macOS and Windows, exposed by #530 |
+| D | [547](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/547) | 6 | 4 | v4 | PRIORITY MEDIUM | Define color-coding cutoffs once, as adjustable parameters (design half … |
 | D | [497](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/497) | 6 | 4 | NA | PRIORITY LOW | refactor / clean up rounding of numbers |
 | D | [86](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/86) | 6 | 4 | NA | PRIORITY LOW | Fix (or remove?) references to ejampackages data object |
 | D | [53](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/53) | 6 | 2 | NA | PRIORITY LOW | for proximity score creation tool, resolve how to apply short distances … |
@@ -468,6 +479,7 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | D | [27](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/27) | 7 | 3 | NA | PRIORITY MEDIUM | ability to save/load/bookmark static report settings (and other paramete… |
 | D | [446](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/446) | 7 | 2 | NA | — | Cache/precompute FIPS-based reports and boundaries (layered design: boun… |
 | D | [18](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/18) | 7 | 0 | NA | — | some FIPS-related functions/data could be improved |
+| D | [550](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/550) | 8 | 4 | v4 | PRIORITY LOW | Point-shapefile upload: make the error message actionable, and dedupe th… |
 | D | [95](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/95) | 8 | 4 | NA | PRIORITY LOW | in map_headernames, consider adding info re: in which tables/ popups/ xl… |
 | D | [29](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/29) | 8 | 3 | NA | PRIORITY LOW | add info about zero results/ zero pop & near other sites, to EJAM::doagg… |
 | D | [387](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/387) | 8 | 1 | NA | PRIORITY LOW | Refactor so 1 release can use any vintage of datasets specified (at load… |
@@ -482,9 +494,8 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | Milestone | Issue count |
 |-----------|------------:|
 | Data Updates | 1 |
-| v3.2022.2 | 2 |
-| v4 | 19 |
-| NA | 110 |
+| v4 | 22 |
+| NA | 113 |
 
 ---
 

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.MD
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.MD
@@ -99,10 +99,10 @@
 - [#126](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126) — enable 1-site report on Polygons / Shapefile, via links/buttons in shiny map popups and table of sites (but NOT outside shiny like in URL-based/link in Excel table)
 - [#279](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279) — Prepare the package to submit to CRAN (and get it accepted for hosting on CRAN)
 - [#87](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/87) — Enable shiny.telemetry log file that is not just a text file on server
-- [#31](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31) — fix distance_avg in doaggregate()$results_bybg_people
+- [#31](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31) — fix distance_avg in doaggregate()\$results_bybg_people
 - [#553](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/553) — plot_lorenz_*() draft plots are broken: undefined bysite, filter on a literal, constant aes mapping
 - [#56](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/56) — check/ fix Distance and Site Count summary stats, in doaggregate()
-- [#135](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135) — finish work in progress on default_ss_choose_method  vs input$ ?
+- [#135](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135) — finish work in progress on default_ss_choose_method  vs input\$ ?
 - [#19](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/19) — FIPS missing/problems (mostly in Connecticut)
 - [#511](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/511) — CI runs only on PRs into main: development and deploy PRs get no checks at all
 - [#510](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/510) — Smoke-test PDF generation in the built image and after deploy (prod PDF broke undetected)
@@ -151,10 +151,10 @@
 | [126](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126) | enable 1-site report on Polygons / Shapefile, via links/buttons in shi… | 4 (🟡 Medium) | 11 (🟩🟦 High) | NA | PRIORITY MEDIUM | Affects Web App, API, rank:B-high-value-high-cost |
 | [279](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279) | Prepare the package to submit to CRAN (and get it accepted for hosting… | 5 (🟡 Medium) | 10 (🟩🟦 High) | NA | PRIORITY MEDIUM | help wanted, Affects R users only - NOT web app users, rank:B-high-value-high-cost |
 | [87](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/87) | Enable shiny.telemetry log file that is not just a text file on server | 6 (🟡 Medium) | 10 (🟩🟦 High) | NA | PRIORITY MEDIUM | datasets-related, Affects Web App, rank:B-high-value-high-cost |
-| [31](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31) | fix distance_avg in doaggregate()$results_bybg_people | 4 (🟡 Medium) | 9 (🟩🟦 High) | NA | PRIORITY MEDIUM | BUG, distance-related, rank:B-high-value-high-cost |
+| [31](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31) | fix distance_avg in doaggregate()\$results_bybg_people | 4 (🟡 Medium) | 9 (🟩🟦 High) | NA | PRIORITY MEDIUM | BUG, distance-related, rank:B-high-value-high-cost |
 | [553](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/553) | plot_lorenz_*() draft plots are broken: undefined bysite, filter on a … | 6 (🟡 Medium) | 9 (🟩🟦 High) | NA | PRIORITY LOW | BUG |
 | [56](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/56) | check/ fix Distance and Site Count summary stats, in doaggregate() | 6 (🟡 Medium) | 9 (🟩🟦 High) | NA | PRIORITY MEDIUM | BUG, documentation, calculate/validate to EJScreen, distance-related |
-| [135](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135) | finish work in progress on default_ss_choose_method  vs input$ ? | 4 (🟡 Medium) | 8 (🟦 Medium) | NA | PRIORITY LOW | BUG, Affects R users only - NOT web app users, rank:B-high-value-high-cost |
+| [135](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135) | finish work in progress on default_ss_choose_method  vs input\$ ? | 4 (🟡 Medium) | 8 (🟦 Medium) | NA | PRIORITY LOW | BUG, Affects R users only - NOT web app users, rank:B-high-value-high-cost |
 | [19](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/19) | FIPS missing/problems (mostly in Connecticut) | 6 (🟡 Medium) | 8 (🟦 Medium) | Data Updates | PRIORITY MEDIUM | BUG, help wanted, maps-related, datasets-related |
 | [511](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/511) | CI runs only on PRs into main: development and deploy PRs get no check… | 4 (🟡 Medium) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | test, Affects Web App |
 | [510](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/510) | Smoke-test PDF generation in the built image and after deploy (prod PD… | 4 (🟡 Medium) | 7 (🟦 Medium) | NA | PRIORITY MEDIUM | test, Affects Web App |
@@ -385,10 +385,10 @@ Sorted: A first (best), then B, C, D; within each group by benefit DESC.
 | B | [126](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/126) | 4 | 11 | NA | PRIORITY MEDIUM | enable 1-site report on Polygons / Shapefile, via links/buttons in shiny… |
 | B | [279](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/279) | 5 | 10 | NA | PRIORITY MEDIUM | Prepare the package to submit to CRAN (and get it accepted for hosting o… |
 | B | [87](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/87) | 6 | 10 | NA | PRIORITY MEDIUM | Enable shiny.telemetry log file that is not just a text file on server |
-| B | [31](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31) | 4 | 9 | NA | PRIORITY MEDIUM | fix distance_avg in doaggregate()$results_bybg_people |
+| B | [31](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31) | 4 | 9 | NA | PRIORITY MEDIUM | fix distance_avg in doaggregate()\$results_bybg_people |
 | B | [553](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/553) | 6 | 9 | NA | PRIORITY LOW | plot_lorenz_*() draft plots are broken: undefined bysite, filter on a li… |
 | B | [56](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/56) | 6 | 9 | NA | PRIORITY MEDIUM | check/ fix Distance and Site Count summary stats, in doaggregate() |
-| B | [135](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135) | 4 | 8 | NA | PRIORITY LOW | finish work in progress on default_ss_choose_method  vs input$ ? |
+| B | [135](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135) | 4 | 8 | NA | PRIORITY LOW | finish work in progress on default_ss_choose_method  vs input\$ ? |
 | B | [19](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/19) | 6 | 8 | Data Updates | PRIORITY MEDIUM | FIPS missing/problems (mostly in Connecticut) |
 | B | [511](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/511) | 4 | 7 | NA | PRIORITY MEDIUM | CI runs only on PRs into main: development and deploy PRs get no checks … |
 | B | [510](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/510) | 4 | 7 | NA | PRIORITY MEDIUM | Smoke-test PDF generation in the built image and after deploy (prod PDF … |

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.html
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.html
@@ -978,9 +978,40 @@ server</td>
 <tr>
 <td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31">31</a></td>
-<td>fix distance_avg in doaggregate()<span
-class="math inline"><em>r</em><em>e</em><em>s</em><em>u</em><em>l</em><em>t</em><em>s</em><sub><em>b</em></sub><em>y</em><em>b</em><em>g</em><sub><em>p</em></sub><em>e</em><em>o</em><em>p</em><em>l</em><em>e</em>|4(🟡<em>M</em><em>e</em><em>d</em><em>i</em><em>u</em><em>m</em>)|9(🟩🟦<em>H</em><em>i</em><em>g</em><em>h</em>)|<em>N</em><em>A</em>|<em>P</em><em>R</em><em>I</em><em>O</em><em>R</em><em>I</em><em>T</em><em>Y</em><em>M</em><em>E</em><em>D</em><em>I</em><em>U</em><em>M</em>|<em>B</em><em>U</em><em>G</em>, <em>d</em><em>i</em><em>s</em><em>t</em><em>a</em><em>n</em><em>c</em><em>e</em> − <em>r</em><em>e</em><em>l</em><em>a</em><em>t</em><em>e</em><em>d</em>, <em>r</em><em>a</em><em>n</em><em>k</em> : <em>B</em> − <em>h</em><em>i</em><em>g</em><em>h</em> − <em>v</em><em>a</em><em>l</em><em>u</em><em>e</em> − <em>h</em><em>i</em><em>g</em><em>h</em> − <em>c</em><em>o</em><em>s</em><em>t</em>||[553](<em>h</em><em>t</em><em>t</em><em>p</em><em>s</em> : //<em>g</em><em>i</em><em>t</em><em>h</em><em>u</em><em>b</em>.<em>c</em><em>o</em><em>m</em>/<em>P</em><em>u</em><em>b</em><em>l</em><em>i</em><em>c</em> − <em>E</em><em>n</em><em>v</em><em>i</em><em>r</em><em>o</em><em>n</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>l</em> − <em>D</em><em>a</em><em>t</em><em>a</em> − <em>P</em><em>a</em><em>r</em><em>t</em><em>n</em><em>e</em><em>r</em><em>s</em>/<em>E</em><em>J</em><em>A</em><em>M</em>/<em>i</em><em>s</em><em>s</em><em>u</em><em>e</em><em>s</em>/553)|<em>p</em><em>l</em><em>o</em><em>t</em><sub><em>l</em></sub><em>o</em><em>r</em><em>e</em><em>n</em><em>z</em><sub>*</sub>()<em>d</em><em>r</em><em>a</em><em>f</em><em>t</em><em>p</em><em>l</em><em>o</em><em>t</em><em>s</em><em>a</em><em>r</em><em>e</em><em>b</em><em>r</em><em>o</em><em>k</em><em>e</em><em>n</em> : <em>u</em><em>n</em><em>d</em><em>e</em><em>f</em><em>i</em><em>n</em><em>e</em><em>d</em><em>b</em><em>y</em><em>s</em><em>i</em><em>t</em><em>e</em>, <em>f</em><em>i</em><em>l</em><em>t</em><em>e</em><em>r</em><em>o</em><em>n</em><em>a</em>…|6(🟡<em>M</em><em>e</em><em>d</em><em>i</em><em>u</em><em>m</em>)|9(🟩🟦<em>H</em><em>i</em><em>g</em><em>h</em>)|<em>N</em><em>A</em>|<em>P</em><em>R</em><em>I</em><em>O</em><em>R</em><em>I</em><em>T</em><em>Y</em><em>L</em><em>O</em><em>W</em>|<em>B</em><em>U</em><em>G</em>||[56](<em>h</em><em>t</em><em>t</em><em>p</em><em>s</em> : //<em>g</em><em>i</em><em>t</em><em>h</em><em>u</em><em>b</em>.<em>c</em><em>o</em><em>m</em>/<em>P</em><em>u</em><em>b</em><em>l</em><em>i</em><em>c</em> − <em>E</em><em>n</em><em>v</em><em>i</em><em>r</em><em>o</em><em>n</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>l</em> − <em>D</em><em>a</em><em>t</em><em>a</em> − <em>P</em><em>a</em><em>r</em><em>t</em><em>n</em><em>e</em><em>r</em><em>s</em>/<em>E</em><em>J</em><em>A</em><em>M</em>/<em>i</em><em>s</em><em>s</em><em>u</em><em>e</em><em>s</em>/56)|<em>c</em><em>h</em><em>e</em><em>c</em><em>k</em>/<em>f</em><em>i</em><em>x</em><em>D</em><em>i</em><em>s</em><em>t</em><em>a</em><em>n</em><em>c</em><em>e</em><em>a</em><em>n</em><em>d</em><em>S</em><em>i</em><em>t</em><em>e</em><em>C</em><em>o</em><em>u</em><em>n</em><em>t</em><em>s</em><em>u</em><em>m</em><em>m</em><em>a</em><em>r</em><em>y</em><em>s</em><em>t</em><em>a</em><em>t</em><em>s</em>, <em>i</em><em>n</em><em>d</em><em>o</em><em>a</em><em>g</em><em>g</em><em>r</em><em>e</em><em>g</em><em>a</em><em>t</em><em>e</em>()|6(🟡<em>M</em><em>e</em><em>d</em><em>i</em><em>u</em><em>m</em>)|9(🟩🟦<em>H</em><em>i</em><em>g</em><em>h</em>)|<em>N</em><em>A</em>|<em>P</em><em>R</em><em>I</em><em>O</em><em>R</em><em>I</em><em>T</em><em>Y</em><em>M</em><em>E</em><em>D</em><em>I</em><em>U</em><em>M</em>|<em>B</em><em>U</em><em>G</em>, <em>d</em><em>o</em><em>c</em><em>u</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>t</em><em>i</em><em>o</em><em>n</em>, <em>c</em><em>a</em><em>l</em><em>c</em><em>u</em><em>l</em><em>a</em><em>t</em><em>e</em>/<em>v</em><em>a</em><em>l</em><em>i</em><em>d</em><em>a</em><em>t</em><em>e</em><em>t</em><em>o</em><em>E</em><em>J</em><em>S</em><em>c</em><em>r</em><em>e</em><em>e</em><em>n</em>, <em>d</em><em>i</em><em>s</em><em>t</em><em>a</em><em>n</em><em>c</em><em>e</em> − <em>r</em><em>e</em><em>l</em><em>a</em><em>t</em><em>e</em><em>d</em>||[135](<em>h</em><em>t</em><em>t</em><em>p</em><em>s</em> : //<em>g</em><em>i</em><em>t</em><em>h</em><em>u</em><em>b</em>.<em>c</em><em>o</em><em>m</em>/<em>P</em><em>u</em><em>b</em><em>l</em><em>i</em><em>c</em> − <em>E</em><em>n</em><em>v</em><em>i</em><em>r</em><em>o</em><em>n</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>l</em> − <em>D</em><em>a</em><em>t</em><em>a</em> − <em>P</em><em>a</em><em>r</em><em>t</em><em>n</em><em>e</em><em>r</em><em>s</em>/<em>E</em><em>J</em><em>A</em><em>M</em>/<em>i</em><em>s</em><em>s</em><em>u</em><em>e</em><em>s</em>/135)|<em>f</em><em>i</em><em>n</em><em>i</em><em>s</em><em>h</em><em>w</em><em>o</em><em>r</em><em>k</em><em>i</em><em>n</em><em>p</em><em>r</em><em>o</em><em>g</em><em>r</em><em>e</em><em>s</em><em>s</em><em>o</em><em>n</em><em>d</em><em>e</em><em>f</em><em>a</em><em>u</em><em>l</em><em>t</em><sub><em>s</em></sub><em>s</em><sub><em>c</em></sub><em>h</em><em>o</em><em>o</em><em>s</em><em>e</em><sub><em>m</em></sub><em>e</em><em>t</em><em>h</em><em>o</em><em>d</em><em>v</em><em>s</em><em>i</em><em>n</em><em>p</em><em>u</em><em>t</em></span>
-?</td>
+<td>fix distance_avg in doaggregate()$results_bybg_people</td>
+<td>4 (🟡 Medium)</td>
+<td>9 (🟩🟦 High)</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>BUG, distance-related, rank:B-high-value-high-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/553">553</a></td>
+<td>plot_lorenz_*() draft plots are broken: undefined bysite, filter on
+a …</td>
+<td>6 (🟡 Medium)</td>
+<td>9 (🟩🟦 High)</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>BUG</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/56">56</a></td>
+<td>check/ fix Distance and Site Count summary stats, in
+doaggregate()</td>
+<td>6 (🟡 Medium)</td>
+<td>9 (🟩🟦 High)</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>BUG, documentation, calculate/validate to EJScreen,
+distance-related</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135">135</a></td>
+<td>finish work in progress on default_ss_choose_method vs input$ ?</td>
 <td>4 (🟡 Medium)</td>
 <td>8 (🟦 Medium)</td>
 <td>NA</td>
@@ -2762,9 +2793,39 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31">31</
 <td>9</td>
 <td>NA</td>
 <td>PRIORITY MEDIUM</td>
-<td>fix distance_avg in doaggregate()<span
-class="math inline"><em>r</em><em>e</em><em>s</em><em>u</em><em>l</em><em>t</em><em>s</em><sub><em>b</em></sub><em>y</em><em>b</em><em>g</em><sub><em>p</em></sub><em>e</em><em>o</em><em>p</em><em>l</em><em>e</em>||<em>B</em>|[553](<em>h</em><em>t</em><em>t</em><em>p</em><em>s</em> : //<em>g</em><em>i</em><em>t</em><em>h</em><em>u</em><em>b</em>.<em>c</em><em>o</em><em>m</em>/<em>P</em><em>u</em><em>b</em><em>l</em><em>i</em><em>c</em> − <em>E</em><em>n</em><em>v</em><em>i</em><em>r</em><em>o</em><em>n</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>l</em> − <em>D</em><em>a</em><em>t</em><em>a</em> − <em>P</em><em>a</em><em>r</em><em>t</em><em>n</em><em>e</em><em>r</em><em>s</em>/<em>E</em><em>J</em><em>A</em><em>M</em>/<em>i</em><em>s</em><em>s</em><em>u</em><em>e</em><em>s</em>/553)|6|9|<em>N</em><em>A</em>|<em>P</em><em>R</em><em>I</em><em>O</em><em>R</em><em>I</em><em>T</em><em>Y</em><em>L</em><em>O</em><em>W</em>|<em>p</em><em>l</em><em>o</em><em>t</em><sub><em>l</em></sub><em>o</em><em>r</em><em>e</em><em>n</em><em>z</em><sub>*</sub>()<em>d</em><em>r</em><em>a</em><em>f</em><em>t</em><em>p</em><em>l</em><em>o</em><em>t</em><em>s</em><em>a</em><em>r</em><em>e</em><em>b</em><em>r</em><em>o</em><em>k</em><em>e</em><em>n</em> : <em>u</em><em>n</em><em>d</em><em>e</em><em>f</em><em>i</em><em>n</em><em>e</em><em>d</em><em>b</em><em>y</em><em>s</em><em>i</em><em>t</em><em>e</em>, <em>f</em><em>i</em><em>l</em><em>t</em><em>e</em><em>r</em><em>o</em><em>n</em><em>a</em><em>l</em><em>i</em>…||<em>B</em>|[56](<em>h</em><em>t</em><em>t</em><em>p</em><em>s</em> : //<em>g</em><em>i</em><em>t</em><em>h</em><em>u</em><em>b</em>.<em>c</em><em>o</em><em>m</em>/<em>P</em><em>u</em><em>b</em><em>l</em><em>i</em><em>c</em> − <em>E</em><em>n</em><em>v</em><em>i</em><em>r</em><em>o</em><em>n</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>l</em> − <em>D</em><em>a</em><em>t</em><em>a</em> − <em>P</em><em>a</em><em>r</em><em>t</em><em>n</em><em>e</em><em>r</em><em>s</em>/<em>E</em><em>J</em><em>A</em><em>M</em>/<em>i</em><em>s</em><em>s</em><em>u</em><em>e</em><em>s</em>/56)|6|9|<em>N</em><em>A</em>|<em>P</em><em>R</em><em>I</em><em>O</em><em>R</em><em>I</em><em>T</em><em>Y</em><em>M</em><em>E</em><em>D</em><em>I</em><em>U</em><em>M</em>|<em>c</em><em>h</em><em>e</em><em>c</em><em>k</em>/<em>f</em><em>i</em><em>x</em><em>D</em><em>i</em><em>s</em><em>t</em><em>a</em><em>n</em><em>c</em><em>e</em><em>a</em><em>n</em><em>d</em><em>S</em><em>i</em><em>t</em><em>e</em><em>C</em><em>o</em><em>u</em><em>n</em><em>t</em><em>s</em><em>u</em><em>m</em><em>m</em><em>a</em><em>r</em><em>y</em><em>s</em><em>t</em><em>a</em><em>t</em><em>s</em>, <em>i</em><em>n</em><em>d</em><em>o</em><em>a</em><em>g</em><em>g</em><em>r</em><em>e</em><em>g</em><em>a</em><em>t</em><em>e</em>()||<em>B</em>|[135](<em>h</em><em>t</em><em>t</em><em>p</em><em>s</em> : //<em>g</em><em>i</em><em>t</em><em>h</em><em>u</em><em>b</em>.<em>c</em><em>o</em><em>m</em>/<em>P</em><em>u</em><em>b</em><em>l</em><em>i</em><em>c</em> − <em>E</em><em>n</em><em>v</em><em>i</em><em>r</em><em>o</em><em>n</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>l</em> − <em>D</em><em>a</em><em>t</em><em>a</em> − <em>P</em><em>a</em><em>r</em><em>t</em><em>n</em><em>e</em><em>r</em><em>s</em>/<em>E</em><em>J</em><em>A</em><em>M</em>/<em>i</em><em>s</em><em>s</em><em>u</em><em>e</em><em>s</em>/135)|4|8|<em>N</em><em>A</em>|<em>P</em><em>R</em><em>I</em><em>O</em><em>R</em><em>I</em><em>T</em><em>Y</em><em>L</em><em>O</em><em>W</em>|<em>f</em><em>i</em><em>n</em><em>i</em><em>s</em><em>h</em><em>w</em><em>o</em><em>r</em><em>k</em><em>i</em><em>n</em><em>p</em><em>r</em><em>o</em><em>g</em><em>r</em><em>e</em><em>s</em><em>s</em><em>o</em><em>n</em><em>d</em><em>e</em><em>f</em><em>a</em><em>u</em><em>l</em><em>t</em><sub><em>s</em></sub><em>s</em><sub><em>c</em></sub><em>h</em><em>o</em><em>o</em><em>s</em><em>e</em><sub><em>m</em></sub><em>e</em><em>t</em><em>h</em><em>o</em><em>d</em><em>v</em><em>s</em><em>i</em><em>n</em><em>p</em><em>u</em><em>t</em></span>
-?</td>
+<td>fix distance_avg in doaggregate()$results_bybg_people</td>
+</tr>
+<tr>
+<td>B</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/553">553</a></td>
+<td>6</td>
+<td>9</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>plot_lorenz_*() draft plots are broken: undefined bysite, filter on
+a li…</td>
+</tr>
+<tr>
+<td>B</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/56">56</a></td>
+<td>6</td>
+<td>9</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>check/ fix Distance and Site Count summary stats, in
+doaggregate()</td>
+</tr>
+<tr>
+<td>B</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/135">135</a></td>
+<td>4</td>
+<td>8</td>
+<td>NA</td>
+<td>PRIORITY LOW</td>
+<td>finish work in progress on default_ss_choose_method vs input$ ?</td>
 </tr>
 <tr>
 <td>B</td>

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.html
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.html
@@ -207,8 +207,8 @@
 <body>
 <h1 id="ejam-open-issues-scored-by-cost-benefit">EJAM Open Issues —
 Scored by Cost &amp; Benefit</h1>
-<p><strong>Total open issues:</strong> 132 | <strong>Generated:</strong>
-2026-08-02 | <strong>Source:</strong> Live GitHub REST API open issues
+<p><strong>Total open issues:</strong> 136 | <strong>Generated:</strong>
+2026-08-11 | <strong>Source:</strong> Live GitHub REST API open issues
 (Public-Environmental-Data-Partners/EJAM)</p>
 <p><strong>Score payload:</strong>
 <code>inst/issues/ejam_issues_scored_by_risk_and_value.json</code></p>
@@ -225,15 +225,15 @@ Scored by Cost &amp; Benefit</h1>
 <tbody>
 <tr>
 <td>Previous run</td>
-<td>2026-07-27</td>
+<td>2026-08-02</td>
 </tr>
 <tr>
 <td>Issues opened since previous run</td>
-<td>0</td>
+<td>7</td>
 </tr>
 <tr>
 <td>Issues closed since previous run</td>
-<td>0</td>
+<td>3</td>
 </tr>
 <tr>
 <td>Issues whose quadrant changed</td>
@@ -259,13 +259,13 @@ Scored by Cost &amp; Benefit</h1>
 <tbody>
 <tr>
 <td><strong>LOW Cost</strong><br>cost &lt; median</td>
-<td><strong>C — Other Low-Cost Work</strong><br>41 issues</td>
+<td><strong>C — Other Low-Cost Work</strong><br>38 issues</td>
 <td><strong>A — Focus Shortlist (max 20)</strong><br>20 issues</td>
 </tr>
 <tr>
 <td><strong>HIGH Cost</strong><br>cost ≥ median</td>
-<td><strong>D — WORST CANDIDATES</strong><br>24 issues</td>
-<td><strong>B — OK Candidates</strong><br>47 issues</td>
+<td><strong>D — WORST CANDIDATES</strong><br>29 issues</td>
+<td><strong>B — OK Candidates</strong><br>49 issues</td>
 </tr>
 </tbody>
 </table>
@@ -309,14 +309,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/400">#40
 — improve how webapp users can find info on data vintage (in EJAM web
 app UI, from community report, and from EJScreen UI)</li>
 <li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344">#344</a>
-— Show an example of a community report - e.g., in or linked from
-“basics” vignette</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/249">#249</a>
-— ejam2report() fails if filename is specified without path, or with
-“./xyz.html”</li>
-<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/137">#137</a>
 — fix bug in popshare_at_top_x_pct() - results sometimes not quite
 right. seems to interpolate badly.</li>
@@ -353,6 +345,12 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/91">#91<
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161">#161</a>
 — ejamapp() should be able to handle mix of fips types</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">#162</a>
+— rename “in_how_many_states” column in table of results</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">#136</a>
+— in web app, fix console error msg when uploading a shapefile</li>
 </ul>
 <table class="issue-details">
 <colgroup>
@@ -467,30 +465,6 @@ ap…</td>
 </tr>
 <tr>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344">344</a></td>
-<td>Show an example of a community report - e.g., in or linked from
-“basic…</td>
-<td>2 (🔵 Low)</td>
-<td>12 (🟩🟦 High)</td>
-<td>v4</td>
-<td>PRIORITY HIGH-ish but not a bug</td>
-<td>documentation, help wanted, good first issue,
-rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/249">249</a></td>
-<td>ejam2report() fails if filename is specified without path, or with
-“./…</td>
-<td>2 (🔵 Low)</td>
-<td>12 (🟩🟦 High)</td>
-<td>v3.2022.2</td>
-<td>PRIORITY LOW</td>
-<td>BUG, Affects R users only - NOT web app users,
-rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/137">137</a></td>
 <td>fix bug in popshare_at_top_x_pct() - results sometimes not quite
 right…</td>
@@ -597,6 +571,26 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161">161
 <td>PRIORITY MEDIUM</td>
 <td>Affects Web App, rank:A-high-value-low-cost</td>
 </tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">162</a></td>
+<td>rename “in_how_many_states” column in table of results</td>
+<td>1 (🟢 Very Low)</td>
+<td>7 (🟦 Medium)</td>
+<td>v4</td>
+<td>PRIORITY MEDIUM</td>
+<td>Affects Web App, rank:A-high-value-low-cost</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">136</a></td>
+<td>in web app, fix console error msg when uploading a shapefile</td>
+<td>1 (🟢 Very Low)</td>
+<td>7 (🟦 Medium)</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>BUG, rank:A-high-value-low-cost</td>
+</tr>
 </tbody>
 </table>
 <hr />
@@ -604,7 +598,7 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161">161
 Candidates — High Cost, High Benefit</h2>
 <p><em>Worth doing but require more effort or expertise. Plan carefully
 before starting.</em></p>
-<p><strong>47 issues</strong></p>
+<p><strong>49 issues</strong></p>
 <ul>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/293">#293</a>
@@ -643,6 +637,10 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/68">#68<
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46">#46</a>
 — Long Report text needed</li>
 <li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/555">#555</a>
+— Saved-results fixtures are macOS-specific: the 4 comparisons fail on
+Linux and Windows</li>
+<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/527">#527</a>
 — shapes_from_fips() errors offline even when the county boundary is
 built into the package</li>
@@ -662,6 +660,10 @@ server</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31">#31</a>
 — fix distance_avg in doaggregate()$results_bybg_people</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/553">#553</a>
+— plot_lorenz_*() draft plots are broken: undefined bysite, filter on a
+literal, constant aes mapping</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/56">#56</a>
 — check/ fix Distance and Site Count summary stats, in
@@ -919,6 +921,17 @@ rank:B-high-value-high-cost</td>
 </tr>
 <tr>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/555">555</a></td>
+<td>Saved-results fixtures are macOS-specific: the 4 comparisons fail on
+L…</td>
+<td>4 (🟡 Medium)</td>
+<td>12 (🟩🟦 High)</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>BUG, test</td>
+</tr>
+<tr>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/527">527</a></td>
 <td>shapes_from_fips() errors offline even when the county boundary is
 bui…</td>
@@ -966,7 +979,7 @@ server</td>
 <td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31">31</a></td>
 <td>fix distance_avg in doaggregate()<span
-class="math inline"><em>r</em><em>e</em><em>s</em><em>u</em><em>l</em><em>t</em><em>s</em><sub><em>b</em></sub><em>y</em><em>b</em><em>g</em><sub><em>p</em></sub><em>e</em><em>o</em><em>p</em><em>l</em><em>e</em>|4(🟡<em>M</em><em>e</em><em>d</em><em>i</em><em>u</em><em>m</em>)|9(🟩🟦<em>H</em><em>i</em><em>g</em><em>h</em>)|<em>N</em><em>A</em>|<em>P</em><em>R</em><em>I</em><em>O</em><em>R</em><em>I</em><em>T</em><em>Y</em><em>M</em><em>E</em><em>D</em><em>I</em><em>U</em><em>M</em>|<em>B</em><em>U</em><em>G</em>, <em>d</em><em>i</em><em>s</em><em>t</em><em>a</em><em>n</em><em>c</em><em>e</em> − <em>r</em><em>e</em><em>l</em><em>a</em><em>t</em><em>e</em><em>d</em>, <em>r</em><em>a</em><em>n</em><em>k</em> : <em>B</em> − <em>h</em><em>i</em><em>g</em><em>h</em> − <em>v</em><em>a</em><em>l</em><em>u</em><em>e</em> − <em>h</em><em>i</em><em>g</em><em>h</em> − <em>c</em><em>o</em><em>s</em><em>t</em>||[56](<em>h</em><em>t</em><em>t</em><em>p</em><em>s</em> : //<em>g</em><em>i</em><em>t</em><em>h</em><em>u</em><em>b</em>.<em>c</em><em>o</em><em>m</em>/<em>P</em><em>u</em><em>b</em><em>l</em><em>i</em><em>c</em> − <em>E</em><em>n</em><em>v</em><em>i</em><em>r</em><em>o</em><em>n</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>l</em> − <em>D</em><em>a</em><em>t</em><em>a</em> − <em>P</em><em>a</em><em>r</em><em>t</em><em>n</em><em>e</em><em>r</em><em>s</em>/<em>E</em><em>J</em><em>A</em><em>M</em>/<em>i</em><em>s</em><em>s</em><em>u</em><em>e</em><em>s</em>/56)|<em>c</em><em>h</em><em>e</em><em>c</em><em>k</em>/<em>f</em><em>i</em><em>x</em><em>D</em><em>i</em><em>s</em><em>t</em><em>a</em><em>n</em><em>c</em><em>e</em><em>a</em><em>n</em><em>d</em><em>S</em><em>i</em><em>t</em><em>e</em><em>C</em><em>o</em><em>u</em><em>n</em><em>t</em><em>s</em><em>u</em><em>m</em><em>m</em><em>a</em><em>r</em><em>y</em><em>s</em><em>t</em><em>a</em><em>t</em><em>s</em>, <em>i</em><em>n</em><em>d</em><em>o</em><em>a</em><em>g</em><em>g</em><em>r</em><em>e</em><em>g</em><em>a</em><em>t</em><em>e</em>()|6(🟡<em>M</em><em>e</em><em>d</em><em>i</em><em>u</em><em>m</em>)|9(🟩🟦<em>H</em><em>i</em><em>g</em><em>h</em>)|<em>N</em><em>A</em>|<em>P</em><em>R</em><em>I</em><em>O</em><em>R</em><em>I</em><em>T</em><em>Y</em><em>M</em><em>E</em><em>D</em><em>I</em><em>U</em><em>M</em>|<em>B</em><em>U</em><em>G</em>, <em>d</em><em>o</em><em>c</em><em>u</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>t</em><em>i</em><em>o</em><em>n</em>, <em>c</em><em>a</em><em>l</em><em>c</em><em>u</em><em>l</em><em>a</em><em>t</em><em>e</em>/<em>v</em><em>a</em><em>l</em><em>i</em><em>d</em><em>a</em><em>t</em><em>e</em><em>t</em><em>o</em><em>E</em><em>J</em><em>S</em><em>c</em><em>r</em><em>e</em><em>e</em><em>n</em>, <em>d</em><em>i</em><em>s</em><em>t</em><em>a</em><em>n</em><em>c</em><em>e</em> − <em>r</em><em>e</em><em>l</em><em>a</em><em>t</em><em>e</em><em>d</em>||[135](<em>h</em><em>t</em><em>t</em><em>p</em><em>s</em> : //<em>g</em><em>i</em><em>t</em><em>h</em><em>u</em><em>b</em>.<em>c</em><em>o</em><em>m</em>/<em>P</em><em>u</em><em>b</em><em>l</em><em>i</em><em>c</em> − <em>E</em><em>n</em><em>v</em><em>i</em><em>r</em><em>o</em><em>n</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>l</em> − <em>D</em><em>a</em><em>t</em><em>a</em> − <em>P</em><em>a</em><em>r</em><em>t</em><em>n</em><em>e</em><em>r</em><em>s</em>/<em>E</em><em>J</em><em>A</em><em>M</em>/<em>i</em><em>s</em><em>s</em><em>u</em><em>e</em><em>s</em>/135)|<em>f</em><em>i</em><em>n</em><em>i</em><em>s</em><em>h</em><em>w</em><em>o</em><em>r</em><em>k</em><em>i</em><em>n</em><em>p</em><em>r</em><em>o</em><em>g</em><em>r</em><em>e</em><em>s</em><em>s</em><em>o</em><em>n</em><em>d</em><em>e</em><em>f</em><em>a</em><em>u</em><em>l</em><em>t</em><sub><em>s</em></sub><em>s</em><sub><em>c</em></sub><em>h</em><em>o</em><em>o</em><em>s</em><em>e</em><sub><em>m</em></sub><em>e</em><em>t</em><em>h</em><em>o</em><em>d</em><em>v</em><em>s</em><em>i</em><em>n</em><em>p</em><em>u</em><em>t</em></span>
+class="math inline"><em>r</em><em>e</em><em>s</em><em>u</em><em>l</em><em>t</em><em>s</em><sub><em>b</em></sub><em>y</em><em>b</em><em>g</em><sub><em>p</em></sub><em>e</em><em>o</em><em>p</em><em>l</em><em>e</em>|4(🟡<em>M</em><em>e</em><em>d</em><em>i</em><em>u</em><em>m</em>)|9(🟩🟦<em>H</em><em>i</em><em>g</em><em>h</em>)|<em>N</em><em>A</em>|<em>P</em><em>R</em><em>I</em><em>O</em><em>R</em><em>I</em><em>T</em><em>Y</em><em>M</em><em>E</em><em>D</em><em>I</em><em>U</em><em>M</em>|<em>B</em><em>U</em><em>G</em>, <em>d</em><em>i</em><em>s</em><em>t</em><em>a</em><em>n</em><em>c</em><em>e</em> − <em>r</em><em>e</em><em>l</em><em>a</em><em>t</em><em>e</em><em>d</em>, <em>r</em><em>a</em><em>n</em><em>k</em> : <em>B</em> − <em>h</em><em>i</em><em>g</em><em>h</em> − <em>v</em><em>a</em><em>l</em><em>u</em><em>e</em> − <em>h</em><em>i</em><em>g</em><em>h</em> − <em>c</em><em>o</em><em>s</em><em>t</em>||[553](<em>h</em><em>t</em><em>t</em><em>p</em><em>s</em> : //<em>g</em><em>i</em><em>t</em><em>h</em><em>u</em><em>b</em>.<em>c</em><em>o</em><em>m</em>/<em>P</em><em>u</em><em>b</em><em>l</em><em>i</em><em>c</em> − <em>E</em><em>n</em><em>v</em><em>i</em><em>r</em><em>o</em><em>n</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>l</em> − <em>D</em><em>a</em><em>t</em><em>a</em> − <em>P</em><em>a</em><em>r</em><em>t</em><em>n</em><em>e</em><em>r</em><em>s</em>/<em>E</em><em>J</em><em>A</em><em>M</em>/<em>i</em><em>s</em><em>s</em><em>u</em><em>e</em><em>s</em>/553)|<em>p</em><em>l</em><em>o</em><em>t</em><sub><em>l</em></sub><em>o</em><em>r</em><em>e</em><em>n</em><em>z</em><sub>*</sub>()<em>d</em><em>r</em><em>a</em><em>f</em><em>t</em><em>p</em><em>l</em><em>o</em><em>t</em><em>s</em><em>a</em><em>r</em><em>e</em><em>b</em><em>r</em><em>o</em><em>k</em><em>e</em><em>n</em> : <em>u</em><em>n</em><em>d</em><em>e</em><em>f</em><em>i</em><em>n</em><em>e</em><em>d</em><em>b</em><em>y</em><em>s</em><em>i</em><em>t</em><em>e</em>, <em>f</em><em>i</em><em>l</em><em>t</em><em>e</em><em>r</em><em>o</em><em>n</em><em>a</em>…|6(🟡<em>M</em><em>e</em><em>d</em><em>i</em><em>u</em><em>m</em>)|9(🟩🟦<em>H</em><em>i</em><em>g</em><em>h</em>)|<em>N</em><em>A</em>|<em>P</em><em>R</em><em>I</em><em>O</em><em>R</em><em>I</em><em>T</em><em>Y</em><em>L</em><em>O</em><em>W</em>|<em>B</em><em>U</em><em>G</em>||[56](<em>h</em><em>t</em><em>t</em><em>p</em><em>s</em> : //<em>g</em><em>i</em><em>t</em><em>h</em><em>u</em><em>b</em>.<em>c</em><em>o</em><em>m</em>/<em>P</em><em>u</em><em>b</em><em>l</em><em>i</em><em>c</em> − <em>E</em><em>n</em><em>v</em><em>i</em><em>r</em><em>o</em><em>n</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>l</em> − <em>D</em><em>a</em><em>t</em><em>a</em> − <em>P</em><em>a</em><em>r</em><em>t</em><em>n</em><em>e</em><em>r</em><em>s</em>/<em>E</em><em>J</em><em>A</em><em>M</em>/<em>i</em><em>s</em><em>s</em><em>u</em><em>e</em><em>s</em>/56)|<em>c</em><em>h</em><em>e</em><em>c</em><em>k</em>/<em>f</em><em>i</em><em>x</em><em>D</em><em>i</em><em>s</em><em>t</em><em>a</em><em>n</em><em>c</em><em>e</em><em>a</em><em>n</em><em>d</em><em>S</em><em>i</em><em>t</em><em>e</em><em>C</em><em>o</em><em>u</em><em>n</em><em>t</em><em>s</em><em>u</em><em>m</em><em>m</em><em>a</em><em>r</em><em>y</em><em>s</em><em>t</em><em>a</em><em>t</em><em>s</em>, <em>i</em><em>n</em><em>d</em><em>o</em><em>a</em><em>g</em><em>g</em><em>r</em><em>e</em><em>g</em><em>a</em><em>t</em><em>e</em>()|6(🟡<em>M</em><em>e</em><em>d</em><em>i</em><em>u</em><em>m</em>)|9(🟩🟦<em>H</em><em>i</em><em>g</em><em>h</em>)|<em>N</em><em>A</em>|<em>P</em><em>R</em><em>I</em><em>O</em><em>R</em><em>I</em><em>T</em><em>Y</em><em>M</em><em>E</em><em>D</em><em>I</em><em>U</em><em>M</em>|<em>B</em><em>U</em><em>G</em>, <em>d</em><em>o</em><em>c</em><em>u</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>t</em><em>i</em><em>o</em><em>n</em>, <em>c</em><em>a</em><em>l</em><em>c</em><em>u</em><em>l</em><em>a</em><em>t</em><em>e</em>/<em>v</em><em>a</em><em>l</em><em>i</em><em>d</em><em>a</em><em>t</em><em>e</em><em>t</em><em>o</em><em>E</em><em>J</em><em>S</em><em>c</em><em>r</em><em>e</em><em>e</em><em>n</em>, <em>d</em><em>i</em><em>s</em><em>t</em><em>a</em><em>n</em><em>c</em><em>e</em> − <em>r</em><em>e</em><em>l</em><em>a</em><em>t</em><em>e</em><em>d</em>||[135](<em>h</em><em>t</em><em>t</em><em>p</em><em>s</em> : //<em>g</em><em>i</em><em>t</em><em>h</em><em>u</em><em>b</em>.<em>c</em><em>o</em><em>m</em>/<em>P</em><em>u</em><em>b</em><em>l</em><em>i</em><em>c</em> − <em>E</em><em>n</em><em>v</em><em>i</em><em>r</em><em>o</em><em>n</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>l</em> − <em>D</em><em>a</em><em>t</em><em>a</em> − <em>P</em><em>a</em><em>r</em><em>t</em><em>n</em><em>e</em><em>r</em><em>s</em>/<em>E</em><em>J</em><em>A</em><em>M</em>/<em>i</em><em>s</em><em>s</em><em>u</em><em>e</em><em>s</em>/135)|<em>f</em><em>i</em><em>n</em><em>i</em><em>s</em><em>h</em><em>w</em><em>o</em><em>r</em><em>k</em><em>i</em><em>n</em><em>p</em><em>r</em><em>o</em><em>g</em><em>r</em><em>e</em><em>s</em><em>s</em><em>o</em><em>n</em><em>d</em><em>e</em><em>f</em><em>a</em><em>u</em><em>l</em><em>t</em><sub><em>s</em></sub><em>s</em><sub><em>c</em></sub><em>h</em><em>o</em><em>o</em><em>s</em><em>e</em><sub><em>m</em></sub><em>e</em><em>t</em><em>h</em><em>o</em><em>d</em><em>v</em><em>s</em><em>i</em><em>n</em><em>p</em><em>u</em><em>t</em></span>
 ?</td>
 <td>4 (🟡 Medium)</td>
 <td>8 (🟦 Medium)</td>
@@ -1316,7 +1329,7 @@ list</td>
 WORK</h2>
 <p><em>Cheap to do but not in the current focus shortlist. Pick these up
 when bandwidth allows or combine them with nearby work.</em></p>
-<p><strong>41 issues</strong></p>
+<p><strong>38 issues</strong></p>
 <ul>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/490">#490</a>
@@ -1328,15 +1341,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/361">#36
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163">#163</a>
 — put certain columns last in table of results (bg count, block count,
 radius)</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">#162</a>
-— rename “in_how_many_states” column in table of results</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">#136</a>
-— in web app, fix console error msg when uploading a shapefile</li>
-<li><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288">#288</a>
-— ratio of 1.0 should not be yellow on community report</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/70">#70</a>
 — set up alerts that monitor and alert staff when the app goes down -
@@ -1513,36 +1517,6 @@ r…</td>
 <td>NA</td>
 <td>PRIORITY MEDIUM</td>
 <td>Affects Web App, rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">162</a></td>
-<td>rename “in_how_many_states” column in table of results</td>
-<td>1 (🟢 Very Low)</td>
-<td>7 (🟦 Medium)</td>
-<td>v4</td>
-<td>PRIORITY MEDIUM</td>
-<td>Affects Web App, rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">136</a></td>
-<td>in web app, fix console error msg when uploading a shapefile</td>
-<td>1 (🟢 Very Low)</td>
-<td>7 (🟦 Medium)</td>
-<td>v4</td>
-<td>PRIORITY LOW</td>
-<td>BUG, rank:A-high-value-low-cost</td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288">288</a></td>
-<td>ratio of 1.0 should not be yellow on community report</td>
-<td>2 (🔵 Low)</td>
-<td>7 (🟦 Medium)</td>
-<td>v3.2022.2</td>
-<td>PRIORITY MEDIUM</td>
-<td>Affects Web App, Community Report, rank:A-high-value-low-cost</td>
 </tr>
 <tr>
 <td><a
@@ -1925,8 +1899,12 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60">60</
 WORST CANDIDATES — High Cost, Low Benefit</h2>
 <p><em>Expensive to fix, limited payoff. Defer or deprioritize unless
 circumstances change.</em></p>
-<p><strong>24 issues</strong></p>
+<p><strong>29 issues</strong></p>
 <ul>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/560">#560</a>
+— Four NAICS web-scrape tests fail when naics.com blocks a CI runner
+(seen on Linux)</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/508">#508</a>
 — ECR lifecycle policy: prune accumulating dev images (without touching
@@ -1949,6 +1927,10 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/536">#53
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/35">#35</a>
 — Review/revise/expand unit testing for URL functions</li>
 <li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/546">#546</a>
+— count_sites_with_n_high_scores() ratio default still 1.01,
+inconsistent with the 1.05 yellow cutoff from #369</li>
+<li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/62">#62</a>
 — Enable download of ‘Plot of Average Scores’ and ‘Plot Full Range of
 Scores’ plots</li>
@@ -1960,6 +1942,13 @@ seconds</li>
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/55">#55</a>
 — add links to COUNTY-LEVEL reports - on a place - from other tools/
 sources</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/548">#548</a>
+— R CMD check has 2 ERRORs on macOS and Windows, exposed by #530</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/547">#547</a>
+— Define color-coding cutoffs once, as adjustable parameters (design
+half of #288)</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/497">#497</a>
 — refactor / clean up rounding of numbers</li>
@@ -1991,6 +1980,10 @@ bounds, ejamit results, rendered reports)</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/18">#18</a>
 — some FIPS-related functions/data could be improved</li>
+<li><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/550">#550</a>
+— Point-shapefile upload: make the error message actionable, and dedupe
+the rule between app_server.R and shapefix.R</li>
 <li><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/95">#95</a>
 — in map_headernames, consider adding info re: in which tables/ popups/
@@ -2040,6 +2033,17 @@ code</li>
 </tr>
 </thead>
 <tbody>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/560">560</a></td>
+<td>Four NAICS web-scrape tests fail when naics.com blocks a CI runner
+(se…</td>
+<td>4 (🟡 Medium)</td>
+<td>4 (⬜ Low)</td>
+<td>NA</td>
+<td>—</td>
+<td></td>
+</tr>
 <tr>
 <td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/508">508</a></td>
@@ -2107,6 +2111,17 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/35">35</
 </tr>
 <tr>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/546">546</a></td>
+<td>count_sites_with_n_high_scores() ratio default still 1.01,
+inconsisten…</td>
+<td>4 (🟡 Medium)</td>
+<td>1 (⬜ Very Low)</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>LongReport_output</td>
+</tr>
+<tr>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/62">62</a></td>
 <td>Enable download of ‘Plot of Average Scores’ and ’Plot Full Range of
 Sc…</td>
@@ -2137,6 +2152,27 @@ sou…</td>
 <td>NA</td>
 <td>PRIORITY LOW</td>
 <td>still relevant?, rank:D-defer</td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/548">548</a></td>
+<td>R CMD check has 2 ERRORs on macOS and Windows, exposed by #530</td>
+<td>4 (🟡 Medium)</td>
+<td>0 (⬜ Very Low)</td>
+<td>v4</td>
+<td>—</td>
+<td></td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/547">547</a></td>
+<td>Define color-coding cutoffs once, as adjustable parameters (design
+hal…</td>
+<td>6 (🟡 Medium)</td>
+<td>4 (⬜ Low)</td>
+<td>v4</td>
+<td>PRIORITY MEDIUM</td>
+<td>refactor, Community Report</td>
 </tr>
 <tr>
 <td><a
@@ -2237,6 +2273,17 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/18">18</
 </tr>
 <tr>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/550">550</a></td>
+<td>Point-shapefile upload: make the error message actionable, and
+dedupe …</td>
+<td>8 (🟠 High)</td>
+<td>4 (⬜ Low)</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>shapefile-related, refactor, Affects Web App</td>
+</tr>
+<tr>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/95">95</a></td>
 <td>in map_headernames, consider adding info re: in which tables/
 popups/ …</td>
@@ -2306,7 +2353,7 @@ code</td>
 </tbody>
 </table>
 <hr />
-<h2 id="full-table-all-132-issues">Full Table — All 132 Issues</h2>
+<h2 id="full-table-all-136-issues">Full Table — All 136 Issues</h2>
 <p>Sorted: A first (best), then B, C, D; within each group by benefit
 DESC.</p>
 <table>
@@ -2422,28 +2469,6 @@ app …</td>
 <tr>
 <td>A</td>
 <td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344">344</a></td>
-<td>2</td>
-<td>12</td>
-<td>v4</td>
-<td>PRIORITY HIGH-ish but not a bug</td>
-<td>Show an example of a community report - e.g., in or linked from
-“basics”…</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/249">249</a></td>
-<td>2</td>
-<td>12</td>
-<td>v3.2022.2</td>
-<td>PRIORITY LOW</td>
-<td>ejam2report() fails if filename is specified without path, or with
-“./xy…</td>
-</tr>
-<tr>
-<td>A</td>
-<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/137">137</a></td>
 <td>1</td>
 <td>11</td>
@@ -2547,6 +2572,26 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/161">161
 <td>NA</td>
 <td>PRIORITY MEDIUM</td>
 <td>ejamapp() should be able to handle mix of fips types</td>
+</tr>
+<tr>
+<td>A</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">162</a></td>
+<td>1</td>
+<td>7</td>
+<td>v4</td>
+<td>PRIORITY MEDIUM</td>
+<td>rename “in_how_many_states” column in table of results</td>
+</tr>
+<tr>
+<td>A</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">136</a></td>
+<td>1</td>
+<td>7</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>in web app, fix console error msg when uploading a shapefile</td>
 </tr>
 <tr>
 <td>B</td>
@@ -2657,6 +2702,17 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/46">46</
 <tr>
 <td>B</td>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/555">555</a></td>
+<td>4</td>
+<td>12</td>
+<td>NA</td>
+<td>PRIORITY MEDIUM</td>
+<td>Saved-results fixtures are macOS-specific: the 4 comparisons fail on
+Lin…</td>
+</tr>
+<tr>
+<td>B</td>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/527">527</a></td>
 <td>4</td>
 <td>11</td>
@@ -2707,7 +2763,7 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/31">31</
 <td>NA</td>
 <td>PRIORITY MEDIUM</td>
 <td>fix distance_avg in doaggregate()<span
-class="math inline"><em>r</em><em>e</em><em>s</em><em>u</em><em>l</em><em>t</em><em>s</em><sub><em>b</em></sub><em>y</em><em>b</em><em>g</em><sub><em>p</em></sub><em>e</em><em>o</em><em>p</em><em>l</em><em>e</em>||<em>B</em>|[56](<em>h</em><em>t</em><em>t</em><em>p</em><em>s</em> : //<em>g</em><em>i</em><em>t</em><em>h</em><em>u</em><em>b</em>.<em>c</em><em>o</em><em>m</em>/<em>P</em><em>u</em><em>b</em><em>l</em><em>i</em><em>c</em> − <em>E</em><em>n</em><em>v</em><em>i</em><em>r</em><em>o</em><em>n</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>l</em> − <em>D</em><em>a</em><em>t</em><em>a</em> − <em>P</em><em>a</em><em>r</em><em>t</em><em>n</em><em>e</em><em>r</em><em>s</em>/<em>E</em><em>J</em><em>A</em><em>M</em>/<em>i</em><em>s</em><em>s</em><em>u</em><em>e</em><em>s</em>/56)|6|9|<em>N</em><em>A</em>|<em>P</em><em>R</em><em>I</em><em>O</em><em>R</em><em>I</em><em>T</em><em>Y</em><em>M</em><em>E</em><em>D</em><em>I</em><em>U</em><em>M</em>|<em>c</em><em>h</em><em>e</em><em>c</em><em>k</em>/<em>f</em><em>i</em><em>x</em><em>D</em><em>i</em><em>s</em><em>t</em><em>a</em><em>n</em><em>c</em><em>e</em><em>a</em><em>n</em><em>d</em><em>S</em><em>i</em><em>t</em><em>e</em><em>C</em><em>o</em><em>u</em><em>n</em><em>t</em><em>s</em><em>u</em><em>m</em><em>m</em><em>a</em><em>r</em><em>y</em><em>s</em><em>t</em><em>a</em><em>t</em><em>s</em>, <em>i</em><em>n</em><em>d</em><em>o</em><em>a</em><em>g</em><em>g</em><em>r</em><em>e</em><em>g</em><em>a</em><em>t</em><em>e</em>()||<em>B</em>|[135](<em>h</em><em>t</em><em>t</em><em>p</em><em>s</em> : //<em>g</em><em>i</em><em>t</em><em>h</em><em>u</em><em>b</em>.<em>c</em><em>o</em><em>m</em>/<em>P</em><em>u</em><em>b</em><em>l</em><em>i</em><em>c</em> − <em>E</em><em>n</em><em>v</em><em>i</em><em>r</em><em>o</em><em>n</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>l</em> − <em>D</em><em>a</em><em>t</em><em>a</em> − <em>P</em><em>a</em><em>r</em><em>t</em><em>n</em><em>e</em><em>r</em><em>s</em>/<em>E</em><em>J</em><em>A</em><em>M</em>/<em>i</em><em>s</em><em>s</em><em>u</em><em>e</em><em>s</em>/135)|4|8|<em>N</em><em>A</em>|<em>P</em><em>R</em><em>I</em><em>O</em><em>R</em><em>I</em><em>T</em><em>Y</em><em>L</em><em>O</em><em>W</em>|<em>f</em><em>i</em><em>n</em><em>i</em><em>s</em><em>h</em><em>w</em><em>o</em><em>r</em><em>k</em><em>i</em><em>n</em><em>p</em><em>r</em><em>o</em><em>g</em><em>r</em><em>e</em><em>s</em><em>s</em><em>o</em><em>n</em><em>d</em><em>e</em><em>f</em><em>a</em><em>u</em><em>l</em><em>t</em><sub><em>s</em></sub><em>s</em><sub><em>c</em></sub><em>h</em><em>o</em><em>o</em><em>s</em><em>e</em><sub><em>m</em></sub><em>e</em><em>t</em><em>h</em><em>o</em><em>d</em><em>v</em><em>s</em><em>i</em><em>n</em><em>p</em><em>u</em><em>t</em></span>
+class="math inline"><em>r</em><em>e</em><em>s</em><em>u</em><em>l</em><em>t</em><em>s</em><sub><em>b</em></sub><em>y</em><em>b</em><em>g</em><sub><em>p</em></sub><em>e</em><em>o</em><em>p</em><em>l</em><em>e</em>||<em>B</em>|[553](<em>h</em><em>t</em><em>t</em><em>p</em><em>s</em> : //<em>g</em><em>i</em><em>t</em><em>h</em><em>u</em><em>b</em>.<em>c</em><em>o</em><em>m</em>/<em>P</em><em>u</em><em>b</em><em>l</em><em>i</em><em>c</em> − <em>E</em><em>n</em><em>v</em><em>i</em><em>r</em><em>o</em><em>n</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>l</em> − <em>D</em><em>a</em><em>t</em><em>a</em> − <em>P</em><em>a</em><em>r</em><em>t</em><em>n</em><em>e</em><em>r</em><em>s</em>/<em>E</em><em>J</em><em>A</em><em>M</em>/<em>i</em><em>s</em><em>s</em><em>u</em><em>e</em><em>s</em>/553)|6|9|<em>N</em><em>A</em>|<em>P</em><em>R</em><em>I</em><em>O</em><em>R</em><em>I</em><em>T</em><em>Y</em><em>L</em><em>O</em><em>W</em>|<em>p</em><em>l</em><em>o</em><em>t</em><sub><em>l</em></sub><em>o</em><em>r</em><em>e</em><em>n</em><em>z</em><sub>*</sub>()<em>d</em><em>r</em><em>a</em><em>f</em><em>t</em><em>p</em><em>l</em><em>o</em><em>t</em><em>s</em><em>a</em><em>r</em><em>e</em><em>b</em><em>r</em><em>o</em><em>k</em><em>e</em><em>n</em> : <em>u</em><em>n</em><em>d</em><em>e</em><em>f</em><em>i</em><em>n</em><em>e</em><em>d</em><em>b</em><em>y</em><em>s</em><em>i</em><em>t</em><em>e</em>, <em>f</em><em>i</em><em>l</em><em>t</em><em>e</em><em>r</em><em>o</em><em>n</em><em>a</em><em>l</em><em>i</em>…||<em>B</em>|[56](<em>h</em><em>t</em><em>t</em><em>p</em><em>s</em> : //<em>g</em><em>i</em><em>t</em><em>h</em><em>u</em><em>b</em>.<em>c</em><em>o</em><em>m</em>/<em>P</em><em>u</em><em>b</em><em>l</em><em>i</em><em>c</em> − <em>E</em><em>n</em><em>v</em><em>i</em><em>r</em><em>o</em><em>n</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>l</em> − <em>D</em><em>a</em><em>t</em><em>a</em> − <em>P</em><em>a</em><em>r</em><em>t</em><em>n</em><em>e</em><em>r</em><em>s</em>/<em>E</em><em>J</em><em>A</em><em>M</em>/<em>i</em><em>s</em><em>s</em><em>u</em><em>e</em><em>s</em>/56)|6|9|<em>N</em><em>A</em>|<em>P</em><em>R</em><em>I</em><em>O</em><em>R</em><em>I</em><em>T</em><em>Y</em><em>M</em><em>E</em><em>D</em><em>I</em><em>U</em><em>M</em>|<em>c</em><em>h</em><em>e</em><em>c</em><em>k</em>/<em>f</em><em>i</em><em>x</em><em>D</em><em>i</em><em>s</em><em>t</em><em>a</em><em>n</em><em>c</em><em>e</em><em>a</em><em>n</em><em>d</em><em>S</em><em>i</em><em>t</em><em>e</em><em>C</em><em>o</em><em>u</em><em>n</em><em>t</em><em>s</em><em>u</em><em>m</em><em>m</em><em>a</em><em>r</em><em>y</em><em>s</em><em>t</em><em>a</em><em>t</em><em>s</em>, <em>i</em><em>n</em><em>d</em><em>o</em><em>a</em><em>g</em><em>g</em><em>r</em><em>e</em><em>g</em><em>a</em><em>t</em><em>e</em>()||<em>B</em>|[135](<em>h</em><em>t</em><em>t</em><em>p</em><em>s</em> : //<em>g</em><em>i</em><em>t</em><em>h</em><em>u</em><em>b</em>.<em>c</em><em>o</em><em>m</em>/<em>P</em><em>u</em><em>b</em><em>l</em><em>i</em><em>c</em> − <em>E</em><em>n</em><em>v</em><em>i</em><em>r</em><em>o</em><em>n</em><em>m</em><em>e</em><em>n</em><em>t</em><em>a</em><em>l</em> − <em>D</em><em>a</em><em>t</em><em>a</em> − <em>P</em><em>a</em><em>r</em><em>t</em><em>n</em><em>e</em><em>r</em><em>s</em>/<em>E</em><em>J</em><em>A</em><em>M</em>/<em>i</em><em>s</em><em>s</em><em>u</em><em>e</em><em>s</em>/135)|4|8|<em>N</em><em>A</em>|<em>P</em><em>R</em><em>I</em><em>O</em><em>R</em><em>I</em><em>T</em><em>Y</em><em>L</em><em>O</em><em>W</em>|<em>f</em><em>i</em><em>n</em><em>i</em><em>s</em><em>h</em><em>w</em><em>o</em><em>r</em><em>k</em><em>i</em><em>n</em><em>p</em><em>r</em><em>o</em><em>g</em><em>r</em><em>e</em><em>s</em><em>s</em><em>o</em><em>n</em><em>d</em><em>e</em><em>f</em><em>a</em><em>u</em><em>l</em><em>t</em><sub><em>s</em></sub><em>s</em><sub><em>c</em></sub><em>h</em><em>o</em><em>o</em><em>s</em><em>e</em><sub><em>m</em></sub><em>e</em><em>t</em><em>h</em><em>o</em><em>d</em><em>v</em><em>s</em><em>i</em><em>n</em><em>p</em><em>u</em><em>t</em></span>
 ?</td>
 </tr>
 <tr>
@@ -3063,36 +3119,6 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/163">163
 <td>PRIORITY MEDIUM</td>
 <td>put certain columns last in table of results (bg count, block count,
 rad…</td>
-</tr>
-<tr>
-<td>C</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/162">162</a></td>
-<td>1</td>
-<td>7</td>
-<td>v4</td>
-<td>PRIORITY MEDIUM</td>
-<td>rename “in_how_many_states” column in table of results</td>
-</tr>
-<tr>
-<td>C</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/136">136</a></td>
-<td>1</td>
-<td>7</td>
-<td>v4</td>
-<td>PRIORITY LOW</td>
-<td>in web app, fix console error msg when uploading a shapefile</td>
-</tr>
-<tr>
-<td>C</td>
-<td><a
-href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288">288</a></td>
-<td>2</td>
-<td>7</td>
-<td>v3.2022.2</td>
-<td>PRIORITY MEDIUM</td>
-<td>ratio of 1.0 should not be yellow on community report</td>
 </tr>
 <tr>
 <td>C</td>
@@ -3465,6 +3491,17 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/60">60</
 <tr>
 <td>D</td>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/560">560</a></td>
+<td>4</td>
+<td>4</td>
+<td>NA</td>
+<td>—</td>
+<td>Four NAICS web-scrape tests fail when naics.com blocks a CI runner
+(seen…</td>
+</tr>
+<tr>
+<td>D</td>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/508">508</a></td>
 <td>4</td>
 <td>4</td>
@@ -3528,6 +3565,17 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/35">35</
 <tr>
 <td>D</td>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/546">546</a></td>
+<td>4</td>
+<td>1</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>count_sites_with_n_high_scores() ratio default still 1.01,
+inconsistent …</td>
+</tr>
+<tr>
+<td>D</td>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/62">62</a></td>
 <td>4</td>
 <td>1</td>
@@ -3557,6 +3605,27 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/55">55</
 <td>PRIORITY LOW</td>
 <td>add links to COUNTY-LEVEL reports - on a place - from other tools/
 sourc…</td>
+</tr>
+<tr>
+<td>D</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/548">548</a></td>
+<td>4</td>
+<td>0</td>
+<td>v4</td>
+<td>—</td>
+<td>R CMD check has 2 ERRORs on macOS and Windows, exposed by #530</td>
+</tr>
+<tr>
+<td>D</td>
+<td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/547">547</a></td>
+<td>6</td>
+<td>4</td>
+<td>v4</td>
+<td>PRIORITY MEDIUM</td>
+<td>Define color-coding cutoffs once, as adjustable parameters (design
+half …</td>
 </tr>
 <tr>
 <td>D</td>
@@ -3656,6 +3725,17 @@ href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/18">18</
 <tr>
 <td>D</td>
 <td><a
+href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/550">550</a></td>
+<td>8</td>
+<td>4</td>
+<td>v4</td>
+<td>PRIORITY LOW</td>
+<td>Point-shapefile upload: make the error message actionable, and
+dedupe th…</td>
+</tr>
+<tr>
+<td>D</td>
+<td><a
 href="https://github.com/Public-Environmental-Data-Partners/EJAM/issues/95">95</a></td>
 <td>8</td>
 <td>4</td>
@@ -3736,16 +3816,12 @@ code</td>
 <td style="text-align: right;">1</td>
 </tr>
 <tr>
-<td>v3.2022.2</td>
-<td style="text-align: right;">2</td>
-</tr>
-<tr>
 <td>v4</td>
-<td style="text-align: right;">19</td>
+<td style="text-align: right;">22</td>
 </tr>
 <tr>
 <td>NA</td>
-<td style="text-align: right;">110</td>
+<td style="text-align: right;">113</td>
 </tr>
 </tbody>
 </table>

--- a/inst/issues/ejam_issues_scored_by_risk_and_value.json
+++ b/inst/issues/ejam_issues_scored_by_risk_and_value.json
@@ -1,9 +1,9 @@
 {
   "metadata": {
-    "generated": "2026-08-02",
+    "generated": "2026-08-11",
     "source": "Live GitHub REST API open issues (Public-Environmental-Data-Partners/EJAM)",
     "repository": "Public-Environmental-Data-Partners/EJAM",
-    "open_issue_count": 132,
+    "open_issue_count": 136,
     "cost_median": 4,
     "benefit_median": 5,
     "rank_labels": {
@@ -14,19 +14,169 @@
     },
     "report_path": "inst/issues/ejam_issues_scored_by_risk_and_value.MD",
     "run_changes": {
-      "previous_run": "2026-07-27",
-      "opened_count": 0,
-      "closed_count": 0,
+      "previous_run": "2026-08-02",
+      "opened_count": 7,
+      "closed_count": 3,
       "quadrant_changed_count": 2,
-      "opened_issue_numbers": [],
-      "closed_issue_numbers": [],
+      "opened_issue_numbers": [
+        546,
+        547,
+        548,
+        550,
+        553,
+        555,
+        560
+      ],
+      "closed_issue_numbers": [
+        249,
+        288,
+        344
+      ],
       "quadrant_changed_issue_numbers": [
         136,
-        458
+        162
       ]
     }
   },
   "issues": [
+    {
+      "number": 560,
+      "title": "Four NAICS web-scrape tests fail when naics.com blocks a CI runner (seen on Linux)",
+      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/560",
+      "existing_labels": [],
+      "milestone": "NA",
+      "cost": 4,
+      "benefit": 4,
+      "quadrant": "D",
+      "rank_label": "rank:D-defer",
+      "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
+        "rank:C-low-value-low-cost"
+      ],
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+    },
+    {
+      "number": 555,
+      "title": "Saved-results fixtures are macOS-specific: the 4 comparisons fail on Linux and Windows",
+      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/555",
+      "existing_labels": [
+        "BUG",
+        "PRIORITY MEDIUM",
+        "test"
+      ],
+      "milestone": "NA",
+      "cost": 4,
+      "benefit": 12,
+      "quadrant": "B",
+      "rank_label": "rank:B-high-value-high-cost",
+      "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
+        "rank:C-low-value-low-cost",
+        "rank:D-defer"
+      ],
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 12\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+    },
+    {
+      "number": 553,
+      "title": "plot_lorenz_*() draft plots are broken: undefined bysite, filter on a literal, constant aes mapping",
+      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/553",
+      "existing_labels": [
+        "BUG",
+        "PRIORITY LOW"
+      ],
+      "milestone": "NA",
+      "cost": 6,
+      "benefit": 9,
+      "quadrant": "B",
+      "rank_label": "rank:B-high-value-high-cost",
+      "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
+        "rank:C-low-value-low-cost",
+        "rank:D-defer"
+      ],
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 6\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+    },
+    {
+      "number": 550,
+      "title": "Point-shapefile upload: make the error message actionable, and dedupe the rule between app_server.R and shapefix.R",
+      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/550",
+      "existing_labels": [
+        "PRIORITY LOW",
+        "shapefile-related",
+        "refactor",
+        "Affects Web App"
+      ],
+      "milestone": "v4",
+      "cost": 8,
+      "benefit": 4,
+      "quadrant": "D",
+      "rank_label": "rank:D-defer",
+      "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
+        "rank:C-low-value-low-cost"
+      ],
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 8\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+    },
+    {
+      "number": 548,
+      "title": "R CMD check has 2 ERRORs on macOS and Windows, exposed by #530",
+      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/548",
+      "existing_labels": [],
+      "milestone": "v4",
+      "cost": 4,
+      "benefit": 0,
+      "quadrant": "D",
+      "rank_label": "rank:D-defer",
+      "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
+        "rank:C-low-value-low-cost"
+      ],
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+    },
+    {
+      "number": 547,
+      "title": "Define color-coding cutoffs once, as adjustable parameters (design half of #288)",
+      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/547",
+      "existing_labels": [
+        "PRIORITY MEDIUM",
+        "refactor",
+        "Community Report"
+      ],
+      "milestone": "v4",
+      "cost": 6,
+      "benefit": 4,
+      "quadrant": "D",
+      "rank_label": "rank:D-defer",
+      "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
+        "rank:C-low-value-low-cost"
+      ],
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+    },
+    {
+      "number": 546,
+      "title": "count_sites_with_n_high_scores() ratio default still 1.01, inconsistent with the 1.05 yellow cutoff from #369",
+      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/546",
+      "existing_labels": [
+        "PRIORITY LOW",
+        "LongReport_output"
+      ],
+      "milestone": "v4",
+      "cost": 4,
+      "benefit": 1,
+      "quadrant": "D",
+      "rank_label": "rank:D-defer",
+      "rank_labels_to_remove": [
+        "rank:A-high-value-low-cost",
+        "rank:B-high-value-high-cost",
+        "rank:C-low-value-low-cost"
+      ],
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+    },
     {
       "number": 536,
       "title": "redo list of URLs in url_package() documentation",
@@ -47,7 +197,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 535,
@@ -69,7 +219,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 527,
@@ -91,7 +241,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 513,
@@ -113,7 +263,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 6\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 511,
@@ -135,7 +285,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 510,
@@ -157,7 +307,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 508,
@@ -177,7 +327,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 507,
@@ -197,7 +347,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 504,
@@ -218,7 +368,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 497,
@@ -240,7 +390,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 490,
@@ -262,7 +412,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 486,
@@ -283,7 +433,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 6\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 1\nBenefit score: 6\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 484,
@@ -304,7 +454,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 482,
@@ -324,7 +474,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 1\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 1\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 464,
@@ -343,7 +493,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 458,
@@ -365,7 +515,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 455,
@@ -385,7 +535,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 1\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 454,
@@ -405,7 +555,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 446,
@@ -425,7 +575,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 7\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 7\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 403,
@@ -448,7 +598,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 1\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 400,
@@ -470,7 +620,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 13\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 399,
@@ -494,7 +644,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 11\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 11\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 387,
@@ -516,7 +666,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 8\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 386,
@@ -535,7 +685,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 8\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 361,
@@ -557,7 +707,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 354,
@@ -580,7 +730,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 350,
@@ -603,7 +753,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 349,
@@ -629,31 +779,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 344,
-      "title": "Show an example of a community report - e.g., in or linked from \"basics\" vignette",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/344",
-      "existing_labels": [
-        "documentation",
-        "enhancement",
-        "help wanted",
-        "good first issue",
-        "PRIORITY HIGH-ish but not a bug",
-        "rank:A-high-value-low-cost"
-      ],
-      "milestone": "v4",
-      "cost": 2,
-      "benefit": 12,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
-      "rank_labels_to_remove": [
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
-        "rank:D-defer"
-      ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 343,
@@ -672,7 +798,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 342,
@@ -695,7 +821,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 341,
@@ -718,7 +844,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 293,
@@ -742,30 +868,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 5\nBenefit score: 19\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 288,
-      "title": "ratio of 1.0 should not be yellow on community report",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/288",
-      "existing_labels": [
-        "enhancement",
-        "PRIORITY MEDIUM",
-        "Affects Web App",
-        "Community Report",
-        "rank:A-high-value-low-cost"
-      ],
-      "milestone": "v3.2022.2",
-      "cost": 2,
-      "benefit": 7,
-      "quadrant": "C",
-      "rank_label": "rank:C-low-value-low-cost",
-      "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
-        "rank:B-high-value-high-cost",
-        "rank:D-defer"
-      ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 5\nBenefit score: 19\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 284,
@@ -787,7 +890,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 6\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 6\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 279,
@@ -810,7 +913,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 5\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 5\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 274,
@@ -833,7 +936,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 268,
@@ -853,7 +956,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 256,
@@ -877,29 +980,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
-    },
-    {
-      "number": 249,
-      "title": "ejam2report() fails if filename is specified without path, or with \"./xyz.html\"",
-      "url": "https://github.com/Public-Environmental-Data-Partners/EJAM/issues/249",
-      "existing_labels": [
-        "BUG",
-        "PRIORITY LOW",
-        "Affects R users only - NOT web app users",
-        "rank:A-high-value-low-cost"
-      ],
-      "milestone": "v3.2022.2",
-      "cost": 2,
-      "benefit": 12,
-      "quadrant": "A",
-      "rank_label": "rank:A-high-value-low-cost",
-      "rank_labels_to_remove": [
-        "rank:B-high-value-high-cost",
-        "rank:C-low-value-low-cost",
-        "rank:D-defer"
-      ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 12\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 231,
@@ -921,7 +1002,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 226,
@@ -945,7 +1026,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 7\nBenefit score: 16\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 7\nBenefit score: 16\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 224,
@@ -966,7 +1047,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 223,
@@ -988,7 +1069,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 208,
@@ -1010,7 +1091,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 194,
@@ -1033,7 +1114,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 5\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 5\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 193,
@@ -1057,7 +1138,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 5\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 5\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 192,
@@ -1080,7 +1161,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 184,
@@ -1104,7 +1185,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 183,
@@ -1128,7 +1209,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 0\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 182,
@@ -1151,7 +1232,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 181,
@@ -1175,7 +1256,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 1\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 180,
@@ -1198,7 +1279,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 7\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 7\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 179,
@@ -1221,7 +1302,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 177,
@@ -1243,7 +1324,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 176,
@@ -1266,7 +1347,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 175,
@@ -1288,7 +1369,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 0\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 174,
@@ -1311,7 +1392,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 0\nBenefit score: 3\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 172,
@@ -1334,7 +1415,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 170,
@@ -1357,7 +1438,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 169,
@@ -1380,7 +1461,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 9\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 168,
@@ -1404,7 +1485,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 8\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 167,
@@ -1428,7 +1509,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 5\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 166,
@@ -1451,7 +1532,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 9\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 163,
@@ -1473,7 +1554,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 162,
@@ -1488,14 +1569,14 @@
       "milestone": "v4",
       "cost": 1,
       "benefit": 7,
-      "quadrant": "C",
-      "rank_label": "rank:C-low-value-low-cost",
+      "quadrant": "A",
+      "rank_label": "rank:A-high-value-low-cost",
       "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
+        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 161,
@@ -1517,7 +1598,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 0\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 159,
@@ -1541,7 +1622,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 153,
@@ -1564,7 +1645,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 15\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 152,
@@ -1588,7 +1669,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 0\nBenefit score: 15\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 137,
@@ -1610,7 +1691,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 1\nBenefit score: 11\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 136,
@@ -1624,14 +1705,14 @@
       "milestone": "v4",
       "cost": 1,
       "benefit": 7,
-      "quadrant": "C",
-      "rank_label": "rank:C-low-value-low-cost",
+      "quadrant": "A",
+      "rank_label": "rank:A-high-value-low-cost",
       "rank_labels_to_remove": [
-        "rank:A-high-value-low-cost",
         "rank:B-high-value-high-cost",
+        "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 1\nBenefit score: 7\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 135,
@@ -1653,7 +1734,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 126,
@@ -1676,7 +1757,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 11\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 119,
@@ -1698,7 +1779,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 102,
@@ -1722,7 +1803,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 0\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 0\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 96,
@@ -1746,7 +1827,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 95,
@@ -1772,7 +1853,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 8\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 93,
@@ -1796,7 +1877,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 92,
@@ -1820,7 +1901,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 91,
@@ -1844,7 +1925,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 8\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 89,
@@ -1868,7 +1949,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 87,
@@ -1893,7 +1974,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 6\nBenefit score: 10\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 86,
@@ -1917,7 +1998,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 6\nBenefit score: 4\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 85,
@@ -1944,7 +2025,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 12\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 12\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 84,
@@ -1969,7 +2050,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 83,
@@ -1994,7 +2075,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 82,
@@ -2018,7 +2099,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 81,
@@ -2042,7 +2123,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 80,
@@ -2067,7 +2148,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 77,
@@ -2092,7 +2173,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 75,
@@ -2118,7 +2199,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 6\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 74,
@@ -2141,7 +2222,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 73,
@@ -2165,7 +2246,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 10\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 72,
@@ -2190,7 +2271,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 70,
@@ -2213,7 +2294,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 7\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 68,
@@ -2236,7 +2317,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 66,
@@ -2261,7 +2342,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 10\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 10\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 63,
@@ -2285,7 +2366,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 6\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 62,
@@ -2309,7 +2390,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 61,
@@ -2332,7 +2413,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 60,
@@ -2359,7 +2440,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 59,
@@ -2382,7 +2463,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 58,
@@ -2405,7 +2486,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 57,
@@ -2430,7 +2511,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 56,
@@ -2457,7 +2538,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 6\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 55,
@@ -2480,7 +2561,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 54,
@@ -2505,7 +2586,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 9\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 9\nBenefit score: 6\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 53,
@@ -2530,7 +2611,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 6\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 52,
@@ -2555,7 +2636,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 8\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 50,
@@ -2582,7 +2663,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 8\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 46,
@@ -2607,7 +2688,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 8\nBenefit score: 13\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 44,
@@ -2633,7 +2714,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 18\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 18\nBenefit score: 17\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 43,
@@ -2657,7 +2738,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 42,
@@ -2681,7 +2762,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 1\nBenefit score: 0\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 41,
@@ -2705,7 +2786,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 40,
@@ -2728,7 +2809,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 5\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 39,
@@ -2752,7 +2833,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 2\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 37,
@@ -2777,7 +2858,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 7\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 35,
@@ -2802,7 +2883,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 2\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 34,
@@ -2827,7 +2908,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 6\nBenefit score: 7\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 33,
@@ -2852,7 +2933,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 5\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 5\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 32,
@@ -2878,7 +2959,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 11\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 11\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 31,
@@ -2902,7 +2983,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 9\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 29,
@@ -2926,7 +3007,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 8\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 8\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 27,
@@ -2953,7 +3034,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 7\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 7\nBenefit score: 3\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 26,
@@ -2977,7 +3058,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 4\nBenefit score: 5\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 25,
@@ -3001,7 +3082,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 12\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 12\nBenefit score: 1\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 24,
@@ -3025,7 +3106,7 @@
         "rank:B-high-value-high-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 3\nBenefit score: 4\nQuadrant: C\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 19,
@@ -3049,7 +3130,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 6\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 6\nBenefit score: 8\nQuadrant: B\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 18,
@@ -3070,7 +3151,7 @@
         "rank:B-high-value-high-cost",
         "rank:C-low-value-low-cost"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 7\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 7\nBenefit score: 0\nQuadrant: D\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     },
     {
       "number": 16,
@@ -3095,7 +3176,7 @@
         "rank:C-low-value-low-cost",
         "rank:D-defer"
       ],
-      "rank_comment": "Last ranked: 2026-08-02\nCost score: 2\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
+      "rank_comment": "Last ranked: 2026-08-11\nCost score: 2\nBenefit score: 17\nQuadrant: A\nRun report: inst/issues/ejam_issues_scored_by_risk_and_value.MD"
     }
   ]
 }

--- a/inst/issues/ejam_issues_scoring_functions.py
+++ b/inst/issues/ejam_issues_scoring_functions.py
@@ -522,6 +522,23 @@ def issue_count_text(count: int) -> str:
     return f"{count} issue" if count == 1 else f"{count} issues"
 
 
+def md_escape(text: str) -> str:
+    """Escape the characters in an issue title that break the generated report.
+
+    Both of these are structural, not cosmetic:
+
+    * ``$`` opens a Pandoc inline-math span. Titles such as
+      ``doaggregate()$results_bybg_people`` and ``... vs input$ ?`` left an
+      unclosed span that swallowed every following table row into one cell --
+      three issues disappeared from each of two tables in the rendered HTML.
+    * ``|`` would end a table cell early and shift the rest of the row.
+
+    Applied only where a title is written into Markdown; the JSON payload keeps
+    the raw title, since it is data rather than markup.
+    """
+    return text.replace("$", r"\$").replace("|", r"\|")
+
+
 def _write_quad(lines: list[str], letter: str, heading: str, desc: str,
                 issues: list[dict]) -> None:
     lines.append(f"## Quadrant {letter} — {heading}")
@@ -531,7 +548,7 @@ def _write_quad(lines: list[str], letter: str, heading: str, desc: str,
     lines.append("")
     for r in issues:
         lines.append(
-            f"- [#{r['num']}]({URL_BASE}{r['num']}) — {r['title']}"
+            f"- [#{r['num']}]({URL_BASE}{r['num']}) — {md_escape(r['title'])}"
         )
     lines.append("")
     lines.append(
@@ -548,7 +565,9 @@ def _write_quad(lines: list[str], letter: str, heading: str, desc: str,
             and "PRIORITY" not in l
         ]
         lab_str  = ", ".join(key_labs[:4])
-        short    = r["title"][:70] + ("…" if len(r["title"]) > 70 else "")
+        ## truncate first, then escape - escaping first would let backslashes
+        ## count toward the limit and could cut a "\$" in half
+        short    = md_escape(r["title"][:70] + ("…" if len(r["title"]) > 70 else ""))
         lines.append(
             f"| [{r['num']}]({URL_BASE}{r['num']}) | {short} | "
             f"{r['cost']} ({cost_tier(r['cost'])}) | "
@@ -681,7 +700,7 @@ def generate_markdown(scored_issues: list[dict],
     for letter in ("A", "B", "C", "D"):
         for r in quads[letter]:
             plbl  = get_priority_label(r["labels"])
-            short = r["title"][:72] + ("…" if len(r["title"]) > 72 else "")
+            short = md_escape(r["title"][:72] + ("…" if len(r["title"]) > 72 else ""))
             lines.append(
                 f"| {letter} | [{r['num']}]({URL_BASE}{r['num']}) | "
                 f"{r['cost']} | {r['benefit']} | {r['milestone']} | "

--- a/inst/issues/test_ejam_issues_scoring_functions.py
+++ b/inst/issues/test_ejam_issues_scoring_functions.py
@@ -107,6 +107,51 @@ class IssueScorePayloadTest(unittest.TestCase):
         self.assertEqual(changes["closed_issue_numbers"], [999])
         self.assertEqual(changes["quadrant_changed_issue_numbers"], [101])
 
+    def test_markdown_escapes_dollar_signs_that_would_start_pandoc_math(self):
+        """A "$" in a title opened an inline-math span that ate later rows.
+
+        Titles like doaggregate()$results_bybg_people and "vs input$ ?" left an
+        unclosed <span class="math inline">, swallowing three following table
+        rows into one cell -- so those issues vanished from the rendered HTML.
+        """
+        scored = [
+            {
+                "num": 31,
+                "title": "fix distance_avg in doaggregate()$results_bybg_people",
+                "labels": ["BUG"],
+                "milestone": "NA",
+                "cost": 4,
+                "benefit": 9,
+                "quad": "B",
+            },
+            {
+                "num": 32,
+                "title": "a title with a | pipe that would end a table cell",
+                "labels": ["BUG"],
+                "milestone": "NA",
+                "cost": 4,
+                "benefit": 9,
+                "quad": "B",
+            },
+        ]
+
+        markdown = scoring.generate_markdown(
+            scored, cost_med=4, benefit_med=6, generated_date="2026-06-20"
+        )
+
+        # no bare "$" or in-title "|" survives into the Markdown
+        self.assertNotIn("doaggregate()$results", markdown)
+        self.assertIn(r"doaggregate()\$results_bybg_people", markdown)
+        self.assertIn(r"a title with a \| pipe", markdown)
+
+        # and the escaping is applied everywhere a title is written:
+        # the bullet list, the quadrant table, and the full table
+        self.assertEqual(markdown.count(r"doaggregate()\$results_bybg_people"), 3)
+
+    def test_md_escape_leaves_ordinary_titles_untouched(self):
+        plain = "check/ fix Distance and Site Count summary stats"
+        self.assertEqual(scoring.md_escape(plain), plain)
+
     def test_generate_markdown_puts_methodology_at_end(self):
         scored = [
             {


### PR DESCRIPTION
Refreshes the live GitHub-derived open-issues prioritization report for 2026-08-11.

- 136 open issues scored
- Retains the capped 20-item Quadrant A focus shortlist
- Regenerates the Markdown, JSON, and HTML artifacts
- Does not modify GitHub rank labels