### PR TITLE
Remove the scheduled release trigger; dispatch releases by hand

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,14 +25,13 @@ name: 'Release: tag and publish'
 # events raised by the default GITHUB_TOKEN, so the `release: published` event
 # this workflow generates triggers nothing on its own.
 #
-# The scheduled path is deliberately one-shot: it refuses to do anything unless
-# DESCRIPTION on `main` still reads exactly SCHEDULED_EXPECTED_VERSION. So when
-# this cron fires again in later years it will find a different version and exit
-# quietly instead of releasing something nobody asked for. Re-running it is
-# always safe: if the tag already exists, the job skips.
-#
-# NOTE: scheduled workflows only fire from the default branch (`main`), so this
-# file has to be merged to `main` before the scheduled run can happen.
+# THERE IS NO SCHEDULED RELEASE. This workflow only runs when a human dispatches it.
+# The scheduled path and its cron were removed for the v4 line - see the comment where
+# the `schedule:` trigger used to be, above the `permissions:` block. The
+# SCHEDULED_EXPECTED_VERSION guard is retained but inert: it refuses to do anything
+# unless DESCRIPTION on `main` reads exactly that version, which is the safety net if a
+# schedule is ever deliberately restored. Re-running by hand is always safe: if the tag
+# already exists, the job skips.
 #
 # VERSION NUMBERING: EJAM versions are MAJOR.ACSENDYEAR.PATCH - the second field is
 # the ACS vintage end year, not a minor number (3.2022.2, 4.2022.0, 4.2024.0). Two
@@ -57,13 +56,20 @@ on:
         required: true
         type: boolean
         default: true
-  schedule:
-    # 21:00 UTC = 17:00 EDT on September 1.
-    #
-    # Retargeted from August 1 (which shipped 3.2022.2 on 2026-08-01) to the
-    # 4.2022.0 window. The guard below makes a mistimed firing a clean no-op, so
-    # if the v4 date slips this simply does nothing until DESCRIPTION catches up.
-    - cron: '0 21 1 9 *'
+  # NO `schedule:` TRIGGER. Releasing is a deliberate, human-initiated act: run this
+  # workflow by hand from the Actions tab (workflow_dispatch above).
+  #
+  # There used to be an annual August 1 cron, which shipped 3.2022.2 on 2026-08-01.
+  # It is deliberately NOT carried forward to the v4 line. The SCHEDULED_EXPECTED_VERSION
+  # guard below only protects against firing on the WRONG version; it cannot tell a
+  # release that is ready from one that is merely dated. So if the code freeze landed on
+  # time but the release were being held back - for more testing, or a deploy window, or
+  # any reason at all - a cron would publish it anyway. That is the failure this removal
+  # prevents.
+  #
+  # Do not re-add a cron here without the maintainer's explicit approval for that
+  # specific release. The env var below is kept only so the guard still works if a
+  # schedule is ever deliberately restored.
 
 permissions:
   contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,19 +3,20 @@ name: 'Release: tag and publish'
 # Tags the version currently in DESCRIPTION on `main` and publishes a GitHub
 # Release whose notes are the matching section of NEWS.md.
 #
-# Two ways to run it:
+# ONE way to run it: manually (workflow_dispatch). Use dry_run first to see exactly
+# what would be tagged and what the notes would say.
 #
-#   1. Manually (workflow_dispatch) - the normal path. Use dry_run first to see
-#      exactly what would be tagged and what the notes would say.
-#   2. On a schedule - 21:00 UTC on August 1, to ship v3.2022.2 without anyone
-#      having to be at a keyboard.
+# THERE IS NO SCHEDULED RELEASE. An annual cron used to ship the August release
+# unattended; it was removed for the v4 line - see the comment where the `schedule:`
+# trigger used to be, just above `permissions:`. Do not re-add one without the
+# maintainer's explicit approval for that specific release.
 #
 # What it does depends on what is already on the releases page:
 #
 #   * an unpublished DRAFT exists -> that draft is published as-is, keeping the
 #     title and notes someone reviewed. Publishing is what creates the tag.
