### PR TITLE
Skip, don't fail, when a live service the tests depend on is down

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -74,6 +74,25 @@ test_check("EJAM")
 #   or run all tests in the package with testthat::test_package("EJAM").
 #   testthat::test_check("EJAM") would run all tests plus do other checks.
 #
+# !! But do not run plain  library(EJAM); testthat::test_dir("tests/testthat")  !!
+#
+#   Without a package, test_dir() builds a test environment whose parent is the
+#   global environment, so the tests can see only what library() EXPORTED. Two
+#   whole categories of call then fail for reasons that have nothing to do with
+#   the code being tested:
+#     - unexported EJAM functions:  "could not find function \"offline\""
+#     - dplyr verbs EJAM imports:   "could not find function \"arrange\""
+#   That is a spurious error, not a broken test: the same tests pass under
+#   R CMD check, which parents the test environment to the package NAMESPACE.
+#   Chasing it by rewriting tests to say EJAM:::offline() and dplyr::arrange()
+#   would be fixing the source to suit the way it was run.
+#
+#   Any of these run the tests the way R CMD check does, with no code changes:
+#     testthat::test_dir("tests/testthat", package = "EJAM")  # parents to the namespace
+#     testthat::test_local()                                  # pkgload::load_all()
+#     devtools::test()                                        # pkgload::load_all()
+#     EJAM:::test_ejam()                                      # load_all(); see its useloadall arg
+#
 # But note that these testthat package functions do not automatically
 # build and install the package before running the tests,
 # so they will only test the last-installed version of the package, not the latest source version.

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -329,6 +329,85 @@ skip_if_naics_web_unavailable <- function(scraped) {
 }
 ############################### ################################ #
 
+# helper for tests that need a live external URL to answer ####
+
+# skip_if_offline() only proves that SOME host is reachable. It says nothing about
+# whether the specific service a test needs is up, so a test that asserts
+# url_online(x) still fails when EPA, EJScreen, or the EJAM API is down or
+# throttling the runner - a red check that tells us nothing about EJAM.
+#
+# Seen in R CMD check run 31491603711 (2026-08-11): the url_by_id example took the
+# whole "checking examples" step to ERROR when
+# frs-public.epa.gov/ords/frs_public2/frs_rest_services.get_facilities returned 503.
+# Same failure class as the naics.com blocking above.
+# See Public-Environmental-Data-Partners/EJAM#548
+#
+# The point of these tests is that OUR URL BUILDERS still produce URLs the service
+# accepts, so the two cases have to stay separate:
+#
+#   the service could not answer  -> not an EJAM problem  -> skip
+#   the service answered "no"     -> our URL is wrong     -> fail, loudly
+#
+# So: connection failure, timeout, 5xx, and 429 skip. 4xx does NOT skip - a 404 or
+# 400 is exactly the regression these tests exist to catch, and skipping it would
+# make them permanently vacuous.
+
+# skip_if_url_unreachable() is the probe: it only ever skips or returns quietly, so
+# use it to gate a test whose real subject is something else (the DATA an API sends
+# back, say). expect_url_online_or_skip() adds the 200 assertion on top, for tests
+# whose subject IS the URL.
+
+skip_if_url_unreachable <- function(url, what = NULL) {
+
+  what <- if (is.null(what)) url else what
+  if (length(url) != 1 || is.na(url) || !nzchar(trimws(as.character(url)))) {
+    testthat::fail(paste0(
+      "expected a single non-empty URL for ", what,
+      ", got ", class(url)[1], " of length ", length(url),
+      ". That is a URL-builder regression, not a service outage."
+    ))
+    return(invisible(NA_integer_))
+  }
+
+  # A request that never gets an HTTP reply (DNS, TLS, refused, timeout) throws
+  # rather than returning a status, so treat it as "service unreachable".
+  resp <- tryCatch(
+    httr2::req_perform(httr2::req_error(
+      httr2::req_timeout(httr2::request(url), 30),
+      is_error = function(resp) FALSE   # keep 4xx/5xx as responses so we can tell them apart
+    )),
+    error = function(e) e
+  )
+  if (inherits(resp, "condition")) {
+    testthat::skip(paste0(
+      "could not reach ", what, " (no HTTP response): ", conditionMessage(resp)
+    ))
+  }
+
+  status <- httr2::resp_status(resp)
+  if (status >= 500 || status == 429) {
+    testthat::skip(paste0(
+      what, " returned HTTP ", status,
+      " - the service is down or throttling this runner, not an EJAM regression."
+    ))
+  }
+  invisible(status)
+}
+
+expect_url_online_or_skip <- function(url, what = NULL) {
+
+  what   <- if (is.null(what)) url else what
+  status <- skip_if_url_unreachable(url, what = what)
+
+  testthat::expect_equal(
+    status, 200L,
+    label = paste0("HTTP status of ", what),
+    expected.label = "200 (a 4xx here means the URL EJAM built is wrong, not that the service is down)"
+  )
+  invisible(status)
+}
+############################### ################################ #
+
 # helpers to check map functions ####
 
 # these 2 got used in some test files:

