### PR TITLE
Link vignettes to the docs site via url_package("docs"), not ../ paths (fixes #565)

### DIFF
--- a/vignettes/analyzing.Rmd
+++ b/vignettes/analyzing.Rmd
@@ -27,6 +27,14 @@ knitr::opts_chunk$set(eval = FALSE, warning = FALSE)
 # https://r-pkgs.org/vignettes.html
 ```
 
+```{r SETUP_urls, eval=TRUE, echo=FALSE, include=FALSE}
+
+docs_reponame_url <- EJAM::url_package(type = "docs", get_full_url = TRUE)  # "https://OWNER.github.io/REPONAME"
+# Used for links into the reference manual. Absolute, not "../reference/...",
+# so the links also work in the vignette as installed with the package.
+
+```
+
 ```{r libraryEJAM, eval = TRUE, echo=FALSE, include=FALSE, warning=FALSE, message=FALSE}
 # rm(list = ls()); golem::detach_all_attached(); devtools::load_all()
  
@@ -80,7 +88,7 @@ However, if you first need to get the points (lat, lon values), or you need a
 more in-depth, custom approach to finding facilities or Census places to
 analyze, there are several groups of functions to help with that, as shown in
 all the examples below. They are also shown in the [EJAM package reference
-manual](../reference/index.html), by category.
+manual](`r paste0(docs_reponame_url, "/reference/index.html")`), by category.
 
 You can specify locations for analysis in a variety of ways:
 
@@ -129,7 +137,7 @@ In the web app you can also pick points without a file by choosing
 point's marker again to remove it).
 
 There are also [more detailed functions for working with latlon
-coordinates.](../reference/index.html#specify-points-by-lat-lon)
+coordinates.](`r paste0(docs_reponame_url, "/reference/index.html#specify-points-by-lat-lon")`)
 
 The simplest way to do that in the RStudio console is something like
 `x <- ejamit()`, which prompts you to upload a spreadsheet with lat lon columns,
@@ -149,7 +157,7 @@ greenhouse gas reporters), or a Clean Air Act MACT subpart.
 EPA-regulated facilities can be found in the Facility Registry Services by
 identification number.
 