-#     This is the normal path: prepare a draft, review it, let the schedule
-#     ship it.
+#     This is the normal path: prepare a draft, review it, then dispatch this
+#     workflow to ship it.
 #   * nothing exists -> a tag is created and a release is built from the
 #     matching NEWS.md section.
 #   * already published -> nothing happens; a shipped release is never touched.
@@ -25,13 +26,10 @@ name: 'Release: tag and publish'
 # events raised by the default GITHUB_TOKEN, so the `release: published` event
 # this workflow generates triggers nothing on its own.
 #
-# THERE IS NO SCHEDULED RELEASE. This workflow only runs when a human dispatches it.
-# The scheduled path and its cron were removed for the v4 line - see the comment where
-# the `schedule:` trigger used to be, above the `permissions:` block. The
-# SCHEDULED_EXPECTED_VERSION guard is retained but inert: it refuses to do anything
-# unless DESCRIPTION on `main` reads exactly that version, which is the safety net if a
-# schedule is ever deliberately restored. Re-running by hand is always safe: if the tag
-# already exists, the job skips.
+# SCHEDULED_EXPECTED_VERSION below is retained but inert: it refuses to do anything
+# unless DESCRIPTION on `main` reads exactly that version. It is the safety net if a
+# schedule is ever deliberately restored. Re-running by hand is always safe: if the
+# tag already exists, the job skips.
 #
 # VERSION NUMBERING: EJAM versions are MAJOR.ACSENDYEAR.PATCH - the second field is
 # the ACS vintage end year, not a minor number (3.2022.2, 4.2022.0, 4.2024.0). Two
@@ -78,7 +76,9 @@ permissions:
   actions: write
 
 env:
-  # Guard for the scheduled run only - see the header comment.
+  # Guard for the scheduled run only, and therefore INERT while there is no `schedule:`
+  # trigger - the code reading it runs only when github.event_name == 'schedule'. Kept so
+  # the safety net still works if a schedule is ever deliberately restored. See the header.
   SCHEDULED_EXPECTED_VERSION: '4.2022.0'
 
 jobs:


### PR DESCRIPTION
Removes the scheduled release trigger that #571 introduced. `workflow_dispatch` becomes the only way `release.yaml` runs.

### Why

#571 retargeted the annual release cron from August 1 to September 1 and repinned it at `4.2022.0`. That was the wrong call and this reverses it.

`SCHEDULED_EXPECTED_VERSION` only guards against firing on the **wrong version**. It cannot tell a release that is *ready* from one that merely matches a *date*. If the code freeze landed on time but the release were being held back — more testing, a deploy window, a slipped milestone, any reason at all — the cron would publish it anyway with nobody in the loop.

**A release should require a human to start it.**

### Current exposure

Not urgent, but it must land before the next `development` → `main` sync:

- Scheduled workflows only fire from the **default branch**. The Sept 1 / `4.2022.0` cron is currently on `development` only, so it **cannot fire today**.
- `main` still carries the old Aug 1 / `3.2022.2` cron, which is inert — it already shipped 3.2022.2, and a future firing would find a different version and no-op.
- The cron goes live the moment `development` syncs to `main`. If `v4-version-bump` has merged by then, a Sept 1 firing would auto-publish 4.2022.0.

### What stays

The `SCHEDULED_EXPECTED_VERSION` env var and its guard logic are retained but inert, so the safety net still works if a schedule is ever deliberately restored. The comment where the trigger used to be explains why it was removed and asks that it not be re-added without explicit per-release approval.

### Verification

- Workflow parses; `workflow_dispatch` is the only trigger.
- No `cron:` remains anywhere in the file.
- No other workflow in the repo has a `schedule:` trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