--- a/tests/testthat/test-URL_FUNCTIONS_part2-live.R
+++ b/tests/testthat/test-URL_FUNCTIONS_part2-live.R
@@ -1,11 +1,31 @@
-test_that("core external URL helpers respond", {
+# Live checks that the URLs these helpers build are ones the external sites accept.
+# Each URL is checked on its own so one site being down skips only its own
+# expectation instead of taking the other two with it. Skips when a site cannot
+# answer; a 4xx still fails. See expect_url_online_or_skip() in setup.R
+
+test_that("url_ejscreenmap builds a URL EJScreen accepts", {
   skip_if_offline()
 
-  urls <- c(
+  expect_url_online_or_skip(
     url_ejscreenmap(sitepoints = testpoints_10[1, ]),
-    url_enviromapper(sitepoints = testpoints_10[1, ]),
-    url_county_health(fips = testinput_fips_counties[1])
+    what = "url_ejscreenmap()"
   )
+})
 
-  expect_true(all(vapply(urls, url_online, logical(1))))
+test_that("url_enviromapper builds a URL EPA accepts", {
+  skip_if_offline()
+
+  expect_url_online_or_skip(
+    url_enviromapper(sitepoints = testpoints_10[1, ]),
+    what = "url_enviromapper()"
+  )
+})
+
+test_that("url_county_health builds a URL County Health Rankings accepts", {
+  skip_if_offline()
+
+  expect_url_online_or_skip(
+    url_county_health(fips = testinput_fips_counties[1]),
+    what = "url_county_health()"
+  )
 })

--- a/tests/testthat/test-ejamapi-live.R
+++ b/tests/testthat/test-ejamapi-live.R
@@ -1,9 +1,17 @@
+# These test the DATA the deployed API sends back, so the API has to be up for any
+# of it to mean anything. skip_if_offline() only proves the runner has an internet
+# connection, which is why these used to go red whenever the API itself was down or
+# still redeploying. Probe the API first and skip - see skip_if_url_unreachable()
+# in setup.R, and Public-Environmental-Data-Partners/EJAM#548
+
 endpoint <- "data"
 browse <- FALSE
 eg <- FALSE
+apiurl <- url_package("api")
 
 testthat::test_that("ejamapi live API returns all blockgroups in a county", {
   skip_if_offline()
+  skip_if_url_unreachable(apiurl, what = "the deployed EJAM API")
 
   expect_no_error({
     x <- ejamapi(
@@ -23,6 +31,7 @@ testthat::test_that("ejamapi live API returns all blockgroups in a county", {
 
 testthat::test_that("ejamapi live API returns all blockgroups in a state", {
   skip_if_offline()
+  skip_if_url_unreachable(apiurl, what = "the deployed EJAM API")
 
   expect_no_error({
     x <- ejamapi(
@@ -39,6 +48,7 @@ testthat::test_that("ejamapi live API returns all blockgroups in a state", {
 
 testthat::test_that("ejamapi live API returns all counties in a state", {
   skip_if_offline()
+  skip_if_url_unreachable(apiurl, what = "the deployed EJAM API")
 
   expect_no_error({
     x <- ejamapi(

--- a/tests/testthat/test-frs_from_naics.R
+++ b/tests/testthat/test-frs_from_naics.R
@@ -15,9 +15,16 @@ test_that('website_url causes an error',{
   })
 
 # website_scrape = TRUE reaches naics.com, so it is its own test and stays covered
-# offline only for the website_url case above
+# offline only for the website_url case above.
+#
+# frs_from_naics() passes website_scrape through to naics_from_any() and feeds the
+# resulting $code straight into regid_from_naics(). When naics.com serves a runner
+# the search page with no results in it, that $code is character(0), so this test
+# failed for the same reason as its siblings below rather than for anything to do
+# with EJAM. Scrape once up front and skip on that known symptom, as they do.
 test_that('website_scrape does not cause an error',{
   skip_if(offline())
+  skip_if_naics_web_unavailable(naics_from_any(21112, website_scrape = TRUE))
   expect_no_error({val <- frs_from_naics(21112, website_scrape = TRUE)}) # "crude petroleum"
   })
 

--- a/tests/testthat/test-url_ejamapi-live.R
+++ b/tests/testthat/test-url_ejamapi-live.R
@@ -1,9 +1,14 @@
+# Live checks that the URLs url_ejamapi() builds are ones the API actually accepts.
+# Skips (does not fail) when the API cannot answer, but a 4xx still fails - a bad
+# path or query string is exactly the regression these tests exist to catch.
+# See expect_url_online_or_skip() in setup.R
+
 test_that("url_ejamapi live point report URL responds", {
   skip_if_offline()
 
   url <- url_ejamapi(sitepoints = testpoints_10[1, ], as_html = FALSE)
 
-  expect_true(url_online(url[1]))
+  expect_url_online_or_skip(url[1], what = "url_ejamapi() point report URL")
 })
 
 test_that("url_ejamapi live FIPS report URL responds", {
@@ -11,7 +16,7 @@ test_that("url_ejamapi live FIPS report URL responds", {
 
   url <- url_ejamapi(fips = testinput_fips_counties[1], as_html = FALSE)
 
-  expect_true(url_online(url[1]))
+  expect_url_online_or_skip(url[1], what = "url_ejamapi() FIPS report URL")
 })
 
 test_that("url_ejamapi live polygon app-fallback URL responds", {
@@ -19,5 +24,5 @@ test_that("url_ejamapi live polygon app-fallback URL responds", {
 
   url <- url_ejamapi(shapefile = testinput_shapes_2[1, ], as_html = FALSE)
 
-  expect_true(url_online(url[1]))
+  expect_url_online_or_skip(url[1], what = "url_ejamapi() polygon app-fallback URL")
 })

--- a/tests/testthat/test-url_package-live.R
+++ b/tests/testthat/test-url_package-live.R
@@ -1,7 +1,12 @@
+# A live check that the URL url_package() hands out is actually serving.
+# Skips (does not fail) when the site cannot answer - see
+# expect_url_online_or_skip() in setup.R for why 4xx still fails.
+
 test_that("url_package default URL responds", {
   skip_if_offline()
 
-  expect_true(
-    url_online(url_package(get_full_url = TRUE))
+  expect_url_online_or_skip(
+    url_package(get_full_url = TRUE),
+    what = "url_package() default URL"
   )
 })


### PR DESCRIPTION
## Why

`skip_if_offline()` only proves the runner can reach *some* host. It says nothing about whether the specific service a test needs is up, so the `test-*-live.R` files went red whenever EPA, EJScreen, County Health Rankings, or the deployed EJAM API was down, redeploying, or throttling the runner — a red `R CMD check` that tells us nothing about EJAM.

Those five `-live` files are **not** gated by any env var. They run in every `R CMD check`, and four of them had only `skip_if_offline()`.

This is the same failure class as the naics.com blocking handled in #561. In run [31491603711](https://github.com/Public-Environmental-Data-Partners/EJAM/actions/runs/31491603711) a 503 from the FRS endpoint took the whole examples step to ERROR.

Part of #548.

### Scope note

The two items originally on the cleanup list are already fixed, by PRs that landed *after* that run's commit `cdeb5120` — #559 moved the `url_by_id` example to `\dontrun{}`, and #561 added `skip_if_naics_web_unavailable()`. Re-verified with `tools::Rd2ex(commentDontrun = TRUE)` over every `man/*.Rd`: **no executable example makes a network call**. This PR generalizes the same idea to the exposure that was left.

## What

Two helpers in `tests/testthat/setup.R`, keeping the distinction the existing `skip_if_naics_web_unavailable()` draws — only the known symptom gets a skip:

| Response | Result | Why |
|---|---|---|
| no HTTP reply, 5xx, 429 | **skip** | service down or throttling — not ours |
| 4xx | **fail** | the URL EJAM built is wrong |
| malformed / multiple URL | **fail** | URL-builder regression |

- `skip_if_url_unreachable()` — bare probe, for tests whose real subject is the data an API returns.
- `expect_url_online_or_skip()` — adds the 200 assertion, for tests whose subject *is* the URL.

**Keeping 4xx fatal is the point.** A blanket skip-on-any-failure would make these tests permanently vacuous, which is the opposite of what they are for.

Applied to the four unguarded live files. `test-ejscreen-facilities-live.R` already did this correctly with its own `tryCatch`, and is left alone. `test-URL_FUNCTIONS_part2-live.R` also gets its three URLs split into separate `test_that` blocks, so one site being down no longer takes the other two with it.

**Plus the one naics gap #561 left:** `frs_from_naics(website_scrape = TRUE)` feeds `naics_from_any()$code` straight into `regid_from_naics()`, so a blocked scrape makes that `character(0)` and the call errors. It now scrapes once up front and skips on the same symptom its siblings already check.

## Second commit: a documentation trap

`tests/testthat.R` recommends `testthat::test_dir("tests/testthat")` with no caveat. Run that way after a plain `library(EJAM)`, the test environment's parent is the global environment, so tests see only what was *exported* and two categories of call fail spuriously — `could not find function "offline"` (unexported) and `could not find function "arrange"` (a dplyr verb EJAM imports).

Same filter, same installed build: **3 errors / 26 passed** without `package=`, **0 errors / 29 passed** with it.

`R/test_ejam.R:1112` already warns about the unexported half, but nothing said it next to the `test_dir()` suggestion itself. The comment now documents the no-code-change fixes (`test_dir(package = "EJAM")`, `test_local()`, `devtools::test()`, `test_ejam()`) and says explicitly not to chase it by rewriting tests to `EJAM:::offline()` / `dplyr::arrange()` — that would be editing the source to suit how it was invoked. Comment-only; no test behavior changes.

## Verification

Against a local status-echo server, every branch behaves as described:

| Input | `expect_url_online_or_skip` | `skip_if_url_unreachable` |
|---|---|---|
| 200 | pass | pass |
| 400 / 403 / 404 | **fail** | pass (probe only) |
| 500 / 503 / 429 | **skip** | **skip** |
| connection refused | **skip** | **skip** |
| `NA`, length-2 vector | **fail** | **fail** |

And the suites still pass for real, with the package namespace loaded: **live 26/26**, **naics 61/61**.

## Note

This only removes false reds. It does not change any real result, and the deterministic percentile failures are still #570's job.