### PR TITLE
Guard the report-description helpers against inputs they can actually get

### DIFF
--- a/R/community_report_helper_funs.R
+++ b/R/community_report_helper_funs.R
@@ -1338,8 +1338,11 @@ sitetype2text <- function(sitetype = NULL, site_method = sitetype, sitetype_null
   if (is.null(nsites) || any(is.na(nsites))) {
     nsites <- 99 # just makes it plural, e.g., "places"
   }
-  if (is.null(sitetype))    {sitetype    <- sitetype_nullna}
-  if (is.null(site_method)) {site_method <- sitetype}
+  ## length-0 is handled alongside NULL, not left to fall through: character(0)
+  ## survives the is.na() replacement below unchanged, and then `sitetype %in% ...`
+  ## yields logical(0), which makes the if() below error instead of simply not matching.
+  if (is.null(sitetype)    || length(sitetype) == 0)    {sitetype    <- sitetype_nullna}
+  if (is.null(site_method) || length(site_method) == 0) {site_method <- sitetype}
 
   sitetype[   is.na(sitetype)]    <- sitetype_nullna
   site_method[is.na(site_method)] <- sitetype_nullna

--- a/R/ejam2report.R
+++ b/R/ejam2report.R
@@ -398,6 +398,17 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
     ejamitout$sitetype <- ejamit_sitetype_from_output(ejamitout)
   }
   sitetype <- ejamitout$sitetype
+  ## Normalized once here, so none of the ~9 `sitetype %in% ...` tests below can see a
+  ## length-0 value: NULL %in% "shp" is logical(0), which if() cannot use. This is
+  ## reachable - an ejamitout carrying an explicit NULL sitetype still has "sitetype"
+  ## in names(), so the inference above is skipped and NULL arrives here.
+  ## NA is deliberately left as NA: %in% returns FALSE for it, never NA, so it is
+  ## already safe in every test below, and keeping it distinguishes "could not tell"
+  ## from "shp"/"fips"/"latlon".
+  if (is.null(sitetype) || length(sitetype) == 0) {
+    sitetype <- NA
+    ejamitout$sitetype <- sitetype # keep the two in step
+  }
 
   # 2d, get more detailed info about how site was specified, from "site_method" parameter,
   # which server stores as the submitted_upload_method() reactive

--- a/R/ejam2report.R
+++ b/R/ejam2report.R
@@ -415,6 +415,14 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
       } else {
         if (sitetype %in% 'latlon') {
           site_method <- 'latlon'
+        } else {
+          ## final fallback, so site_method is always set from here on. Without it an
+          ## unrecognized sitetype (including the NA that ejamit_sitetype_from_output()
+          ## returns when it cannot tell) left site_method NULL, and every downstream
+          ## use had to defend itself separately - which is how the polygon-rebuild
+          ## gates came to need isTRUE(). "" is what the missing/blank test at the top
+          ## of this block already treats as "not supplied".
+          site_method <- ""
         }
       }
     }

--- a/R/ejam2report.R
+++ b/R/ejam2report.R
@@ -406,7 +406,7 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
   ## already safe in every test below, and keeping it distinguishes "could not tell"
   ## from "shp"/"fips"/"latlon".
   if (is.null(sitetype) || length(sitetype) == 0) {
-    sitetype <- NA
+    sitetype <- NA_character_ # character, since sitetype is otherwise "latlon"/"fips"/"shp"
     ejamitout$sitetype <- sitetype # keep the two in step
   }
 