-[See a list of functions related to EPA IDs](../reference/index.html#specify-facilities-by-id)
+[See a list of functions related to EPA IDs](`r paste0(docs_reponame_url, "/reference/index.html#specify-facilities-by-id")`)
 
 ### by Facility, using EPA Registry ID
 
@@ -189,7 +197,7 @@ if (exists("frs_by_programid")) {
 
 ## Facilities by Type
 
-[See a list of functions related to type of facility (NAICS/SIC/Program/MACT)](../reference/index.html#specify-facility-type)
+[See a list of functions related to type of facility (NAICS/SIC/Program/MACT)](`r paste0(docs_reponame_url, "/reference/index.html#specify-facility-type")`)
 
 ### by Industry (NAICS) {#by-industry-naics data-link="by Industry (NAICS)"}
 
@@ -210,11 +218,11 @@ naics_from_any("paint and coating", children = T)
 See many more examples of [Working with NAICS Codes (Industry
 Codes)](#working-with-naics-codes-industry-codes), in a section below.
 
-[Functions related to NAICS/SIC codes](../reference/index.html#choosing-naics-sic-industry-codes)
+[Functions related to NAICS/SIC codes](`r paste0(docs_reponame_url, "/reference/index.html#choosing-naics-sic-industry-codes")`)
 
 ### by EPA Regulatory Program
 
-[See a list of functions related to EPA programs](../reference/index.html#epa-programs)
+[See a list of functions related to EPA programs](`r paste0(docs_reponame_url, "/reference/index.html#epa-programs")`)
 
 ```{r tryload_frs_AND_frs_by_programid, include=FALSE}
 dataload_dynamic("frs_by_programid")
@@ -243,7 +251,7 @@ if (exists("frs_by_programid") && exists("frs")) {
 
 ### by MACT Subpart (hazardous air pollutant source category) {#by-mact-subpart-hazardous-air-pollutant-source-category}
 
-[Functions related to MACT codes](../reference/index.html#mact-categories)
+[Functions related to MACT codes](`r paste0(docs_reponame_url, "/reference/index.html#mact-categories")`)
 
 ```{r tryload_frs_by_mact, include=FALSE}
 dataload_dynamic("frs_by_mact")
@@ -450,7 +458,7 @@ if (exists("frs") & exists("frs_from_naics")) {
 You can upload polygons in a shapefile, and use EJAM to analyze them. See the
 Shiny app.
 
-See `shapefile_from_any()` and other [shapefile-related functions](../reference/index.html#specify-places-by-shapefile):
+See `shapefile_from_any()` and other [shapefile-related functions](`r paste0(docs_reponame_url, "/reference/index.html#specify-places-by-shapefile")`):
 
 ```{r notrun_shapefile_functionlist, eval=FALSE, echo=TRUE}
 shapefile_from_any()
@@ -469,7 +477,7 @@ shp1 <- shapefile_from_any(system.file("testdata/shapes/portland.gdb.zip", packa
 
 You can compare places defined by FIPS code, such as a group of US Counties.
 
-See a list of [functions for working with Census FIPS codes](../reference/index.html#specify-counties-etc-).
+See a list of [functions for working with Census FIPS codes](`r paste0(docs_reponame_url, "/reference/index.html#specify-counties-etc-")`).
 
 Compare all Counties in a State, using EJAM indicators
 
@@ -526,11 +534,11 @@ mapfastej_counties(xmd$results_bysite, 'state.pctile.pctlowinc')
 
 See also 
 
--  [functions for mapping](../reference/index.html#viewing-results). 
+-  [functions for mapping](`r paste0(docs_reponame_url, "/reference/index.html#viewing-results")`). 
 
--  [functions for seeing plots/graphics](../reference/index.html#plots-mean-of-one-indicator-at-each-site-or-type-of-site-comparing-sites-or-categories-of-sites-)
+-  [functions for seeing plots/graphics](`r paste0(docs_reponame_url, "/reference/index.html#plots-mean-of-one-indicator-at-each-site-or-type-of-site-comparing-sites-or-categories-of-sites-")`)
 
--  [functions for seeing tables of results](../reference/index.html#tables)
+-  [functions for seeing tables of results](`r paste0(docs_reponame_url, "/reference/index.html#tables")`)
 
 ### The most striking findings (e.g., which group is most over-represented?)
 
@@ -707,7 +715,7 @@ statestats_means(ST = c("MD", "VA"), varnames = names_e[1:3])
 
 # VISUALIZATION OF FINDINGS (PLOTS) {#visualization-of-findings-plots}
 
-See examples below, and the [list of plot-related functions](../reference/index.html#viewing-results).
+See examples below, and the [list of plot-related functions](`r paste0(docs_reponame_url, "/reference/index.html#viewing-results")`).
 
 ## Indicators
 

--- a/vignettes/basics.Rmd
+++ b/vignettes/basics.Rmd
@@ -322,8 +322,8 @@ mapfast(testpoints_n(300, ST = c('LA','TX'), weighting = 'bg'), radius = 0.1)
 
 # Documentation of Functions and Data
 
--   [README](../index.html){.uri target="_blank" rel="noreferrer noopener"}
--   [Function Reference Document](../reference/index.html){.uri target="_blank"
+-   [README](`r paste0(EJAM::url_package("docs"), "/index.html")`){.uri target="_blank" rel="noreferrer noopener"}
+-   [Function Reference Document](`r paste0(EJAM::url_package("docs"), "/reference/index.html")`){.uri target="_blank"
 rel="noreferrer noopener"}
 -   In RStudio, see `?EJAM`
 

--- a/vignettes/counties.Rmd
+++ b/vignettes/counties.Rmd
@@ -45,7 +45,7 @@ A few large counties contain a large proportion of the US population. This
 vignette briefly explores the distribution of counties in the US, particularly how many counties
 have a large number of block groups and residents.
 
-_Note there are also [guides to using EJAM in R for County/FIPS analysis](analyzing.html#fips-codes) and [reference documents on relevant R functions](../reference/index.html#specify-counties-etc-) and [county-related test data](../reference/index.html#examples-of-inputs-census-units-by-fips-)._
+_Note there are also [guides to using EJAM in R for County/FIPS analysis](analyzing.html#fips-codes) and [reference documents on relevant R functions](`r paste0(EJAM::url_package("docs"), "/reference/index.html#specify-counties-etc-")`) and [county-related test data](`r paste0(EJAM::url_package("docs"), "/reference/index.html#examples-of-inputs-census-units-by-fips-")`)._
 
 The US has over 3,200 Counties but the 80/20 rule applies almost exactly -- About 80% of the population is in just 20% of all Counties. In fact, most of the US population lives in less than 5% of all US Counties. About 150 counties account for most of the US residents. 
 ```{r stats1, eval=TRUE}

--- a/vignettes/dev-future-plans.Rmd
+++ b/vignettes/dev-future-plans.Rmd
@@ -62,7 +62,7 @@ Communicating key findings is challenging when such a large number of metrics ar
 
 ### Visualization Tools
 
-A variety of plots and maps will be explored as ways to communicate the rich data results calculated by EJAM. For example, EJAM R functions can calculate and display detailed estimates of the range of residential distances to facilities within each residential population subgroup - this type of visualization could be incorporated into the web app if there appears to be interest in it. Another possibility is that plots, maps, and tables could be made to interact in sync with each other, where that supports useful data exploration. See examples of plots in the vignettes, for example, and [the many plot_xyz functions and mapping functions](../reference/index.html#viewing-results).
+A variety of plots and maps will be explored as ways to communicate the rich data results calculated by EJAM. For example, EJAM R functions can calculate and display detailed estimates of the range of residential distances to facilities within each residential population subgroup - this type of visualization could be incorporated into the web app if there appears to be interest in it. Another possibility is that plots, maps, and tables could be made to interact in sync with each other, where that supports useful data exploration. See examples of plots in the vignettes, for example, and [the many plot_xyz functions and mapping functions](`r paste0(EJAM::url_package("docs"), "/reference/index.html#viewing-results")`).
 
 ### Spatial Resolution
 

--- a/vignettes/dev-update-datasets.Rmd
+++ b/vignettes/dev-update-datasets.Rmd
@@ -74,10 +74,10 @@ x$Item[!grepl("names_|^test", x$Item)]
 EJAM relies on datasets mostly stored in the package itself or in a separate,
 data-related repository:
 
--   Datasets stored within the EJAM package (`.rda` files): [Documentation](../reference/index.html#datasets-with-indicators-raw-data-means-percentiles-) and
+-   Datasets stored within the EJAM package (`.rda` files): [Documentation](`r paste0(docs_reponame_url, "/reference/index.html#datasets-with-indicators-raw-data-means-percentiles-")`) and
 [access to package data files](`r paste0(code_reponame_url, "/tree/main/data")`)
 
--   Datasets used by EJAM but stored separately (large `.arrow` files): [Documentation](../reference/index.html#datasets-with-indicators-raw-data-means-percentiles-) and
+-   Datasets used by EJAM but stored separately (large `.arrow` files): [Documentation](`r paste0(docs_reponame_url, "/reference/index.html#datasets-with-indicators-raw-data-means-percentiles-")`) and
 [access to the large data files as GitHub release assets](`r paste0(data_reponame_url, "/releases")`)
 
 ### Why the large datasets are put into the data repository using piggyback instead of committed using Git
@@ -93,7 +93,7 @@ changed ANNUALLY or more often:
 
 -   ***Blockgroup Datasets (Demographic and Environmental Data)***: These
 include datasets included with the package `?blockgroupstats`,
-[usastats](../reference/usastats.html), `?statestats`, and `?bgej`. The
+[usastats](`r paste0(docs_reponame_url, "/reference/usastats.html")`), `?statestats`, and `?bgej`. The
 annual staged workflow for updating these ACS/EJScreen-style blockgroup
 datasets is now documented separately in [Updating EJScreen Datasets Annually
 (via the Pipeline)](dev-update-ejscreen-datasets-yearly.html). That pipeline

--- a/vignettes/dev-update-documentation.Rmd
+++ b/vignettes/dev-update-documentation.Rmd
@@ -64,17 +64,17 @@ Each is explained below:
     following: `DESCRIPTION`, `README.Rmd` (for the README, **edit
     `README.Rmd`, not the generated `README.md` file**),
     `R/EJAM-package.R` (for `?EJAM-package`),
-    `NEWS.md` used to make [NEWS](../news/index.html), 
-    `CONTRIBUTING.md` used to make [CONTRIBUTING](../CONTRIBUTING.html),
-    [LICENSE](../LICENSE.html) based on `inst/LICENSE.md`,
-    [CITATION](../authors.html#citation) based on `inst/CITATION`, 
+    `NEWS.md` used to make [NEWS](`r paste0(docs_reponame_url, "/news/index.html")`), 
+    `CONTRIBUTING.md` used to make [CONTRIBUTING](`r paste0(docs_reponame_url, "/CONTRIBUTING.html")`),
+    [LICENSE](`r paste0(docs_reponame_url, "/LICENSE.html")`) based on `inst/LICENSE.md`,
+    [CITATION](`r paste0(docs_reponame_url, "/authors.html#citation")`) based on `inst/CITATION`, 
     CITATION.cff, and others.
 
 -   Some of these are used by and shown by the GitHub repository, notably
     the `README.md` that is generated from the `README.Rmd` file and appears on
     the GitHub repository as
     [README](`r paste0(code_reponame_url, "?tab=readme-ov-file#readme")`)
-    and in the pkgdown site as [README](../index.html), and the `DESCRIPTION`
+    and in the pkgdown site as [README](`r paste0(docs_reponame_url, "/index.html")`), and the `DESCRIPTION`
     file that stores the package version number, repository URLs, and related
     package metadata.
 
@@ -313,3 +313,16 @@ https://public-environmental-data-partners.github.io/EJAM/v3/
     pages had been on GitHub Pages at URLs related to the `USEPA/EJAM` and
     `USEPA/EJAM-open` repositories, but those pages may now be archived,
     unpublished, or otherwise obsolete.
+
+-   When a vignette links to a part of the site that is not itself a vignette
+    -- the reference manual, NEWS, LICENSE, the home page -- write the link
+    with `EJAM::url_package("docs")` rather than a relative path like
+    `../reference/index.html`. Relative paths work on the pkgdown site but
+    break in the vignette as installed with the package, where there is no
+    `reference/` folder next to the vignettes, and `R CMD check` reports them
+    under `checking relative paths in package URLs`. Inside a pkgdown CI build
+    `url_package("docs")` honors `EJAM_DOCS_BASE_URL`, so the links still point
+    within the version being built, such as the `/dev/` copy of the site.
+    Links from one vignette to another, like `[Basics](basics.html)`, should
+    stay relative -- vignettes sit in one folder in both places, so those
+    already resolve correctly.

--- a/vignettes/distances.Rmd
+++ b/vignettes/distances.Rmd
@@ -49,7 +49,7 @@ An outline of how to use key functions is provided below. After these examples
 is a discussion of background information and considerations in selecting
 radius.
 
-Also see the list of [functions related to comparing distances](../reference/index.html#comparing-distances-multiple-radius-values).
+Also see the list of [functions related to comparing distances](`r paste0(EJAM::url_package("docs"), "/reference/index.html#comparing-distances-multiple-radius-values")`).
 
 ## RESIDENTIAL POPULATION GROUP PERCENTAGES BY DISTANCE AT BLOCKGROUP RESOLUTION
 

--- a/vignettes/ejscreen.Rmd
+++ b/vignettes/ejscreen.Rmd
@@ -81,11 +81,11 @@ EJAM-related repositories.
     -   Raw Data Downloads -- EJSCREEN datasets as used by EJAM
 
         -   Datasets stored in the EJAM repository (.rda files):
-            [Documentation](../reference/index.html#datasets-with-indicators-raw-data-means-percentiles-){target="_blank"}
+            [Documentation](`r paste0(EJAM::url_package("docs"), "/reference/index.html#datasets-with-indicators-raw-data-means-percentiles-")`){target="_blank"}
             and [Data
             files](`r paste0(EJAM::url_package(get_full_url = TRUE),"/tree/main/data")`){target="_blank"}
         -   Datasets used by EJAM but stored separately (large .arrow files):
-            [Documentation](../articles/dev-update-datasets.html#blockgroup-and-block-level-arrow-files){target="_blank"}
+            [Documentation](`r paste0(EJAM::url_package("docs"), "/articles/dev-update-datasets.html#blockgroup-and-block-level-arrow-files")`){target="_blank"}
             and [release assets with data
             files](`r paste0(EJAM::url_package(type = "data", get_full_url = TRUE), "/releases")`){target="_blank"}
 

--- a/vignettes/naics.Rmd
+++ b/vignettes/naics.Rmd
@@ -50,7 +50,7 @@ FRS dataset, and the functions in EJAM that help find or use NAICS codes.
 NAICS/SIC categories can be explored in a few ways:
 
 -   [Key EJAM functions for using
-    NAICS/SIC](../reference/index.html#naics-sic-datasets)
+    NAICS/SIC](`r paste0(EJAM::url_package("docs"), "/reference/index.html#naics-sic-datasets")`)
 -   [NAICS.com website](https://www.naics.com) with extensive information [about
     NAICS](https://www.naics.com/everything-naics/) and
     [SIC](https://www.naics.com/everything-sic/)

--- a/vignettes/testdata.Rmd
+++ b/vignettes/testdata.Rmd
@@ -110,7 +110,7 @@ functions, or you may just want to see what the outputs and inputs look like,
 or you could use them for testing purposes.
 
 For documentation on each input or output item (R object), see 
-[reference documentation on each object](../reference/index.html#test-data)
+[reference documentation on each object](`r paste0(EJAM::url_package("docs"), "/reference/index.html#test-data")`)
 
 This code snippet provides a useful list of test/ sample data
 objects in EJAM and related packages:
@@ -168,4 +168,4 @@ Note that the largest files used by the package are mostly the block-related dat
 
 Some datasets get downloaded by the package at installation or launch or as needed. See the article on [Updating EJAM Datasets](dev-update-datasets.html) for more information on these. 
 
-Also see [reference documentation for each dataset](../reference/index.html#datasets-with-indicators-raw-data-means-percentiles-).
+Also see [reference documentation for each dataset](`r paste0(EJAM::url_package("docs"), "/reference/index.html#datasets-with-indicators-raw-data-means-percentiles-")`).

--- a/vignettes/webapp.Rmd
+++ b/vignettes/webapp.Rmd
@@ -75,7 +75,7 @@ The EJAM software and data are available as open source resources, so that anyon
 
 Analysts or developers using R/RStudio have the option of running a local copy of the EJAM web app on their own computer. This may be even faster than relying on a hosted web app, does not time out after inactivity, and could be customized by a developer. You can also launch it with customized options or use bookmarked settings (and/or use EJAM functions and data directly without the web app, for more complex work).
 
-You can install the EJAM R package and datasets as explained in [Installing the EJAM R package](installing.html). There is also a [Basics - Quick Start Guide](basics.html) and extensive [documentation of EJAM functions/tools/data](../reference/index.html).
+You can install the EJAM R package and datasets as explained in [Installing the EJAM R package](installing.html). There is also a [Basics - Quick Start Guide](basics.html) and extensive [documentation of EJAM functions/tools/data](`r paste0(EJAM::url_package("docs"), "/reference/index.html")`).
 
 Once EJAM is installed, you can launch the local web app from RStudio as follows:
 


### PR DESCRIPTION
Fixes [#565](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/565). This is the NOTE deferred out of [#548](https://github.com/Public-Environmental-Data-Partners/EJAM/issues/548) — the last one left on macOS after [#551](https://github.com/Public-Environmental-Data-Partners/EJAM/pull/551), [#554](https://github.com/Public-Environmental-Data-Partners/EJAM/pull/554) and [#559](https://github.com/Public-Environmental-Data-Partners/EJAM/pull/559).

```
* checking relative paths in package URLs ... NOTE
Found the following (possibly) invalid URLs:
  URL: ../reference/index.html
    From: inst/doc/analyzing.html
  ... 30 more, across 11 vignettes
```

## The links really are broken, not just flagged

`../reference/index.html` was written for the pkgdown site, where the vignette sits at `/articles/analyzing.html`, so it resolves to `/reference/index.html`. In the **installed package** the same vignette is at `<library>/EJAM/doc/analyzing.html`, and there is no `reference/` folder next to `doc/`. All 33 of these were dead for anyone reading through `vignette("analyzing", package = "EJAM")` or `browseVignettes("EJAM")`.

## Why this does not hardcode the docs hostname

That was the objection when it was deferred, and it is a fair one. `url_package("docs")` already resolves the docs base per build:

- normally from `Config/EJAM/url_ejamdocs` in `DESCRIPTION`
- inside a pkgdown CI build from `EJAM_DOCS_BASE_URL`, which `.github/workflows/pkgdown.yaml` sets to the base URL of the version being built

So `DESCRIPTION` stays the single source, and a `/dev/` docs build still links within `/dev/`. Verified both ways:

```
default                              https://…github.io/EJAM/reference/index.html#tables
EJAM_DOCS_BASE_URL=…/EJAM/dev        https://…github.io/EJAM/dev/reference/index.html#tables
```

The other option floated on #548 was rewriting these as `?topic` cross-references. That does not work here: most of them point at *sections of the reference index* (`#specify-points-by-lat-lon`, `#mact-categories`, …), which are pkgdown groupings with no `?topic` equivalent.

## What changed

33 link destinations in 11 vignettes.

| how | vignettes |
|---|---|
| already defined `docs_reponame_url` in a setup chunk, so it is just used | `dev-update-datasets.Rmd` (3), `dev-update-documentation.Rmd` (5) |
| gains that same setup chunk, for 13 links | `analyzing.Rmd` (13) |
| inline `EJAM::url_package("docs")`, matching what `ejscreen.Rmd` already does | `basics.Rmd`, `counties.Rmd`, `ejscreen.Rmd`, `testdata.Rmd` (2 each), `dev-future-plans.Rmd`, `distances.Rmd`, `naics.Rmd`, `webapp.Rmd` (1 each) |

Each file follows whatever idiom it already used, so nothing here is a new convention — the `../` links were simply the ones never converted.

**Links from one vignette to another are deliberately left relative** (`[Basics](basics.html)`, `[…](analyzing.html#fips-codes)`). Vignettes share a single folder in both the built package and the pkgdown site, so those already resolve in both, and making them absolute would send a reader of the installed docs out to the web for no reason.

`dev-update-documentation.Rmd` gains a short paragraph stating the rule, next to where it already documents `url_package("docs")`, so the pattern does not creep back.

## Verified

- **All 33 destinations evaluated**, plus the 7 pre-existing `docs_reponame_url` links: 40 expressions, 0 failures, every result an absolute `https://` URL with no `../` left anywhere in `vignettes/`.
- **Knitted 10 of the 11 changed vignettes end to end.** Zero `../` links survive into the rendered markdown, and the absolute docs links are present.
- `analyzing.Rmd` and `basics.Rmd` **fail to knit on this machine, identically before and after this change** (`'length = 8' in coercion to 'logical(1)'`, from the data-loading chunks) — pre-existing and unrelated. To cover `analyzing.Rmd` anyway, its YAML, its setup chunks and its 13 link lines were knitted in isolation: 13 absolute URLs rendered, no `` `r ` `` left unevaluated.
- Confirmed **inline R in a link destination still evaluates under `knitr::opts_chunk$set(eval = FALSE)`**, which is what `analyzing.Rmd` and `basics.Rmd` set globally.

## Known tradeoff

In a **local** pkgdown preview with `EJAM_DOCS_BASE_URL` unset, these links point at the published docs site rather than the local build. That is the deliberate trade: correct everywhere the vignettes are actually installed or published, at the cost of cross-site links in an unconfigured local preview. CI sets the variable, so published builds are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)