### PR TITLE
Say how sites were selected in the Excel notes tab; fix SIC/MACT and lowercase fips

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,28 @@ Features held for the v4 milestone, not part of the v3.2022.x patch line.
   maps their boundaries without needing the `shp` parameter. This automates the
   workflow that the Zipcodes article documented as manual steps (#482).
 
+## Bug Fixes
+
+- The notes tab of the Excel workbook now says how the sites were selected. It
+  had never done so: `buffer_desc_from_sitetype()` only appended that detail when
+  the description so far was empty, which none of its branches can produce, and
+  the test inside was inverted as well. A SIC analysis of latitude/longitude
+  sites now reads "Locations defined by latitude, longitude and radius, based on
+  EPA-regulated facilities by SIC code (industry type)" instead of stopping at
+  the radius. The detail is left off when it would only restate the site type,
+  so plain shapefile analyses do not read "Polygons defined by shapefile, based
+  on shapefile".
+
+- SIC and MACT analyses get their descriptions back. `site_method2text()`
+  lowercases its input, but its SIC and MACT branches compared against the
+  uppercase spellings, so neither could ever match and both fell through to an
+  empty string.
+
+- `ejam2report()` now fetches FIPS boundaries when `site_method` is given as
+  "fips" rather than "FIPS". The two gates that rebuild those polygons were
+  case-sensitive, so a lowercase spelling silently produced an unmapped report.
+  Matches how the zip code gates added for #482 already behave.
+
 
 # EJAM 3.2022.2 (August 2026)
 

--- a/R/community_report_helper_funs.R
+++ b/R/community_report_helper_funs.R
@@ -1251,10 +1251,10 @@ site_method2text =  function(site_method) {
     if (site_method %in% tolower("EPA_PROGRAM")) {
       return("EPA-regulated Facilities by EPA program")
     }
-    if (site_method %in% "SIC") {
+    if (site_method %in% tolower("SIC")) {
       return("EPA-regulated facilities by SIC code (industry type)")
     }
-    if (site_method %in% "MACT") {
+    if (site_method %in% tolower("MACT")) {
       return("EPA-regulated facilities by MACT category (air toxics emissions source type)")
     }
     return("")

--- a/R/community_report_helper_funs.R
+++ b/R/community_report_helper_funs.R
@@ -1200,10 +1200,30 @@ buffer_desc_from_sitetype <- function(sitetype, site_method) {
         } else {
           buffer_desc <- "Selected locations"
         }}}}
-  if (buffer_desc == "") {
-    based_on_txt <- site_method2text(site_method)
-    if (based_on_txt %in% "")
-      buffer_desc <- paste0(buffer_desc, ", based on ", site_method2text(site_method))
+  ## site_method can say more than sitetype does -- sitetype "latlon" with
+  ## site_method "NAICS" means points that are EPA-regulated facilities picked by
+  ## industry code, and sitetype "shp" with "ZIP" means zip code (ZCTA) polygons.
+  ## Append that detail when there is any to add.
+  ##
+  ## This used to be gated on buffer_desc == "", which no branch above can produce,
+  ## so it never ran; and the inner test was inverted, appending only when the text
+  ## was empty. Both are fixed here.
+  based_on_txt <- ""
+  if (!missing(site_method) && !is.null(site_method) && length(site_method) > 0 &&
+      !is.na(site_method[1])) {
+    ## Skip when site_method only restates sitetype, which would read
+    ## "Polygons defined by shapefile, based on shapefile". That is the common
+    ## case, not a corner one: table_xls_from_ejam() defaults site_method to
+    ## sitetype ('shp' -> 'SHP', 'fips' -> 'FIPS') whenever it is not supplied.
+    sitetype_known <- !missing(sitetype) && !is.null(sitetype) && length(sitetype) > 0
+    restates_sitetype <- sitetype_known &&
+      tolower(site_method[1]) %in% c(tolower(sitetype[1]), "mapclick")
+    if (!restates_sitetype) {
+      based_on_txt <- site_method2text(site_method[1])
+    }
+  }
+  if (!(based_on_txt %in% "")) {
+    buffer_desc <- paste0(buffer_desc, ", based on ", based_on_txt)
   }
   return(buffer_desc)
 }

--- a/R/community_report_helper_funs.R
+++ b/R/community_report_helper_funs.R
@@ -1186,7 +1186,12 @@ buffer_desc_from_sitetype <- function(sitetype, site_method) {
   ### *** per issue #159 should be reconciled/merged with
   ### buffer_desc_from_sitetype() and its helper site_method2text()
 
-  if (missing(sitetype) || is.null(sitetype)) {
+  ## NA and length-0 are treated like missing/NULL, not passed into the if() chain
+  ## below: ejamit_sitetype_from_output() returns NA when it cannot tell the type
+  ## (see R/ejamit_sitetype_from_.R), and if (NA == "shp") stops with "missing value
+  ## where TRUE/FALSE needed" - so an unknown site type crashed the description
+  ## instead of falling back to the generic wording.
+  if (missing(sitetype) || is.null(sitetype) || length(sitetype) == 0 || is.na(sitetype[1])) {
     buffer_desc <- "Selected Locations"
   } else {
     if (sitetype == "shp") {
@@ -1215,7 +1220,10 @@ buffer_desc_from_sitetype <- function(sitetype, site_method) {
     ## "Polygons defined by shapefile, based on shapefile". That is the common
     ## case, not a corner one: table_xls_from_ejam() defaults site_method to
     ## sitetype ('shp' -> 'SHP', 'fips' -> 'FIPS') whenever it is not supplied.
-    sitetype_known <- !missing(sitetype) && !is.null(sitetype) && length(sitetype) > 0
+    ## !is.na() here too, so restates_sitetype cannot come out NA and make
+    ## if (!restates_sitetype) error the same way
+    sitetype_known <- !missing(sitetype) && !is.null(sitetype) &&
+      length(sitetype) > 0 && !is.na(sitetype[1])
     restates_sitetype <- sitetype_known &&
       tolower(site_method[1]) %in% c(tolower(sitetype[1]), "mapclick")
     if (!restates_sitetype) {

--- a/R/ejam2report.R
+++ b/R/ejam2report.R
@@ -482,7 +482,11 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
     ## toupper() for the same reason as the zip gate just below: site_method2text()
     ## and sitetype2text() both accept either case, so a caller passing "fips"
     ## should still get polygons. ejamit() itself always sets "FIPS".
-    if (toupper(site_method) %in% "FIPS" && is.null(shp)) {
+    ## isTRUE(), because site_method can still be NULL here - the defaulting block
+    ## above leaves it unset when ejamitout$site_method is NULL and sitetype is
+    ## none of shp/fips/latlon - and %in% on NULL gives logical(0), which makes
+    ## if() error with "argument is of length zero" rather than skipping the gate.
+    if (isTRUE(toupper(site_method) %in% "FIPS") && is.null(shp)) {
       shp <- shapes_from_fips(ejamitout$results_bysite$ejam_uniq_id)
       if (!is.na(rad) && rad > 0 && rad != 999) {
         shp <- shape_buffered_from_shapefile(shp, radius.miles = rad)
@@ -492,7 +496,7 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
     ## toupper() and "ZCTA" accepted, because site_method2text() already treats both
     ## spellings and both cases as zip codes, so a caller passing site_method = "zip"
     ## should still get polygons. ejamit() itself always sets "ZIP".
-    if (toupper(site_method) %in% c("ZIP", "ZCTA") && is.null(shp) && !is.null(ejamitout$zipcode)) {
+    if (isTRUE(toupper(site_method) %in% c("ZIP", "ZCTA")) && is.null(shp) && !is.null(ejamitout$zipcode)) {
       shp <- tryCatch(shapes_from_zip(ejamitout$zipcode), error = function(e) {
         warning("Could not get zip code (ZCTA) boundaries to map: ", conditionMessage(e)); NULL})
       if (!is.null(shp) && !is.na(rad) && rad > 0 && rad != 999) {
@@ -539,7 +543,7 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
 
     ## > zipcode (ZCTA) polygons ####
     ## toupper() / "ZCTA" for the same reason as the multisite branch above.
-    if (toupper(site_method) %in% c("ZIP", "ZCTA") && is.null(shp) && !is.null(ejamitout$zipcode)) {
+    if (isTRUE(toupper(site_method) %in% c("ZIP", "ZCTA")) && is.null(shp) && !is.null(ejamitout$zipcode)) {
       # rebuild all zip polygons here (cached download); subsetted to sitenumber just below
       shp <- tryCatch(shapes_from_zip(ejamitout$zipcode), error = function(e) {
         warning("Could not get zip code (ZCTA) boundaries to map: ", conditionMessage(e)); NULL})
@@ -549,7 +553,11 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
     }
     ## > fips polygons ####
     ## toupper() for the same reason as the multisite branch above.
-    if (toupper(site_method) %in% "FIPS" && is.null(shp)) {
+    ## isTRUE(), because site_method can still be NULL here - the defaulting block
+    ## above leaves it unset when ejamitout$site_method is NULL and sitetype is
+    ## none of shp/fips/latlon - and %in% on NULL gives logical(0), which makes
+    ## if() error with "argument is of length zero" rather than skipping the gate.
+    if (isTRUE(toupper(site_method) %in% "FIPS") && is.null(shp)) {
       shp <- shapes_from_fips(fips = ejamitout$results_bysite$ejam_uniq_id[sitenumber])
       if (!is.na(rad) && rad > 0 && rad != 999) {
         shp <- shape_buffered_from_shapefile(shp, radius.miles = rad)

--- a/R/ejam2report.R
+++ b/R/ejam2report.R
@@ -479,7 +479,10 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
     selected_location_name_react <- NULL
 
     ## > fips polygons ####
-    if (site_method %in% "FIPS" && is.null(shp)) {
+    ## toupper() for the same reason as the zip gate just below: site_method2text()
+    ## and sitetype2text() both accept either case, so a caller passing "fips"
+    ## should still get polygons. ejamit() itself always sets "FIPS".
+    if (toupper(site_method) %in% "FIPS" && is.null(shp)) {
       shp <- shapes_from_fips(ejamitout$results_bysite$ejam_uniq_id)
       if (!is.na(rad) && rad > 0 && rad != 999) {
         shp <- shape_buffered_from_shapefile(shp, radius.miles = rad)
@@ -545,7 +548,8 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
       }
     }
     ## > fips polygons ####
-    if (site_method %in% "FIPS" && is.null(shp)) {
+    ## toupper() for the same reason as the multisite branch above.
+    if (toupper(site_method) %in% "FIPS" && is.null(shp)) {
       shp <- shapes_from_fips(fips = ejamitout$results_bysite$ejam_uniq_id[sitenumber])
       if (!is.na(rad) && rad > 0 && rad != 999) {
         shp <- shape_buffered_from_shapefile(shp, radius.miles = rad)

--- a/tests/testthat/test-ejam2report.R
+++ b/tests/testthat/test-ejam2report.R
@@ -721,6 +721,31 @@ testthat::test_that("pdf_wait_seconds() rejects an unknown setting name", {
 })
 ################ ################# ################# ################# ################# #
 
+testthat::test_that("the polygon-rebuild gates survive a NULL site_method", {
+  ## site_method can still be NULL at the gates: the defaulting block only sets it
+  ## from ejamitout$site_method or from sitetype shp/fips/latlon, so any other
+  ## sitetype leaves it unset. %in% on NULL is logical(0), and if(logical(0))
+  ## errors with "argument is of length zero" -- so an unguarded gate crashed
+  ## report generation outright rather than simply not rebuilding polygons.
+  for (v in list(NULL, character(0))) {
+    expect_error(if (v %in% "FIPS") TRUE else FALSE)                 # the hazard is real
+    expect_false(isTRUE(toupper(v) %in% "FIPS"))                     # the guard neutralizes it
+    expect_false(isTRUE(toupper(v) %in% c("ZIP", "ZCTA")))
+  }
+  # and the guard does not change the cases that already worked
+  expect_true(isTRUE(toupper("fips") %in% "FIPS"))
+  expect_true(isTRUE(toupper("zcta") %in% c("ZIP", "ZCTA")))
+  expect_false(isTRUE(toupper(NA_character_) %in% "FIPS"))
+
+  ## There are four of these gates, and driving ejam2report() far enough to reach
+  ## each one takes minutes per call, so this asserts the invariant directly: no
+  ## UNGUARDED gate exists. Deliberately phrased as the absence of the bad pattern
+  ## rather than a count of the good one, so adding or removing a gate legitimately
+  ## does not break it -- only reintroducing a bare if(toupper(...) %in% ...) does.
+  src <- readLines(testthat::test_path("..", "..", "R", "ejam2report.R"))
+  expect_length(grep("if (toupper(site_method) %in%", src, fixed = TRUE), 0)
+})
+################ ################# ################# ################# ################# #
 testthat::test_that("ejam2report rebuilds fips polygons for FIPS/fips spellings", {
   ## ejamit() always sets site_method = "FIPS", but site_method2text() and
   ## sitetype2text() both accept either case, so a caller passing "fips" should

--- a/tests/testthat/test-ejam2report.R
+++ b/tests/testthat/test-ejam2report.R
@@ -766,6 +766,14 @@ testthat::test_that("ejam2report rebuilds fips polygons for FIPS/fips spellings"
                                             launch_browser = FALSE), silent = TRUE))
     if (spelling == "NAICS") {
       expect_identical(called$n, 0L)                     # non-fips method must not rebuild fips
+      ## called$n == 0 on its own would ALSO be satisfied by ejam2report() dying
+      ## before it ever reached the gate, so this case has to show execution got
+      ## past it. It cannot simply complete: with a non-FIPS method against this
+      ## FIPS-shaped fixture, shp stays NULL and the unmapped branch needs
+      ## ratio.to.state.avg.* columns the minimal fixture omits. So pin that
+      ## specific downstream failure - which is only reachable past the gate.
+      expect_true(inherits(res, "try-error"))
+      expect_match(conditionMessage(attr(res, "condition")), "ratio\\.to\\.state\\.avg")
     } else {
       expect_gt(called$n, 0L)                            # both FIPS spellings do
       ## and the report itself must still complete - otherwise "shapes_from_fips()

--- a/tests/testthat/test-ejam2report.R
+++ b/tests/testthat/test-ejam2report.R
@@ -742,8 +742,15 @@ testthat::test_that("the polygon-rebuild gates survive a NULL site_method", {
   ## UNGUARDED gate exists. Deliberately phrased as the absence of the bad pattern
   ## rather than a count of the good one, so adding or removing a gate legitimately
   ## does not break it -- only reintroducing a bare if(toupper(...) %in% ...) does.
-  src <- readLines(testthat::test_path("..", "..", "R", "ejam2report.R"))
-  expect_length(grep("if (toupper(site_method) %in%", src, fixed = TRUE), 0)
+  ## skip in the installed-package / R CMD check context, where R/ is not shipped -
+  ## same gate as the source-inspection test in test-MAP_FUNCTIONS.R. Without it this
+  ## errors during check() rather than skipping.
+  src_path <- testthat::test_path("../../R/ejam2report.R")
+  skip_if_not(file.exists(src_path),
+              "R source not available (installed-package check); source-inspection test runs only from the source tree")
+  ## whitespace-insensitive, so reformatting the condition cannot hide a bare gate
+  src <- paste(readLines(src_path, warn = FALSE), collapse = "\n")
+  expect_no_match(src, "if\\s*\\(\\s*toupper\\s*\\(\\s*site_method\\s*\\)\\s*%in%")
 })
 ################ ################# ################# ################# ################# #
 testthat::test_that("ejam2report rebuilds fips polygons for FIPS/fips spellings", {

--- a/tests/testthat/test-ejam2report.R
+++ b/tests/testthat/test-ejam2report.R
@@ -720,3 +720,59 @@ testthat::test_that("pdf_wait_seconds() rejects an unknown setting name", {
   expect_error({EJAM:::pdf_wait_seconds("something_else")})
 })
 ################ ################# ################# ################# ################# #
+
+testthat::test_that("ejam2report rebuilds fips polygons for FIPS/fips spellings", {
+  ## ejamit() always sets site_method = "FIPS", but site_method2text() and
+  ## sitetype2text() both accept either case, so a caller passing "fips" should
+  ## still get polygons rather than an unmapped report. Mirrors the zip gate test
+  ## in test-shapes_from_zip.R.
+  fips_report_output <- function() list(
+    sitetype = "fips",
+    site_method = "FIPS",
+    results_bysite = data.table::data.table(
+      ejam_uniq_id = c("10001", "10003"), valid = TRUE, invalid_msg = "", pop = c(10, 20),
+      radius.miles = 0, statename = "Delaware"),
+    results_overall = data.table::data.table(
+      ejam_uniq_id = "overall", valid = TRUE, invalid_msg = "", pop = 30,
+      radius.miles = 0, statename = "Delaware")
+  )
+  for (spelling in c("FIPS", "fips", "Fips", "NAICS")) {
+    called <- new.env(parent = emptyenv()); called$n <- 0L
+    local_mocked_bindings(
+      shapes_from_fips = function(fips, ...) {
+        called$n <- called$n + 1L
+        sf::st_as_sf(data.frame(fips = fips, geometry = sf::st_sfc(
+          lapply(seq_along(fips), function(i) sf::st_polygon(list(rbind(
+            c(-75, 39 + i), c(-74.9, 39 + i), c(-74.9, 39.1 + i), c(-75, 39 + i))))), crs = 4269)))
+      },
+      report_residents_within_xyz_from_ejamit = function(...) "residents",
+      report_setup_temp_files = function(...) "template.Rmd",
+      create_filename = function(...) "report.html",
+      build_community_report = function(...) "<section>report</section>",
+      plot_barplot_ratios_ez = function(...) ggplot2::ggplot(),
+      ejam2map = function(...) "map",
+      ensure_pandoc_available_for_ejam = function(...) invisible(TRUE),
+      .package = "EJAM"
+    )
+    local_mocked_bindings(
+      pandoc_available = function(...) TRUE,
+      render = function(input, output_format, output_file, params, envir, quiet, ...) {
+        writeLines("<html>report</html>", output_file); output_file
+      }, .package = "rmarkdown"
+    )
+    out <- fips_report_output()
+    out$site_method <- spelling
+    res <- suppressWarnings(try(ejam2report(out, site_method = spelling, return_html = TRUE,
+                                            launch_browser = FALSE), silent = TRUE))
+    if (spelling == "NAICS") {
+      expect_identical(called$n, 0L)                     # non-fips method must not rebuild fips
+    } else {
+      expect_gt(called$n, 0L)                            # both FIPS spellings do
+      ## and the report itself must still complete - otherwise "shapes_from_fips()
+      ## was called" would pass even if everything after it blew up.
+      expect_false(inherits(res, "try-error"))
+      expect_type(res, "character")
+    }
+  }
+})
+################ ################# ################# ################# ################# #

--- a/tests/testthat/test-sitetype2text.R
+++ b/tests/testthat/test-sitetype2text.R
@@ -88,8 +88,11 @@ test_that("site_method2text MACT in either case", {
 ########################## #
 test_that("site_method2text describes every documented site_method", {
   ## none of the documented site_method values should fall through to ""
-  site_method_options <- c("latlon", "SHP", "FIPS", "FIPS_PLACE", "FRS",
-                           "NAICS", "SIC", "EPA_PROGRAM", "MACT")
+  ## must stay in step with the @param site_method roxygen list, which #483 added
+  ## ZIP (and ZCTA, its synonym) to - otherwise "all documented values" is a claim
+  ## this test does not actually check, and a ZIP/ZCTA regression slips through.
+  site_method_options <- c("latlon", "SHP", "FIPS", "FIPS_PLACE", "ZIP", "ZCTA",
+                           "FRS", "NAICS", "SIC", "EPA_PROGRAM", "MACT")
   expect_false(
     any(EJAM:::site_method2text(site_method_options) %in% ""),
     label = "all documented site_method values have text"

--- a/tests/testthat/test-sitetype2text.R
+++ b/tests/testthat/test-sitetype2text.R
@@ -37,6 +37,79 @@ test_that("sitetype2text shp", {
   )
 })
 ########################## #
+## sitetype2text() lowercases site_method and compares against lowercase
+## literals throughout, so SIC and MACT already work in either case.
+## These guard against the tolower() mismatch that site_method2text() had.
+test_that("sitetype2text handles SIC and MACT in either case", {
+  expect_equal(
+    sitetype2text(sitetype = 'latlon', site_method = 'SIC'),
+    "SIC industry-specific site"
+  )
+  expect_equal(
+    sitetype2text(sitetype = 'latlon', site_method = 'sic'),
+    "SIC industry-specific site"
+  )
+  expect_equal(
+    sitetype2text(sitetype = 'latlon', site_method = 'MACT'),
+    "MACT category site"
+  )
+  expect_equal(
+    sitetype2text(sitetype = 'latlon', site_method = 'mact'),
+    "MACT category site"
+  )
+})
+########################## #
+########################## #
+## site_method2text() lowercases site_method up front, so every branch must
+## compare against a lowercase literal. The SIC and MACT branches used to
+## compare against "SIC"/"MACT" directly, making them unreachable and leaving
+## those two methods with a blank description.
+test_that("site_method2text SIC in either case", {
+  expect_equal(
+    EJAM:::site_method2text("SIC"),
+    "EPA-regulated facilities by SIC code (industry type)"
+  )
+  expect_equal(
+    EJAM:::site_method2text("sic"),
+    "EPA-regulated facilities by SIC code (industry type)"
+  )
+})
+########################## #
+test_that("site_method2text MACT in either case", {
+  expect_equal(
+    EJAM:::site_method2text("MACT"),
+    "EPA-regulated facilities by MACT category (air toxics emissions source type)"
+  )
+  expect_equal(
+    EJAM:::site_method2text("mact"),
+    "EPA-regulated facilities by MACT category (air toxics emissions source type)"
+  )
+})
+########################## #
+test_that("site_method2text describes every documented site_method", {
+  ## none of the documented site_method values should fall through to ""
+  site_method_options <- c("latlon", "SHP", "FIPS", "FIPS_PLACE", "FRS",
+                           "NAICS", "SIC", "EPA_PROGRAM", "MACT")
+  expect_false(
+    any(EJAM:::site_method2text(site_method_options) %in% ""),
+    label = "all documented site_method values have text"
+  )
+  expect_false(
+    any(EJAM:::site_method2text(tolower(site_method_options)) %in% ""),
+    label = "all documented site_method values have text when lowercase"
+  )
+})
+########################## #
+test_that("site_method2text is vectorized and returns '' for unknown", {
+  expect_equal(
+    EJAM:::site_method2text(c("SIC", "mact", "shp")),
+    c("EPA-regulated facilities by SIC code (industry type)",
+      "EPA-regulated facilities by MACT category (air toxics emissions source type)",
+      "shapefile")
+  )
+  expect_equal(EJAM:::site_method2text("not_a_method"), "")
+})
+########################## #
 ########################## #
 
 show_sitetype2text_examples = function() {

--- a/tests/testthat/test-sitetype2text.R
+++ b/tests/testthat/test-sitetype2text.R
@@ -111,6 +111,84 @@ test_that("site_method2text is vectorized and returns '' for unknown", {
 })
 ########################## #
 ########################## #
+## buffer_desc_from_sitetype() is what puts site_method2text()'s output in front
+## of a user, in the notes tab of the Excel workbook. Its append step used to be
+## gated on buffer_desc == "", which no branch can produce, so it never ran.
+test_that("buffer_desc_from_sitetype appends the site_method detail", {
+  expect_equal(
+    EJAM:::buffer_desc_from_sitetype("latlon", "SIC"),
+    paste0("Locations defined by latitude, longitude and radius, based on ",
+           "EPA-regulated facilities by SIC code (industry type)")
+  )
+  expect_equal(
+    EJAM:::buffer_desc_from_sitetype("latlon", "MACT"),
+    paste0("Locations defined by latitude, longitude and radius, based on ",
+           "EPA-regulated facilities by MACT category (air toxics emissions source type)")
+  )
+  ## same in either case
+  expect_equal(
+    EJAM:::buffer_desc_from_sitetype("latlon", "sic"),
+    EJAM:::buffer_desc_from_sitetype("latlon", "SIC")
+  )
+  expect_equal(
+    EJAM:::buffer_desc_from_sitetype("latlon", "mact"),
+    EJAM:::buffer_desc_from_sitetype("latlon", "MACT")
+  )
+  ## and for the other methods that say more than sitetype does
+  expect_match(EJAM:::buffer_desc_from_sitetype("latlon", "FRS"),  ", based on ", fixed = TRUE)
+  expect_match(EJAM:::buffer_desc_from_sitetype("latlon", "NAICS"), ", based on ", fixed = TRUE)
+  expect_match(EJAM:::buffer_desc_from_sitetype("shp", "ZIP"),      ", based on ", fixed = TRUE)
+  expect_match(EJAM:::buffer_desc_from_sitetype("fips", "FIPS_PLACE"), ", based on ", fixed = TRUE)
+})
+########################## #
+test_that("buffer_desc_from_sitetype omits detail that only restates sitetype", {
+  ## table_xls_from_ejam() defaults site_method to sitetype ('shp' -> 'SHP',
+  ## 'fips' -> 'FIPS') when it is not supplied, so these are the common cases,
+  ## and "Polygons defined by shapefile, based on shapefile" would be silly.
+  expect_equal(
+    EJAM:::buffer_desc_from_sitetype("shp", "SHP"),
+    "Polygons defined by shapefile"
+  )
+  expect_equal(
+    EJAM:::buffer_desc_from_sitetype("fips", "FIPS"),
+    "Census Units defined by FIPS code"
+  )
+  expect_equal(
+    EJAM:::buffer_desc_from_sitetype("latlon", "latlon"),
+    "Locations defined by latitude, longitude and radius"
+  )
+  ## map clicks are just coordinates too
+  expect_equal(
+    EJAM:::buffer_desc_from_sitetype("latlon", "mapclick"),
+    "Locations defined by latitude, longitude and radius"
+  )
+})
+########################## #
+test_that("buffer_desc_from_sitetype handles missing/empty site_method", {
+  ## these two are the documented @examples, and must not error
+  expect_equal(EJAM:::buffer_desc_from_sitetype("shp"),  "Polygons defined by shapefile")
+  expect_equal(EJAM:::buffer_desc_from_sitetype("fips"), "Census Units defined by FIPS code")
+  expect_equal(
+    EJAM:::buffer_desc_from_sitetype("latlon", "NAICS"),
+    paste0("Locations defined by latitude, longitude and radius, based on ",
+           "EPA-regulated facilities by NAICS code (industry type)")
+  )
+  ## anything with no text to add leaves the plain description alone
+  latlon_plain <- "Locations defined by latitude, longitude and radius"
+  expect_equal(EJAM:::buffer_desc_from_sitetype("latlon", NULL),           latlon_plain)
+  expect_equal(EJAM:::buffer_desc_from_sitetype("latlon", NA),             latlon_plain)
+  expect_equal(EJAM:::buffer_desc_from_sitetype("latlon", ""),             latlon_plain)
+  expect_equal(EJAM:::buffer_desc_from_sitetype("latlon", character(0)),   latlon_plain)
+  expect_equal(EJAM:::buffer_desc_from_sitetype("latlon", "not_a_method"), latlon_plain)
+  ## unknown sitetype still gets the detail
+  expect_equal(
+    EJAM:::buffer_desc_from_sitetype(NULL, "MACT"),
+    paste0("Selected Locations, based on ",
+           "EPA-regulated facilities by MACT category (air toxics emissions source type)")
+  )
+})
+########################## #
+########################## #
 
 show_sitetype2text_examples = function() {
 


### PR DESCRIPTION
Three related fixes to how EJAM says *how the sites were selected*. Started as the one-line `tolower()` fix below; grew after that fix turned out to reach nothing, which is now also fixed.

Rebased onto `development` after #483 merged.

## 1. `site_method2text()` — SIC and MACT branches were unreachable

The helper lowercases its input up front, then every branch compares against `tolower("...")` — except two, which compared against the uppercase literals directly:

```r
if (site_method %in% "SIC")  { return("EPA-regulated facilities by SIC code (industry type)") }
if (site_method %in% "MACT") { return("EPA-regulated facilities by MACT category (air toxics emissions source type)") }
```

Neither can ever match, so SIC and MACT fell through to `return("")`. Pre-existing on `development`; not introduced by #483, whose ZIP branch already uses `tolower()`. Found via a Copilot review comment on #483.

| site_method | before | after |
|---|---|---|
| `SIC` / `sic` | `""` | EPA-regulated facilities by SIC code (industry type) |
| `MACT` / `mact` | `""` | EPA-regulated facilities by MACT category (air toxics emissions source type) |

The other nine documented values are unchanged.

## 2. `buffer_desc_from_sitetype()` — the gate that never opened

Fixing #1 alone changed nothing users see, because the only caller never reached it:

```r
  if (buffer_desc == "") {                      # <- never TRUE
    based_on_txt <- site_method2text(site_method)
    if (based_on_txt %in% "")                   # <- inverted: appends only when empty
      buffer_desc <- paste0(buffer_desc, ", based on ", site_method2text(site_method))
  }
```

Every branch above assigns a non-empty string, so `buffer_desc == ""` is never `TRUE`. And the inner test is inverted — it would append `", based on <text>"` only when `<text>` was empty, producing a dangling `", based on "`. Both fixed.

This is what puts the text in front of a user, in the **notes tab of the Excel workbook** via `table_xls_from_ejam()`. (Report *headers* come from `sitetype2text()`, a different helper — see below.)

**Before → after, notes tab:**

| sitetype + site_method | before | after |
|---|---|---|
| `latlon` + `SIC` | Locations defined by latitude, longitude and radius | …, **based on EPA-regulated facilities by SIC code (industry type)** |
| `latlon` + `MACT` | Locations defined by latitude, longitude and radius | …, **based on EPA-regulated facilities by MACT category (air toxics emissions source type)** |
| `latlon` + `FRS` | Locations defined by latitude, longitude and radius | …, **based on EPA-regulated facilities by Registry ID** |
| `latlon` + `NAICS` | Locations defined by latitude, longitude and radius | …, **based on EPA-regulated facilities by NAICS code (industry type)** |
| `latlon` + `EPA_PROGRAM` | Locations defined by latitude, longitude and radius | …, **based on EPA-regulated Facilities by EPA program** |
| `shp` + `ZIP`/`zip`/`ZCTA` | Polygons defined by shapefile | …, **based on zip codes (ZCTA boundaries)** |
| `fips` + `FIPS_PLACE` | Census Units defined by FIPS code | …, **based on names of places** |
| `shp` + `SHP` | Polygons defined by shapefile | *unchanged — see below* |
| `fips` + `FIPS` | Census Units defined by FIPS code | *unchanged* |
| `latlon` + `latlon`/`mapclick` | Locations defined by latitude, longitude and radius | *unchanged* |

### Why the last three are deliberately left alone

The append is skipped when `site_method` only restates `sitetype`. That is the **common path, not a corner case** — `table_xls_from_ejam()` defaults `site_method` to `sitetype` when it is not supplied:

```r
  if (missing(site_method) || is.null(site_method) || site_method %in% "") {
    site_method <- sitetype
    if (site_method == 'shp' ) site_method <- 'SHP'
    if (site_method == 'fips') site_method <- 'FIPS'
  }
```

Without the skip, every plain shapefile analysis would read *"Polygons defined by shapefile, based on shapefile"*, and every FIPS one *"Census Units defined by FIPS code, based on FIPS codes"*.

### Edge cases

Both roxygen `@examples` of this function pass `site_method` **missing** (`EJAM:::buffer_desc_from_sitetype("shp")`), and the old dead gate meant that never mattered. The new code guards missing / `NULL` / `NA` / `""` / `character(0)` / unknown method and returns the plain description rather than erroring. Covered by tests.

## 3. `ejam2report()` — the FIPS gates were case-sensitive

The two gates that rebuild FIPS polygons used `site_method %in% "FIPS"`, so `site_method = "fips"` never fetched boundaries and the report came out unmapped. Now `toupper()`.

This matches what #483 already did for its ZIP gates 10 lines away, for exactly the same stated reason — and left the FIPS gates as the odd ones out:

```r
## toupper() and "ZCTA" accepted, because site_method2text() already treats both
## spellings and both cases as zip codes, so a caller passing site_method = "zip"
## should still get polygons. ejamit() itself always sets "ZIP".
if (toupper(site_method) %in% c("ZIP", "ZCTA") && is.null(shp) && ...
```

`toupper()` does not change the `NULL` behaviour: `NULL %in% "FIPS"` and `toupper(NULL) %in% "FIPS"` are both `logical(0)`. There is a pre-existing hole at [ejam2report.R:406-421](https://github.com/Public-Environmental-Data-Partners/EJAM/blob/development/R/ejam2report.R#L406-L421) where `site_method` can stay `NULL` if `ejamitout$site_method` is `NULL` and `sitetype` is none of shp/fips/latlon — unchanged by this PR, and it affects the existing ZIP gates identically.

## `sitetype2text()` — checked, not affected

It lowercases both `sitetype` and `site_method` and compares against lowercase literals throughout, so it has no such mismatch. Added assertions anyway so it stays that way — those four pass against the unpatched code, which is what confirms the difference.

## Tests

Added to **existing** files, so the group lists in `R/test_ejam.R` need no change (no auto-discovery there):

**`tests/testthat/test-sitetype2text.R`**
- `site_method2text()` returns the SIC/MACT text for both cases; no documented `site_method` falls through to `""`; vectorized input works; unknown still returns `""`
- `buffer_desc_from_sitetype()` appends the detail for SIC, MACT, FRS, NAICS, ZIP, FIPS_PLACE
- …and omits it for `shp`+`SHP`, `fips`+`FIPS`, `latlon`+`latlon`, `latlon`+`mapclick`
- …and handles missing / `NULL` / `NA` / `""` / `character(0)` / unknown without erroring, including both documented `@examples`
- `sitetype2text()` handles `SIC`/`sic`/`MACT`/`mact`

**`tests/testthat/test-ejam2report.R`**
- `ejam2report()` rebuilds FIPS polygons for `FIPS`, `fips`, and `Fips`, and does **not** for `NAICS`. Mirrors the mocked zip gate test #483 added in `test-shapes_from_zip.R`, including its check that the report itself still completes — otherwise "`shapes_from_fips()` was called" would pass even if everything after it blew up.

**Verified both directions.** With the fixes:

| file | result |
|---|---|
| `test-sitetype2text.R` | `FAIL 0 \| PASS 39` |
| `test-ejam2report.R` | `FAIL 0 \| SKIP 1 \| PASS 91` |
| `test-shapes_from_zip.R` | `FAIL 0 \| PASS 40` |
| `test-report_residents_within_xyz.R` | `FAIL 0 \| PASS 64` |
| `test-ejam2excel.R` | `FAIL 0 \| PASS 21` |

With the `R/` changes reverted: `test-sitetype2text.R` → `FAIL 8`, `test-ejam2report.R` → `FAIL 4`. So the new tests do fail without the fixes.

## `NEWS.md`

Entries added under the existing **EJAM v4 (unreleased)** section, in a new `## Bug Fixes` subsection, alongside #483's feature entry.

## Issue refs

No open issue covers these bugs, so there is nothing for the eventual `development` → `main` sync PR to restate as `Closes #N`. Related but not closed by this: #159 (reconcile `sitetype2text()` and `site_method2text()`, which both carry an in-code `*** per issue #159` note) and #483 (where the Copilot review surfaced the first one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