@@ -414,7 +414,12 @@ ejam2report <- function(ejamitout = testoutput_ejamit_10pts_1miles,
   # which server stores as the submitted_upload_method() reactive
   # and as used in server, this could be SHP, FIPS, latlon, MACT, FRS, EPA_PROGRAM_up, etc. etc.
   # which is useful for providing report header info
-  if (missing(site_method) || is.null(site_method) || site_method %in% "") {
+  ## length(): a supplied character(0) is not NULL and not missing, so it reached
+  ## `site_method %in% ""`, which is logical(0) and errors in the if(). [1] with
+  ## isTRUE() also makes a length > 1 site_method well defined rather than another
+  ## multi-element condition.
+  if (missing(site_method) || is.null(site_method) || length(site_method) == 0 ||
+      isTRUE(site_method[1] %in% "")) {
     if (!is.null(ejamitout$site_method)) {
       # e.g., "ZIP" if ejamit(zipcode = ...) was used (which analyzes via the shp path)
       site_method <- ejamitout$site_method

--- a/R/ejamit_sitetype_from_.R
+++ b/R/ejamit_sitetype_from_.R
@@ -85,6 +85,15 @@ sitetype_from_dt <- function(dt) {
 
   ## dt could be e.g.,  ejamit()$results_bysite
 
+  ## NULL says nothing about the site type, so return the same NA the fallback at the
+  ## bottom returns instead of erroring partway through. ejamit_sitetype_from_output()
+  ## passes whatever out$results_bysite is, and that is NULL for an empty result or a
+  ## list that simply has no such element.
+  if (is.null(dt) || length(dt) == 0) {
+    warning("cannot determine valid sitetype")
+    return(NA)
+  }
+
   #   shp
 
   # if it is class "sf" like a spatial data.frame from [sf::st_as_sf()] or [shapefile_from_any()],
@@ -112,14 +121,17 @@ sitetype_from_dt <- function(dt) {
   # as from output of ejamit(fips="040130610171")$results_bysite
   ## 1st, fips is assumed to be stored as mydf$ejam_uniq_id but
   ## can be provided here as a separate column or parameter
+  ## length() > 0 as well as all(), because all() on zero elements is vacuously TRUE -
+  ## so a 0-row table with an ejam_uniq_id column was reported as "fips" on the strength
+  ## of no values at all. An empty result should be undetermined, not FIPS.
   if ('ejam_uniq_id' %in% names(dt)) {
-    if (all(fips_valid(dt$ejam_uniq_id))) {
+    if (length(dt$ejam_uniq_id) > 0 && all(fips_valid(dt$ejam_uniq_id))) {
       return("fips")
     }
   }
   if ('fips' %in% fixnames_aliases(colnames(dt))) {
     fipsvalues = data.frame(dt)[, which(fixnames_aliases(names(dt)) %in% 'fips')[1]]
-    if (all(fips_valid(fipsvalues))) {
+    if (length(fipsvalues) > 0 && all(fips_valid(fipsvalues))) {
       return("fips")
     }
   }

--- a/R/ejamit_sitetype_from_.R
+++ b/R/ejamit_sitetype_from_.R
@@ -91,7 +91,7 @@ sitetype_from_dt <- function(dt) {
   ## list that simply has no such element.
   if (is.null(dt) || length(dt) == 0) {
     warning("cannot determine valid sitetype")
-    return(NA)
+    return(NA_character_)
   }
 
   #   shp
@@ -137,6 +137,6 @@ sitetype_from_dt <- function(dt) {
   }
 
   warning("cannot determine valid sitetype")
-  return(NA)
+  return(NA_character_)
 }
 ############################ ############################# #

--- a/tests/testthat/test-ejam2report.R
+++ b/tests/testthat/test-ejam2report.R
@@ -728,7 +728,7 @@ testthat::test_that("a NULL or length-0 sitetype does not crash the site_method 
   ## %in% returns FALSE for NA, never NA -- which is why NA is left as NA.
   chain <- function(sitetype) {
     site_method <- NULL
-    if (is.null(sitetype) || length(sitetype) == 0) sitetype <- NA      # the normalization
+    if (is.null(sitetype) || length(sitetype) == 0) sitetype <- NA_character_  # the normalization
     if (is.null(site_method) || site_method %in% "") {
       if (sitetype %in% "shp") site_method <- "SHP"
       else if (sitetype %in% "fips") site_method <- "FIPS"
@@ -753,6 +753,18 @@ testthat::test_that("a NULL or length-0 sitetype does not crash the site_method 
   expect_false(NA_character_ %in% "shp")
   ## whereas length-0 does need the normalization
   expect_length(NULL %in% "shp", 0L)
+
+  ## the opening condition of the same block had the identical length-0 problem:
+  ## a supplied character(0) site_method is neither missing nor NULL, so it reached
+  ## `site_method %in% ""` -> logical(0) -> if() error.
+  opens_defaulting <- function(site_method) {
+    is.null(site_method) || length(site_method) == 0 || isTRUE(site_method[1] %in% "")
+  }
+  expect_true(opens_defaulting(NULL))
+  expect_true(opens_defaulting(character(0)))
+  expect_true(opens_defaulting(""))
+  expect_false(opens_defaulting("SHP"))
+  expect_false(opens_defaulting(c("SHP", "FIPS")))   # length > 1 is well defined, not an error
 })
 ################ ################# ################# ################# ################# #
 testthat::test_that("the polygon-rebuild gates survive a NULL site_method", {

--- a/tests/testthat/test-ejam2report.R
+++ b/tests/testthat/test-ejam2report.R
@@ -721,6 +721,40 @@ testthat::test_that("pdf_wait_seconds() rejects an unknown setting name", {
 })
 ################ ################# ################# ################# ################# #
 
+testthat::test_that("a NULL or length-0 sitetype does not crash the site_method defaulting", {
+  ## An ejamitout carrying an explicit NULL sitetype still has "sitetype" in names(),
+  ## so the inference is skipped and NULL reaches the `sitetype %in% ...` chain, where
+  ## NULL %in% "shp" is logical(0) and if() cannot use it. NA is fine there already --
+  ## %in% returns FALSE for NA, never NA -- which is why NA is left as NA.
+  chain <- function(sitetype) {
+    site_method <- NULL
+    if (is.null(sitetype) || length(sitetype) == 0) sitetype <- NA      # the normalization
+    if (is.null(site_method) || site_method %in% "") {
+      if (sitetype %in% "shp") site_method <- "SHP"
+      else if (sitetype %in% "fips") site_method <- "FIPS"
+      else if (sitetype %in% "latlon") site_method <- "latlon"
+      else site_method <- ""
+    }
+    site_method
+  }
+  expect_equal(chain(NULL), "")
+  expect_equal(chain(character(0)), "")
+  expect_equal(chain(NA), "")
+  expect_equal(chain(NA_character_), "")
+  expect_equal(chain("zzz"), "")
+  # unchanged for the recognized types
+  expect_equal(chain("shp"), "SHP")
+  expect_equal(chain("fips"), "FIPS")
+  expect_equal(chain("latlon"), "latlon")
+
+  ## %in% never yields NA, so NA needs no isTRUE() wrapper in that chain
+  expect_false(NA %in% "shp")
+  expect_false(is.na(NA %in% "shp"))
+  expect_false(NA_character_ %in% "shp")
+  ## whereas length-0 does need the normalization
+  expect_length(NULL %in% "shp", 0L)
+})
+################ ################# ################# ################# ################# #
 testthat::test_that("the polygon-rebuild gates survive a NULL site_method", {
   ## site_method can still be NULL at the gates: the defaulting block only sets it
   ## from ejamitout$site_method or from sitetype shp/fips/latlon, so any other

--- a/tests/testthat/test-ejamit_sitetype_from_output.R
+++ b/tests/testthat/test-ejamit_sitetype_from_output.R
@@ -46,3 +46,57 @@ testthat::test_that("ejamit_sitetype_from_output(out_latlon) ok",  {
 })
 
 
+
+########################## #
+## Guards on inputs the report path can actually produce.
+## ejamit_sitetype_from_output() is documented to return NA when it cannot tell the
+## site type, and callers such as buffer_desc_from_sitetype() rely on getting a value
+## back rather than an error. These are the cases where it did not.
+
+testthat::test_that("sitetype_from_dt() returns NA rather than erroring on NULL", {
+  ## ejamit_sitetype_from_output() passes out$results_bysite straight through, and
+  ## that is NULL for an empty result or a list with no such element.
+  expect_warning(res <- EJAM:::sitetype_from_dt(NULL), "cannot determine valid sitetype")
+  expect_true(is.na(res))
+  expect_warning(res2 <- EJAM:::ejamit_sitetype_from_output(NULL), "cannot determine valid sitetype")
+  expect_true(is.na(res2))
+})
+
+testthat::test_that("an empty results table is undetermined, not 'fips'", {
+  ## all() on zero elements is vacuously TRUE, so a 0-row table with an ejam_uniq_id
+  ## column used to be reported as a FIPS analysis on the strength of no values at all.
+  expect_warning(res <- EJAM:::sitetype_from_dt(
+    data.table::data.table(ejam_uniq_id = character(0))), "cannot determine valid sitetype")
+  expect_true(is.na(res))
+  expect_warning(res2 <- EJAM:::sitetype_from_dt(
+    data.table::data.table(fips = character(0))), "cannot determine valid sitetype")
+  expect_true(is.na(res2))
+
+  ## still identifies a populated table exactly as before
+  expect_equal(EJAM:::sitetype_from_dt(
+    data.table::data.table(ejam_uniq_id = c("10001", "10003"))), "fips")
+  expect_equal(EJAM:::sitetype_from_dt(
+    data.table::data.table(lat = c(40, 41), lon = c(-74, -75))), "latlon")
+})
+
+testthat::test_that("a wrong-class input still errors rather than being papered over", {
+  ## Passing a character vector where an ejamit() output list belongs is a caller bug,
+  ## so it must keep erroring - guarding it would hide the mistake.
+  expect_error(EJAM:::ejamit_sitetype_from_output("not_an_ejamit_output"))
+  expect_error(EJAM:::ejamit_sitetype_from_output(NA_character_))
+})
+
+testthat::test_that("a zero-row latlon result is not misreported as fips", {
+  ## The case that made the vacuous-all() bug more than theoretical: dropping every
+  ## row of a latlon analysis (as happens once invalid sites are removed) left a table
+  ## with lat/lon AND ejam_uniq_id columns. The lat/lon branch correctly declined it,
+  ## then all(fips_valid(character(0))) returned TRUE and it was labelled "fips".
+  zero_rows <- testoutput_ejamit_10pts_1miles$results_bysite[0, ]
+  expect_true(all(c("lat", "lon", "ejam_uniq_id") %in% names(zero_rows)))
+  expect_warning(res <- EJAM:::sitetype_from_dt(zero_rows), "cannot determine valid sitetype")
+  expect_true(is.na(res))
+  expect_false(identical(res, "fips"))
+
+  ## the same table with its rows still present is still latlon
+  expect_equal(EJAM:::sitetype_from_dt(testoutput_ejamit_10pts_1miles$results_bysite), "latlon")
+})

--- a/tests/testthat/test-sitetype2text.R
+++ b/tests/testthat/test-sitetype2text.R
@@ -310,3 +310,20 @@ rm(show_sitetype2text_examples)
 # TEXT: 'specified cities'                 sitetype2text(nsites=10, sitetype='fips', site_method='FIPS_PLACE', census_unit_type = 'city')
 # TEXT: 'specified blockgroups'            sitetype2text(nsites=10, sitetype='fips', site_method='FIPS_PLACE', census_unit_type = 'blockgroup')
 # TEXT: 'specified blocks'                 sitetype2text(nsites=10, sitetype='fips', site_method='FIPS_PLACE', census_unit_type = 'block')
+
+########################## #
+testthat::test_that("sitetype2text handles a length-0 sitetype or site_method", {
+  ## character(0) is not NULL, so it slipped past the is.null() defaults and survived
+  ## the is.na() replacement unchanged; `sitetype %in% ...` then gave logical(0) and
+  ## the if() errored instead of simply not matching.
+  expect_no_error(res <- sitetype2text(character(0)))
+  expect_equal(res, "place")                                   # same as sitetype2text(NULL)
+  expect_no_error(res2 <- sitetype2text("latlon", site_method = character(0)))
+  expect_equal(res2, "specified point")
+  expect_equal(sitetype2text(character(0)), sitetype2text(NULL))
+
+  ## unchanged for ordinary values
+  expect_equal(sitetype2text(sitetype = "shp"), "specified polygon")
+  expect_equal(sitetype2text(nsites = 10, sitetype = "shp", site_method = "ZIP"),
+               "specified zip codes")
+})


### PR DESCRIPTION
Review of #563 turned up three latent crashes one at a time — a `NULL` `site_method`, an `NA` `sitetype`, a `logical(0)` in an `if()`. That pattern suggested the report-description helpers are generally unguarded rather than those three being unlucky, so instead of waiting for the next review to find the fourth, I probed them directly with `NULL`, `NA`, `character(0)`, `""` and unknown values.

Five more crashes, and one correctness bug the probing turned up on the way.

## The correctness bug — a zero-row latlon analysis was reported as FIPS

`all()` on zero elements is vacuously `TRUE`, so `all(fips_valid(character(0)))` returned `TRUE` and a 0-row table with an `ejam_uniq_id` column was labelled `"fips"` on the strength of no values at all.

This is reachable, not theoretical. Drop every row of a **latlon** analysis — which is what happens once invalid sites are removed, and is exactly the case covered by the existing "popup_from_ejscreen() handles zero-row results after invalid shapes are dropped" test — and you are left with `lat`/`lon` **and** `ejam_uniq_id` columns. The lat/lon branch correctly declines an all-NA table, and then the vacuous `all()` claimed FIPS:

```
before:  sitetype_from_dt(latlon_results[0, ]) -> "fips"
after:   sitetype_from_dt(latlon_results[0, ]) -> NA, with the existing
         "cannot determine valid sitetype" warning
```

## The crashes

| function | input | was | now |
|---|---|---|---|
| `sitetype_from_dt()` | `NULL` | **ERROR** argument is of length zero | `NA` (its own documented fallback) |
| `ejamit_sitetype_from_output()` | `NULL` | **ERROR** (via the above) | `NA` |
| `sitetype2text()` | `sitetype = character(0)` | **ERROR** missing value where TRUE/FALSE needed | `"place"` — same as `NULL` |
| `sitetype2text()` | `site_method = character(0)` | **ERROR** | same as `NULL` |
| `ejam2report()` | unrecognized `sitetype` | left `site_method` `NULL` | falls back to `""` |

`character(0)` is not `NULL`, so it slipped past the `is.null()` defaults, survived the `is.na()` replacement unchanged, and then `sitetype %in% ...` yielded `logical(0)`, which an `if()` cannot use.

The `ejam2report()` one is the root of the earlier symptoms: the defaulting block sets `site_method` from `ejamitout$site_method` or from `sitetype` shp/fips/latlon, with **no final else** — so an unrecognized sitetype, including the `NA` that `ejamit_sitetype_from_output()` returns when it cannot tell, left it unset and every downstream use had to defend itself separately. That is why the polygon-rebuild gates needed `isTRUE()`. It now falls back to `""`, which the block's own missing/blank test already treats as "not supplied".

## Deliberately not guarded

Passing a character vector where an `ejamit()` output list belongs still errors. That is a caller bug, and papering over it would hide the mistake — there is a test asserting it keeps erroring.

## One behavior change worth knowing about

The `"cannot determine valid sitetype"` warning is now emitted in one existing passing test, where previously the code silently mislabelled the empty result as FIPS. That is the fix working, but it means this warning will appear in logs wherever a zero-row result gets summarized. If that proves noisy, the alternative is to make the explicitly-empty case return `NA` silently and keep the warning only for "has rows but cannot classify" — say the word and I'll split it that way.

## Verification

12 test files, **0 failures**, and the single intended warning above: `MAP_FUNCTIONS` 90, `ejam2map` 41, `ejam2histogram` 18, `ejam2shapefile` 28, `ejam2excel` 21, `ejam2report` 115, `ejamit` 63, `ejamit_sitetype_from_input` 13, `ejamit_sitetype_from_output` 23, `sitetype2text` 46, `shapes_from_zip` 40, `shapefix` 23.

Tests added for every case in the table, for the zero-row latlon regression specifically, and for the wrong-class input continuing to error. No roxygen changed, so no `man/` regeneration; both test files were already registered in `R/test_ejam.R`.

Relates to Public-Environmental-Data-Partners/EJAM#159, which notes these helpers should be reconciled — this does not do that, only stops them crashing.
